### PR TITLE
feat(desktop): light mode and selectable primary color

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
+    "@dayflow/blossom-color-picker-react": "^1.2.1",
     "@earendil-works/pi-ai": "catalog:",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",

--- a/apps/desktop/src/app/layout.tsx
+++ b/apps/desktop/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "@fontsource-variable/geist-mono/index.css";
 import { ModelProviderGroup } from "@llm-space/core";
 
 import { ModelProvider } from "@/components/model-provider";
+import { ThemeProvider, useTheme } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { electrobun } from "@/lib/electrobun";
@@ -12,21 +13,31 @@ import { QueryProvider } from "./query-provider";
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <QueryProvider>
-      <ModelProvider fetcher={fetchModels}>
-        <TooltipProvider delayDuration={1000}>
-          <div className="flex size-full flex-col">
-            <Toaster
-              theme="dark"
-              position="top-center"
-              offset={28}
-              closeButton
-            />
-            {children}
-          </div>
-        </TooltipProvider>
-      </ModelProvider>
-    </QueryProvider>
+    <ThemeProvider>
+      <QueryProvider>
+        <ModelProvider fetcher={fetchModels}>
+          <TooltipProvider delayDuration={1000}>
+            <div className="flex size-full flex-col">
+              <ThemedToaster />
+              {children}
+            </div>
+          </TooltipProvider>
+        </ModelProvider>
+      </QueryProvider>
+    </ThemeProvider>
+  );
+}
+
+/** Sonner toaster that tracks the active appearance. */
+function ThemedToaster() {
+  const { resolvedTheme } = useTheme();
+  return (
+    <Toaster
+      theme={resolvedTheme}
+      position="top-center"
+      offset={28}
+      closeButton
+    />
   );
 }
 

--- a/apps/desktop/src/components/code-editor/editor.tsx
+++ b/apps/desktop/src/components/code-editor/editor.tsx
@@ -16,6 +16,7 @@ import {
   type MouseEvent,
 } from "react";
 
