### PR TITLE
fix: keep file tree in sync when a delete errors or races the OS trash

### DIFF
--- a/apps/desktop/src/bun/fs/trash.ts
+++ b/apps/desktop/src/bun/fs/trash.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises";
+import { lstat, stat } from "node:fs/promises";
 
 /**
  * Move an absolute path to the OS trash / recycle bin — a recoverable delete —
@@ -9,10 +9,17 @@ import { stat } from "node:fs/promises";
  * - Windows — PowerShell + `Microsoft.VisualBasic` with the recycle-bin option.
  * - Linux — `gio trash`.
  *
- * Blocks until the move completes and throws on failure so the caller can
- * surface the error.
+ * A path that no longer exists is a no-op success: the item is already gone
+ * (e.g. an earlier delete completed after its RPC reply timed out), and the
+ * OS helpers would otherwise fail with an obscure platform error — on macOS,
+ * Finder's `delete` reports "Handler can't handle objects of this class"
+ * (-10010) for a path it cannot resolve.
+ *
+ * Otherwise blocks until the move completes and throws on failure so the
+ * caller can surface the error.
  */
 export async function moveToTrash(abs: string): Promise<void> {
+  if (!(await _exists(abs))) return;
   if (process.platform === "darwin") {
     // AppleScript string literals quote/escape like JSON, which is safe for the
     // paths we handle (under the workspace root).
@@ -41,6 +48,16 @@ export async function moveToTrash(abs: string): Promise<void> {
     return;
   }
   await _run(["gio", "trash", abs]);
+}
+
+/** Whether a path exists on disk (as itself — symlinks are not followed). */
+async function _exists(p: string): Promise<boolean> {
+  try {
+    await lstat(p);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function _run(cmd: string[]): Promise<void> {

--- a/apps/desktop/src/components/file-system-tree-view/use-file-system-tree.ts
+++ b/apps/desktop/src/components/file-system-tree-view/use-file-system-tree.ts
@@ -296,6 +296,10 @@ export function useFileSystemTree(): FileSystemTree {
         await localFs.rm(path);
       } catch (err) {
         toast.error((err as Error).message);
+        // The delete may still have landed even though it reported failure
+        // (e.g. the RPC timed out while the OS waited on a permission
+        // prompt), so re-fetch rather than leaving a stale entry in the tree.
+        void qc.invalidateQueries({ queryKey: fsKeys.ls(parentOf(path)) });
         return false;
       }
       // Prune the removed subtree from the expanded set.


### PR DESCRIPTION
## Problem

Deleting an item from the sidebar can fail with an obscure toast on macOS:

```
29:100: execution error: "Finder" got an error: Handler can't handle objects of this class. (-10010)
```

### Root cause

The first-ever delete triggers the macOS automation consent prompt ("llm-space wants to control Finder"). `osascript` blocks on that prompt, so the `fsRm` RPC request exceeds `maxRequestTime` (10 s) and rejects with "RPC request timed out." on the renderer side — but the timeout does not cancel the bun-side handler. Once the user grants permission, Finder completes the move and the file really lands in the Trash; the late success response is dropped because the request listener was already removed.

Meanwhile `remove()` in `use-file-system-tree.ts` treats the timeout as a failure and returns early **without invalidating the directory listing**, so the tree keeps showing a file that no longer exists (`refetchOnWindowFocus` is disabled, so nothing else refreshes it). Deleting that stale entry hands Finder a path it cannot resolve, which is exactly what produces `-10010`.

## Fix

- **`moveToTrash` is now idempotent**: a path that no longer exists is a no-op success instead of an obscure platform error (this also spares the Windows branch a raw `ENOENT` from its `stat` call).
- **`remove()` re-fetches the parent listing on failure too**, since the operation may still have completed behind the reported error — the tree snaps back to what is actually on disk.

## Verification

- Reproduced the original error on macOS 26.5.1: `tell application "Finder" to delete (POSIX file ...)` on a nonexistent path returns `-10010` verbatim; existing files/directories trash fine.
- After the fix, exercised `moveToTrash` directly with bun: nonexistent path resolves silently, existing file still lands in the Trash.
- `eslint .` passes; `tsc --noEmit` reports the same single pre-existing error (electrobun's bundled `three` import) before and after.