### PR TITLE
feat(thread-playground): polish tool calls and message header

### DIFF
--- a/apps/desktop/src/components/code-editor/editor.tsx
+++ b/apps/desktop/src/components/code-editor/editor.tsx
@@ -1,4 +1,7 @@
-import CodeMirror, { type BasicSetupOptions } from "@uiw/react-codemirror";
+import CodeMirror, {
+  type BasicSetupOptions,
+  type ReactCodeMirrorRef,
+} from "@uiw/react-codemirror";
 import {
   forwardRef,
   memo,
@@ -10,6 +13,7 @@ import {
   useState,
   type ClipboardEvent,
   type KeyboardEvent,
+  type MouseEvent,
 } from "react";
 
 import { cn } from "@/lib/utils";
@@ -63,6 +67,7 @@ function _CodeEditor(
   ref: React.ForwardedRef<CodeEditorHandle>
 ) {
   const { resolvedTheme } = { resolvedTheme: "dark" };
+  const cmRef = useRef<ReactCodeMirrorRef>(null);
   const [draft, setDraft] = useState(value);
   const draftRef = useRef(value);
   const committedRef = useRef(value);
@@ -112,6 +117,21 @@ function _CodeEditor(
     isFocusedRef.current = true;
   }, []);
 
+  const handleContainerMouseDown = useCallback(
+    (e: MouseEvent) => {
+      const view = cmRef.current?.view;
+      // Clicks inside CodeMirror are handled by CodeMirror itself; this covers
+      // the container's padding / min-height area so the whole box is clickable.
+      if (readonly || !view || view.dom.contains(e.target as Node)) {
+        return;
+      }
+      e.preventDefault();
+      view.focus();
+      view.dispatch({ selection: { anchor: view.state.doc.length } });
+    },
+    [readonly]
+  );
+
   const handleKeyDownCapture = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Enter" && e.metaKey) {
@@ -149,11 +169,15 @@ function _CodeEditor(
         readonly && "opacity-67",
         className
       )}
+      onMouseDown={handleContainerMouseDown}
     >
       <CodeMirror
+        ref={cmRef}
         className={cn(
           "h-full overflow-auto font-mono [&_.cm-editor]:h-full [&_.cm-focused]:outline-none!",
-          "p-0 px-2 py-1 [&_.cm-line]:p-0!"
+          // Horizontal padding lives on .cm-content (inside the scroller) so
+          // the caret at column 0 is not clipped by the scroller's overflow.
+          "p-0 py-1 [&_.cm-content]:px-2! [&_.cm-line]:p-0!"
         )}
         theme={resolvedTheme === "dark" ? themes.dark : themes.light}
         autoFocus={autoFocus}

--- a/apps/desktop/src/components/thread-playground/message/message-list-item-header.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item-header.tsx
@@ -1,9 +1,9 @@
 import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