+import { useTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 
 import { createExtensions } from "./extensions";
@@ -66,7 +67,7 @@ function _CodeEditor(
   },
   ref: React.ForwardedRef<CodeEditorHandle>
 ) {
-  const { resolvedTheme } = { resolvedTheme: "dark" };
+  const { resolvedTheme } = useTheme();
   const cmRef = useRef<ReactCodeMirrorRef>(null);
   const [draft, setDraft] = useState(value);
   const draftRef = useRef(value);

--- a/apps/desktop/src/components/code-editor/themes.ts
+++ b/apps/desktop/src/components/code-editor/themes.ts
@@ -13,6 +13,10 @@ export const dark = monokaiInit({
 
 export const light = basicLightInit({
   settings: {
+    // Match the editor surface to the container (--textarea); basicLight's
+    // default is a plain white that clashes with the app's light-gray fields.
+    background: "var(--textarea)",
+    gutterBackground: "transparent",
     fontSize: "var(--text-sm)",
   },
 });

--- a/apps/desktop/src/components/settings/general-page.tsx
+++ b/apps/desktop/src/components/settings/general-page.tsx
@@ -3,6 +3,11 @@
 import type { ReactNode } from "react";
 
 import {
+  usePrimaryColor,
+  useTheme,
+  type Theme,
+} from "@/components/theme-provider";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -11,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 
+import { PrimaryColorPicker } from "./primary-color-picker";
 import { SettingsPage } from "./settings-page";
 
 /** A single label-on-the-left, control-on-the-right settings row. */
@@ -30,15 +36,19 @@ function SettingsRow({
 }
 
 export function GeneralPage() {
+  const { theme, setTheme } = useTheme();
+  const { primaryColor, setPrimaryColor } = usePrimaryColor();
   return (
     <SettingsPage title="General">
       <SettingsRow label="Appearance">
-        <Select defaultValue="dark" disabled>
+        <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
           <SelectTrigger className="w-32" aria-label="Appearance">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="light">Light</SelectItem>
             <SelectItem value="dark">Dark</SelectItem>
+            <SelectItem value="system">System</SelectItem>
           </SelectContent>
         </Select>
       </SettingsRow>
@@ -46,17 +56,10 @@ export function GeneralPage() {
       <Separator />
 
       <SettingsRow label="Primary color">
-        <Select defaultValue="default" disabled>
-          <SelectTrigger className="w-32" aria-label="Primary color">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="default">
-              <span className="bg-primary size-2.5 shrink-0 rounded-full" />
-              Default
-            </SelectItem>
-          </SelectContent>
-        </Select>
+        <PrimaryColorPicker
+          value={primaryColor}
+          onChange={setPrimaryColor}
+        />
       </SettingsRow>
 
       <Separator />

--- a/apps/desktop/src/components/settings/primary-color-picker.tsx
+++ b/apps/desktop/src/components/settings/primary-color-picker.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  BlossomColorPicker,
+  hexToHsl,
+  type BlossomColorPickerColor,
+  type BlossomColorPickerValue,
+} from "@dayflow/blossom-color-picker-react";
+import { useCallback } from "react";
+
+/** Seed the core from the active hex (alpha is 0-100 in this widget). */
+function _toValue(hex: string): BlossomColorPickerValue {
+  const { h, s, l } = hexToHsl(hex);
+  return { hue: h, saturation: s, lightness: l, alpha: 100, layer: "outer" };
+}
+
+/**
+ * Accent-color control: the Basic blossom picker
+ * (`@dayflow/blossom-color-picker-react`) whose center core shows the current
+ * accent and blooms hues on click. Emits a `#rrggbb` hex; the widget follows the
+ * app theme via its ancestor `.dark` class.
+ *
+ * Seed with `defaultValue` (not controlled `value`) and a stable `onChange`: the
+ * React wrapper re-applies `value`/`onChange` imperatively whenever their
+ * identity changes, which — since our accent state updates on every drag tick —
+ * would otherwise reset the picker mid-drag and make the slider stutter.
+ */
+export function PrimaryColorPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (hex: string) => void;
+}) {
+  const handleChange = useCallback(
+    (color: BlossomColorPickerColor) => onChange(color.hex),
+    [onChange]
+  );
+  return (
+    <BlossomColorPicker
+      defaultValue={_toValue(value)}
+      showCoreColor
+      adaptivePositioning
+      coreSize={20}
+      onChange={handleChange}
+    />
+  );
+}

--- a/apps/desktop/src/components/theme-provider.tsx
+++ b/apps/desktop/src/components/theme-provider.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+/** User-selectable appearance. `"system"` follows the OS color scheme. */
+export type Theme = "light" | "dark" | "system";
+/** The concrete scheme actually applied to the document. */
+export type ResolvedTheme = "light" | "dark";
+
+/** Accent (as `#rrggbb`) used when nothing is stored — the base `--primary` blue. */
+export const DEFAULT_PRIMARY = "#5e80ee";
+
+/**
+ * localStorage keys for the persisted appearance. Kept in sync with the
+ * anti-FOUC bootstrap script in `mainview/index.html`, which reads the same
+ * keys to apply appearance before React mounts — change both together.
+ */
+export const THEME_STORAGE_KEY = "llm-space-theme";
+export const PRIMARY_STORAGE_KEY = "llm-space-primary";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+interface PrimaryColorContextValue {
+  /** The active accent as a `#rrggbb` hex string. */
+  primaryColor: string;
+  setPrimaryColor: (hex: string) => void;
+}
+
+// Split contexts: the accent updates on every drag tick, but theme consumers
+// (CodeEditor per message/tool-call, ThreadTabs, the toaster) only read
+// `resolvedTheme`. Keeping accent in its own context spares those hot-list
+// components a re-render storm while the color picker is dragged.
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+const PrimaryColorContext = createContext<PrimaryColorContextValue | null>(null);
+
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+function _readStoredTheme(): Theme {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === "light" || stored === "dark" || stored === "system"
+    ? stored
+    : "system";
+}
+
+function _readStoredPrimary(): string {
+  const stored = localStorage.getItem(PRIMARY_STORAGE_KEY);
+  return stored && HEX_RE.test(stored) ? stored : DEFAULT_PRIMARY;
+}
+
+/** Pick a readable foreground for an arbitrary accent (WCAG relative luminance). */
+function _primaryForeground(hex: string): string {
+  const n = parseInt(hex.slice(1), 16);
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const luminance =
+    0.2126 * toLinear((n >> 16) & 255) +
+    0.7152 * toLinear((n >> 8) & 255) +
+    0.0722 * toLinear(n & 255);
+  // Dark ink on bright accents (yellows/ambers), near-white on the rest.
+  return luminance > 0.45 ? "oklch(0.216 0.006 56)" : "oklch(0.985 0 0)";
+}
+
+/** Apply the accent as inline `--primary`/`--ring`/`--primary-foreground` vars. */
+function _applyPrimary(hex: string) {
+  const root = document.documentElement;
+  root.style.setProperty("--primary", hex);
+  root.style.setProperty("--ring", hex);
+  root.style.setProperty("--primary-foreground", _primaryForeground(hex));
+}
+
+function _systemTheme(): ResolvedTheme {
+  return window.matchMedia(DARK_QUERY).matches ? "dark" : "light";
+}
+
+function _resolve(theme: Theme): ResolvedTheme {
+  return theme === "system" ? _systemTheme() : theme;
+}
+
+/** Toggle the `.dark` class the Tailwind `dark` variant keys off of. */
+function _applyTheme(resolved: ResolvedTheme) {
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(_readStoredTheme);
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    _resolve(_readStoredTheme())
+  );
+
+  const [primaryColor, setPrimaryState] = useState<string>(_readStoredPrimary);
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(THEME_STORAGE_KEY, next);
+    setThemeState(next);
+  }, []);
+
+  const setPrimaryColor = useCallback((next: string) => {
+    localStorage.setItem(PRIMARY_STORAGE_KEY, next);
+    setPrimaryState(next);
+  }, []);
+
+  useEffect(() => {
+    _applyPrimary(primaryColor);
+  }, [primaryColor]);
+
+  // Apply the resolved theme to the document, and — while following the system
+  // — re-resolve when the OS color scheme flips.
+  useEffect(() => {
+    const resolved = _resolve(theme);
+    setResolvedTheme(resolved);
+    _applyTheme(resolved);
+
+    if (theme !== "system") {
+      return;
+    }
+    const media = window.matchMedia(DARK_QUERY);
+    const onChange = () => {
+      const next = _systemTheme();
+      setResolvedTheme(next);
+      _applyTheme(next);
+    };
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, [theme]);
+
+  const themeValue = useMemo(
+    (): ThemeContextValue => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme]
+  );
+  const primaryValue = useMemo(
+    (): PrimaryColorContextValue => ({ primaryColor, setPrimaryColor }),
+    [primaryColor, setPrimaryColor]
+  );
+
+  return (
+    <ThemeContext.Provider value={themeValue}>
+      <PrimaryColorContext.Provider value={primaryValue}>
+        {children}
+      </PrimaryColorContext.Provider>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within <ThemeProvider>");
+  }
+  return ctx;
+}
+
+export function usePrimaryColor(): PrimaryColorContextValue {
+  const ctx = useContext(PrimaryColorContext);
+  if (!ctx) {
+    throw new Error("usePrimaryColor must be used within <ThemeProvider>");
+  }
+  return ctx;
+}

--- a/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
@@ -163,7 +163,7 @@ function _MessageListItem({
           />
           {message.content.length > 0 && (
             <CodeEditor
-              className="max-h-[40vh] min-h-9.5 w-full"
+              className="max-h-[40vh] min-h-9.5 w-full bg-transparent"
               autoFocus
               hideFocusRing
               hideBorder

--- a/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
@@ -32,7 +32,7 @@ function _ToolCallListItem({
     [handleRun]
   );
   return (
-    <div className="bg-foreground/4 flex w-full flex-col gap-2 rounded-md px-3 pt-2 pb-3 shadow-md">
+    <div className="bg-foreground/4 flex w-full flex-col gap-2 rounded-md px-3 pt-2 pb-3">
       <ToolCallInputView input={toolCall.input} />
       <hr />
       <div className="flex w-full flex-col gap-1">

--- a/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
@@ -13,6 +13,7 @@ import {
   type MouseEvent,
 } from "react";
 
+import { useTheme } from "@/components/theme-provider";
 import { electrobun } from "@/lib/electrobun";
 import { cn } from "@/lib/utils";
 
@@ -38,6 +39,10 @@ const REVEAL_LABEL = _isWindows ? "Reveal in Explorer" : "Reveal in Finder";
 const MOVE_TO_TRASH_LABEL = _isWindows
   ? "Move to Recycle Bin"
   : "Move to Trash";
+
+// Suppress focus on mouse-down so a click doesn't leave these toolbar icons
+// with the focus-visible ring stuck; keyboard focus (Tab) still rings them.
+const _preventFocusSteal = (e: MouseEvent) => e.preventDefault();
 
 interface ThreadTabsProps {
   className?: string;
@@ -75,6 +80,7 @@ export function ThreadTabs({
   onMove,
   onToggleSidebar,
 }: ThreadTabsProps) {
+  const { resolvedTheme } = useTheme();
   // The chrome-tabs lib renders tab DOM imperatively and exposes no tooltip prop,
   // but it stamps each tab's full path onto `data-tab-id`. Mirror that into the
   // native `title` attribute so hovering a tab reveals its relative path. The
@@ -173,7 +179,10 @@ export function ThreadTabs({
           >
             <div
               className={cn(
-                "flex h-full items-center border-b-4 pt-1 transition-[width]",
+                // border-b-4 continues chrome-tabs' bottom bar across the toggle
+                // area, so its color must match that bar (--tab-bar-bottom), not
+                // the default --border.
+                "flex h-full items-center border-b-4 [border-color:var(--tab-bar-bottom)] pt-1 transition-[width]",
                 fullScreen
                   ? "w-6 pl-1"
                   : sidebarOpen
@@ -195,6 +204,7 @@ export function ThreadTabs({
                   size="icon-sm"
                   variant="ghost"
                   aria-label={sidebarOpen ? "Hide sidebar" : "Show sidebar"}
+                  onMouseDown={_preventFocusSteal}
                   onClick={onToggleSidebar}
                 >
                   {sidebarOpen ? (
@@ -207,7 +217,7 @@ export function ThreadTabs({
             </div>
             <Tabs
               className="grow"
-              darkMode
+              darkMode={resolvedTheme === "dark"}
               tabs={tabs.map((tab) => ({
                 id: tab.path,
                 title: tabLabel(tab.path),
@@ -222,6 +232,7 @@ export function ThreadTabs({
                       size="icon-sm"
                       variant="ghost"
                       aria-label="New file"
+                      onMouseDown={_preventFocusSteal}
                       onClick={onNewFile}
                     >
                       <PlusIcon className="size-3.5" />

--- a/apps/desktop/src/mainview/index.html
+++ b/apps/desktop/src/mainview/index.html
@@ -1,9 +1,46 @@
 <!doctype html>
-<html lang="en" class="dark h-screen w-screen" suppressHydrationWarning>
+<html lang="en" class="h-screen w-screen" suppressHydrationWarning>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LLM Space</title>
+    <script>
+      // Apply the persisted appearance before first paint to avoid a flash of
+      // the wrong theme/accent. Mirrors the logic in theme-provider.tsx — keep
+      // the storage keys ("llm-space-theme", "llm-space-primary") in sync.
+      (function () {
+        try {
+          var root = document.documentElement;
+          var theme = localStorage.getItem("llm-space-theme") || "system";
+          var dark =
+            theme === "dark" ||
+            (theme === "system" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          root.classList.toggle("dark", dark);
+
+          var primary = localStorage.getItem("llm-space-primary");
+          if (primary && /^#[0-9a-fA-F]{6}$/.test(primary)) {
+            var n = parseInt(primary.slice(1), 16);
+            var lin = function (c) {
+              var s = c / 255;
+              return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+            };
+            var lum =
+              0.2126 * lin((n >> 16) & 255) +
+              0.7152 * lin((n >> 8) & 255) +
+              0.0722 * lin(n & 255);
+            root.style.setProperty("--primary", primary);
+            root.style.setProperty("--ring", primary);
+            root.style.setProperty(
+              "--primary-foreground",
+              lum > 0.45 ? "oklch(0.216 0.006 56)" : "oklch(0.985 0 0)"
+            );
+          }
+        } catch (e) {
+          // localStorage unavailable — fall back to the default appearance.
+        }
+      })();
+    </script>
   </head>
   <body class="size-full font-sans select-none">
     <div id="root" class="size-full"></div>

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -71,7 +71,7 @@
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
   --animate-shine: shine var(--duration) infinite linear;
-  --color-tabs: #202124;
+  --color-tabs: var(--tabs);
 
   @keyframes shine {
     0% {
@@ -139,6 +139,15 @@
   --sidebar-ring: oklch(0.708 0 0);
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
+  --textarea: oklch(0.985 0 0);
+  /* Neutral tab-bar strip for light mode. The chrome-tabs library ships a
+     bluish Chrome palette (#dee1e6) that clashes with the app's neutral grays;
+     the overrides at the end of this file recolor the tabs to match this. */
+  --tabs: oklch(0.928 0 0);
+  /* Color of chrome-tabs' 4px bottom bar (the content-colored strip the active
+     tab merges into). The sidebar-toggle wrapper's border-b-4 mirrors this bar,
+     so it must match. Light: content white; dark keeps the library's #323639. */
+  --tab-bar-bottom: var(--background);
 
   --font-sans: "Geist Variable", system-ui, sans-serif;
   --font-mono: monospace;
@@ -182,7 +191,8 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-  --color-tabs: #202124;
+  --tabs: #202124;
+  --tab-bar-bottom: #323639;
 
   font-weight: 300;
 
@@ -251,4 +261,36 @@
 }
 ::-webkit-scrollbar-corner {
   background: transparent;
+}
+
+/*
+ * Light-mode chrome-tabs palette.
+ * @sinm/react-chrome-tabs ships a bluish Chrome light theme (#dee1e6 strip,
+ * #5f6368 titles, #a9adb0 dividers) that clashes with the app's neutral,
+ * white-content design. Recolor it to the app tokens for the light case only —
+ * the dark case is styled by chrome-tabs-dark-theme.css, so we scope to
+ * `:not(.chrome-tabs-dark-theme)`. Unlayered so it wins over the library CSS
+ * (same reasoning as the scrollbar block above).
+ */
+.chrome-tabs:not(.chrome-tabs-dark-theme) {
+  background: var(--tabs);
+
+  /* Active tab merges into the white content area below it. */
+  .chrome-tab[active] .chrome-tab-background > svg .chrome-tab-geometry {
+    fill: var(--background);
+  }
+  /* Inactive tab (shown on hover) sits a touch above the strip. */
+  .chrome-tab .chrome-tab-background > svg .chrome-tab-geometry {
+    fill: oklch(0.96 0 0);
+  }
+  .chrome-tab .chrome-tab-title {
+    color: var(--muted-foreground);
+  }
+  .chrome-tab[active] .chrome-tab-title {
+    color: var(--foreground);
+  }
+  .chrome-tab .chrome-tab-dividers::before,
+  .chrome-tab .chrome-tab-dividers::after {
+    background: color-mix(in oklab, var(--muted-foreground) 30%, transparent);
+  }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
+        "@dayflow/blossom-color-picker-react": "^1.2.1",
         "@earendil-works/pi-ai": "catalog:",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
@@ -301,6 +302,10 @@
     "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "https://registry.npmmirror.com/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
 
     "@codemirror/view": ["@codemirror/view@6.43.1", "https://registry.npmmirror.com/@codemirror/view/-/view-6.43.1.tgz", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
+    "@dayflow/blossom-color-picker": ["@dayflow/blossom-color-picker@2.2.1", "", {}, "sha512-V3CdtY3qLMVDxhtbtAEIyN4wWQEN+vIj6gVkBZY1O2HX4hq+6mwLRZ/A13jEG2PN8WBQmfRw1cgzGx+Pjvd/PQ=="],
+
+    "@dayflow/blossom-color-picker-react": ["@dayflow/blossom-color-picker-react@1.2.1", "", { "dependencies": { "@dayflow/blossom-color-picker": "^2.2.1" }, "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-Bf+LH7FV3dF5FSZbST5WBAs54c3ZeIlzC5qaj5YpEXiqGFZwiPqgXJ8BQ0nJ63WBtIHVAzTLMY+ONkkUYXAknw=="],
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "https://registry.npmmirror.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
 


### PR DESCRIPTION
## Summary

Appearance is now user-configurable in **Settings → General**: a light/dark/system theme toggle and a selectable primary (accent) color. The app was previously hard-pinned to dark.

## Theme (light / dark / system)
- New `ThemeProvider` (`theme-provider.tsx`) exposing `useTheme()` — `theme` (light/dark/system), `resolvedTheme`, `setTheme`. Persisted to `localStorage`, applied by toggling `.dark` on `<html>`, and follows the OS scheme in `system` mode.
- Anti-FOUC bootstrap in `index.html` applies the persisted theme/accent before first paint, so there is no flash on launch.
- Wired `resolvedTheme` into the CodeMirror editor, chrome-tabs (`darkMode`), and the sonner toaster (previously hardcoded to dark).
- Recolored the `@sinm/react-chrome-tabs` light palette to the app's neutral tokens; added `--textarea` / `--tabs` / `--tab-bar-bottom` tokens and fixed the tab-bar seam colors in light mode.
- CodeMirror light theme now matches the container background (`--textarea`) instead of plain white.

## Primary (accent) color
- Selectable accent via a blossom color picker (`@dayflow/blossom-color-picker-react`), persisted as hex and applied as inline `--primary` / `--ring` / `--primary-foreground` vars.
- Foreground is computed per-accent from WCAG relative luminance (dark ink on bright accents, near-white otherwise).
- Theme and accent live in **separate contexts** so dragging the color picker does not re-render the message/tool-call editors in the hot lists.

## Notes
- Persistence uses `localStorage` (with a small hand-maintained FOUC bootstrap) rather than the on-disk `settings/` RPC path; moving appearance onto that infra is a larger, cross-boundary change left for follow-up.
- `lint` and per-file `tsc` are clean; verified live via the CEF/CDP renderer.