-import type { Message } from "@llm-space/core";
+import { getMessageText, type Message } from "@llm-space/core";
 import {
   BotIcon,
   ChevronDownIcon,
-  GripVerticalIcon,
+  GripHorizontalIcon,
   MinusCircle,
   PlayCircleIcon,
   UserIcon,
@@ -39,6 +39,22 @@ function _MessageListItemHeader({
         message.toolCalls.length > 0),
     [message]
   );
+  // A one-line preview shown beside the role tag while collapsed: the text
+  // content, or a summary of tool calls when there is no text. Only computed
+  // while collapsed — an expanded message re-renders on every streamed token.
+  const preview = useMemo(() => {
+    if (!collapsed) {
+      return "";
+    }
+    const text = getMessageText(message).replace(/\s+/g, " ").trim();
+    if (text) {
+      return text;
+    }
+    if (message.role === "assistant" && message.toolCalls?.length) {
+      return message.toolCalls.map((tc) => `${tc.input.name}()`).join(", ");
+    }
+    return "";
+  }, [collapsed, message]);
   const handleRun = useCallback(async () => {
     await run(message.id);
   }, [run, message.id]);
@@ -52,23 +68,30 @@ function _MessageListItemHeader({
     toggleMessageCollapsed(message.id);
   }, [toggleMessageCollapsed, message.id]);
   return (
-    <header className="flex w-full shrink-0 items-center px-3 pt-2">
+    <header className="relative flex w-full shrink-0 items-center px-2 pt-2">
       <Tooltip content="Drag to reorder">
         <div
           {...dragHandleProps}
           aria-label={`${message.role === "user" ? "User" : "Assistant"} message drag handle`}
           className={cn(
-            "text-muted-foreground hover:text-foreground -ml-3.5 flex shrink-0 cursor-grab items-center opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing",
-            readonly ? "invisible" : ""
+            // A small grab affordance near the top edge, centered (out of
+            // flow, so nothing else moves). `z-20` keeps it above the
+            // positioned collapse-toggle spacer, which is a later sibling and
+            // would otherwise capture the clicks.
+            "text-muted-foreground hover:text-foreground hover:bg-foreground/8 absolute top-0.5 left-1/2 z-20 flex h-4 w-9 -translate-x-1/2 cursor-grab items-center justify-center rounded-md opacity-0 transition-opacity group-hover:opacity-70 active:cursor-grabbing",
+            // Hidden while collapsed: the row shows a content preview instead,
+            // and the centered handle would sit on top of it.
+            collapsed && "hidden",
+            readonly && "invisible"
           )}
         >
-          <GripVerticalIcon className="size-4" />
+          <GripHorizontalIcon className="size-3" />
         </div>
       </Tooltip>
       <div className="flex shrink-0 items-center">
         <Tooltip content="Toggle role">
           <Button
-            className="-translate-x-0.5 px-2"
+            className="px-2"
             variant="outline"
             size="sm"
             aria-label={`Change message role from ${message.role}`}
@@ -92,10 +115,19 @@ function _MessageListItemHeader({
         </Tooltip>
       </div>
       <div
-        className="h-full min-h-full min-w-0 grow"
+        className="relative h-full min-h-full min-w-0 grow"
         onClick={handleToggleMessageCollapse}
       >
         &nbsp;
+        {collapsed && preview && (
+          // Absolutely positioned so the (nowrap) preview never contributes to
+          // the intrinsic width of the surrounding ScrollArea's `display:table`
+          // viewport — otherwise it would grow the whole list instead of
+          // truncating. Its width is bounded by this in-flow grow cell.
+          <span className="text-muted-foreground absolute top-1/2 right-0 left-2 -translate-y-1/2 truncate text-sm">
+            {preview}
+          </span>
+        )}
       </div>
       <div
         className={cn(

--- a/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
@@ -1,5 +1,5 @@
 import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd";
-import type { ImageDataContent, Message } from "@llm-space/core";
+import { getMessageText, type ImageDataContent, type Message } from "@llm-space/core";
 import { PlusIcon } from "lucide-react";
 import { memo, useCallback, useMemo } from "react";
 
@@ -35,15 +35,7 @@ function _MessageListItem({
   collapsed?: boolean;
   dragHandleProps?: DraggableProvidedDragHandleProps | null;
 }) {
-  const text = useMemo(() => {
-    const result: string[] = [];
-    for (const c of message.content) {
-      if (c.type === "text") {
-        result.push(c.text);
-      }
-    }
-    return result.join("\n");
-  }, [message.content]);
+  const text = useMemo(() => getMessageText(message), [message]);
   const imageContents = useMemo(() => {
     const result: { content: ImageDataContent; contentIndex: number }[] = [];
     message.content.forEach((content, contentIndex) => {
@@ -153,7 +145,7 @@ function _MessageListItem({
         dragHandleProps={dragHandleProps}
       />
       <CollapsibleContent collapsed={collapsed}>
-        <main className="flex w-full flex-col">
+        <main className="flex w-full flex-col pb-2">
           {message.role === "assistant" &&
             streaming &&
             !message.thinking &&
@@ -188,7 +180,7 @@ function _MessageListItem({
             />
           )}
           {message.role === "assistant" && message.toolCalls && (
-            <div className="mb-3 flex w-full flex-col gap-3 px-3">
+            <div className="flex w-full flex-col gap-3 px-2">
               {message.toolCalls.map((toolCall) => (
                 <ToolCallListItem
                   key={toolCall.id}

--- a/apps/desktop/src/components/thread-playground/message/message-list-view.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-view.tsx
@@ -90,11 +90,12 @@ export function MessageListView({
         </DragDropContext>
         <StreamingMessageListItem streaming={status === "running"} />
         <Button
+          // No top margin: the preceding message / streaming item (or, in the
+          // empty state, the list's own top padding) already provides the gap.
           className={cn(
             "text-muted-foreground hover:text-accent-foreground w-full justify-start rounded-lg py-5",
             dragging && "invisible",
-            readonly && "hidden",
-            !messages || messages?.length === 0 ? "" : "mt-3.5"
+            readonly && "hidden"
           )}
           disabled={readonly}
           variant="secondary"
@@ -152,7 +153,7 @@ function DroppableMessageList({
 
   return (
     <div
-      className="flex flex-col gap-3.5 pt-3"
+      className="flex flex-col pt-3"
       ref={setContainerRef}
       {...droppableProvided.droppableProps}
     >
@@ -170,6 +171,11 @@ function DroppableMessageList({
               <div
                 ref={draggableProvided.innerRef}
                 {...draggableProps}
+                // Spacing lives on the draggable as a margin (not a flex `gap`
+                // on the list) because @hello-pangea/dnd measures item margins
+                // to size the placeholder and compute drag displacement — a
+                // `gap` is invisible to it and offsets every item mid-drag.
+                className="mb-3.5"
                 style={style as CSSProperties}
               >
                 <MessageListItem
@@ -204,7 +210,7 @@ function StreamingMessageListItem({ streaming }: { streaming: boolean }) {
   }
   return (
     <MessageListItem
-      className="mt-3.5"
+      className="mb-3.5"
       message={streamingMessage}
       readonly
       streaming

--- a/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
@@ -12,9 +12,12 @@ function _ToolCallListItem({
   toolCall: ToolCall;
 }) {
   const { run, updateToolCallOutputText } = useThreadStoreActions();
-  const handleOutputChange = useCallback((value: string) => {
-    updateToolCallOutputText(messageId, toolCall.id, value);
-  }, []);
+  const handleOutputChange = useCallback(
+    (value: string) => {
+      updateToolCallOutputText(messageId, toolCall.id, value);
+    },
+    [messageId, toolCall.id, updateToolCallOutputText]
+  );
   const handleRun = useCallback(async () => {
     await run(messageId);
   }, [run, messageId]);
@@ -33,22 +36,16 @@ function _ToolCallListItem({
       <ToolCallInputView input={toolCall.input} />
       <hr />
       <div className="flex w-full flex-col gap-1">
-        <div className="flex w-full flex-col">
-          <div className="text-sm text-[#888cf5]">Response</div>
-        </div>
-        <div className="flex w-full flex-col">
-          <CodeEditor
-            className="max-h-96 min-h-9.5 px-0!"
-            hideBorder
-            hideFocusRing
-            placeholder={`Enter the response of ${toolCall.input.name}()`}
-            value={
-              toolCall.output?.content?.map((c) => c.text).join("\n") ?? ""
-            }
-            onChange={handleOutputChange}
-            onKeyDown={handleKeyDown}
-          />
-        </div>
+        <div className="text-muted-foreground text-xs font-medium">Response</div>
+        <CodeEditor
+          className="max-h-96 min-h-9.5 px-0!"
+          hideBorder
+          hideFocusRing
+          placeholder={`Enter the response of ${toolCall.input.name}()`}
+          value={toolCall.output?.content?.map((c) => c.text).join("\n") ?? ""}
+          onChange={handleOutputChange}
+          onKeyDown={handleKeyDown}
+        />
       </div>
     </div>
   );
@@ -59,13 +56,14 @@ function _ToolCallInputView({ input }: { input: ToolCallInput }) {
   const keys = Object.keys(input.arguments);
   return (
     <div className="block w-full overflow-x-auto font-mono text-sm select-auto">
-      <span className="text-[#888cf5]">{input.name}(</span>
+      <span className="text-primary">{input.name}</span>
+      <span className="text-muted-foreground">(</span>
       {keys.length > 0 && (
         <span className="whitespace-pre">
           {JSON.stringify(input.arguments, null, 2)}
         </span>
       )}
-      <span className="text-[#888cf5]">{")"}</span>
+      <span className="text-muted-foreground">{")"}</span>
     </div>
   );
 }

--- a/apps/desktop/src/components/thread-playground/tool/tool-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/tool/tool-list-item.tsx
@@ -46,7 +46,7 @@ function _ToolListItem({
         content={
           <div>
             <div className="font-mono">
-              <span className="font-bold text-[#888cf5]">{tool.name}</span>
+              <span className="text-primary font-bold">{tool.name}</span>
               <span>(</span>
               <span className="whitespace-pre-wrap">
                 {keys.length > 0

--- a/packages/core/src/types/messages/messages.ts
+++ b/packages/core/src/types/messages/messages.ts
@@ -71,3 +71,17 @@ export type AssistantMessage = Static<typeof AssistantMessage>;
  */
 export const Message = Type.Union([UserMessage, AssistantMessage]);
 export type Message = UserMessage | AssistantMessage;
+
+/**
+ * The plain text of a message: its text content parts joined by newlines.
+ * Non-text content (e.g. images) is ignored.
+ */
+export function getMessageText(message: Message): string {
+  const parts: string[] = [];
+  for (const c of message.content) {
+    if (c.type === "text") {
+      parts.push(c.text);
+    }
+  }
+  return parts.join("\n");
+}


### PR DESCRIPTION
## Summary

UI polish for the thread playground's message list and tool-call rendering, plus two functional fixes surfaced along the way.

### Tool calls & colors
- Replaced the hardcoded `text-[#888cf5]` hex with design tokens (`text-primary` for function names, `text-muted-foreground` for punctuation/labels) across `tool-call-list-item.tsx` and `tool-list-item.tsx`.
- Restyled the "Response" label to a muted, small-caps-weight token.

### CodeMirror caret (Response input)
- The caret at column 0 was clipped because horizontal padding sat on the scroller. Moved `px-2` onto `.cm-content` so the caret is no longer cut off.
- Clicking the editor's padding/empty area now focuses the editor and places the caret at the end, so the whole box is a click target (skipped when read-only).

### Drag-to-reorder position fix
- Dragging a message rendered at the wrong offset and snapped incorrectly on drop. Root cause: `@hello-pangea/dnd` measures each draggable's **margin** (not flex `gap`) to size the placeholder and compute displacement. Replaced the list's `gap-3.5` with a per-item `mb-3.5` margin so the placeholder and drag offset are correct.

### Collapsed message header
- Collapsed messages now hide the drag handle and show a single-line, truncated **content preview** next to the role tag (falls back to a tool-call summary like `get_weather()` when there's no text).
- Moved the drag handle from the left edge to a subtle top-centered grip; added `z-20` so it stays clickable above the collapse-toggle spacer.
- The preview is absolutely positioned so its `nowrap` text can't grow the surrounding Radix ScrollArea's `display:table` viewport (which would horizontally expand the whole list instead of truncating).

### Cleanup
- Extracted a shared `getMessageText(message)` helper into `@llm-space/core` and used it in both the message editor and the collapsed preview, removing duplicated content-extraction loops.
- The preview only computes while collapsed (an expanded message re-renders on every streamed token).
- Minor spacing normalization around "Add message" and the tool-call container.

## Testing
- Verified in the running desktop app (CEF/CDP): caret now visible in empty Response inputs, drag placeholder correctly includes the item margin, drag handle clickable across its full height, collapsed preview truncates without causing horizontal overflow.
- `eslint` clean on all touched files (pre-commit hook passed); `tsc` clean for the core and desktop packages (pre-existing unrelated `extract-initials.ts` strictness errors aside).

## Note
Collapsed messages can no longer be dragged (the handle is hidden when collapsed) - this matches the requested behavior. Easy to revisit if reordering while collapsed is wanted.