### PR TITLE
feat(models): support custom HTTP headers per provider

### DIFF
--- a/apps/desktop/src/bun/models/model-manager.ts
+++ b/apps/desktop/src/bun/models/model-manager.ts
@@ -121,12 +121,14 @@ export class ModelManager {
     {
       apiKey,
       baseUrl,
+      headers,
       name,
       api,
       icon,
     }: {
       apiKey?: string | null;
       baseUrl?: string | null;
+      headers?: Record<string, string> | null;
       name?: string | null;
       api?: CustomProviderApi | null;
       icon?: string | null;
@@ -145,6 +147,13 @@ export class ModelManager {
     if (baseUrl !== undefined) {
       if (baseUrl === null) delete entry.baseUrl;
       else entry.baseUrl = baseUrl;
+    }
+    if (headers !== undefined) {
+      if (headers === null || Object.keys(headers).length === 0) {
+        delete entry.headers;
+      } else {
+        entry.headers = headers;
+      }
     }
     if (name !== undefined) {
       if (name === null) delete entry.name;
@@ -168,6 +177,12 @@ export class ModelManager {
   getBaseUrl(providerId: string): string | undefined {
     return this._config.providers.find((entry) => entry.id === providerId)
       ?.baseUrl;
+  }
+
+  /** The extra HTTP headers configured for a provider, if any. */
+  getHeaders(providerId: string): Record<string, string> | undefined {
+    return this._config.providers.find((entry) => entry.id === providerId)
+      ?.headers;
   }
 
   /** The selected API compatibility mode for a custom provider. */

--- a/apps/desktop/src/bun/models/types.ts
+++ b/apps/desktop/src/bun/models/types.ts
@@ -26,6 +26,11 @@ export interface ProviderConfig {
   apiKey?: string;
   /** Custom base URL override for this provider. Absent means the default. */
   baseUrl?: string;
+  /**
+   * Extra HTTP headers sent with every request to this provider. Merged into
+   * the stream options at request time (per-run values win on collision).
+   */
+  headers?: Record<string, string>;
   /** API compatibility mode for a custom provider. */
   api?: CustomProviderApi;
   /**

--- a/apps/desktop/src/bun/rpc/index.ts
+++ b/apps/desktop/src/bun/rpc/index.ts
@@ -17,6 +17,7 @@ async function getModelProviderGroups() {
       models: provider.getModels(),
       apiKey: await modelManager.getApiKey(provider.id, false),
       baseUrl: modelManager.getBaseUrl(provider.id),
+      headers: modelManager.getHeaders(provider.id),
       api: modelManager.getApi(provider.id),
       disabledModels: modelManager.getDisabledModels(provider.id),
       customModels: modelManager.getCustomModels(provider.id),
@@ -56,6 +57,7 @@ export const mainWindowRPC: MainWindowRPC =
           providerId,
           apiKey,
           baseUrl,
+          headers,
           name,
           api,
           icon,
@@ -63,6 +65,7 @@ export const mainWindowRPC: MainWindowRPC =
           modelManager.updateProvider(providerId, {
             apiKey,
             baseUrl,
+            headers,
             name,
             api,
             icon,

--- a/apps/desktop/src/bun/streaming/stream-thread.ts
+++ b/apps/desktop/src/bun/streaming/stream-thread.ts
@@ -26,6 +26,7 @@ export async function runStreamThread(
       models: await modelManager.getAvailableModels(),
       getApiKey: modelManager.getApiKey.bind(modelManager),
       getBaseUrl: modelManager.getBaseUrl.bind(modelManager),
+      getHeaders: modelManager.getHeaders.bind(modelManager),
       signal: abortController.signal,
     })) {
       send({ streamId, type: "event", event });

--- a/apps/desktop/src/components/model-provider.tsx
+++ b/apps/desktop/src/components/model-provider.tsx
@@ -136,6 +136,7 @@ export function ModelProvider({
       fields: {
         apiKey?: string | null;
         baseUrl?: string | null;
+        headers?: Record<string, string> | null;
         name?: string | null;
         api?:
           | "anthropic-messages"
@@ -327,6 +328,7 @@ export function useUpdateProvider(): (
   fields: {
     apiKey?: string | null;
     baseUrl?: string | null;
+    headers?: Record<string, string> | null;
     name?: string | null;
     api?:
       | "anthropic-messages"

--- a/apps/desktop/src/components/settings/models-page.tsx
+++ b/apps/desktop/src/components/settings/models-page.tsx
@@ -742,6 +742,8 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
             </div>
           )}
 
+          {!isBuiltin && <ProviderHeadersEditor provider={provider} />}
+
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium">Models</span>
@@ -846,6 +848,96 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
         providerApi={isBuiltin ? undefined : apiValue}
         model={editingModel}
       />
+    </div>
+  );
+}
+
+/**
+ * Key-value editor for a custom provider's extra HTTP headers. Rows live in
+ * local state so half-typed entries survive re-renders; only rows with a
+ * non-empty name are persisted, on blur or row removal.
+ */
+function ProviderHeadersEditor({ provider }: { provider: ModelProviderGroup }) {
+  const updateProvider = useUpdateProvider();
+  const [rows, setRows] = useState<{ key: string; value: string }[]>(() =>
+    Object.entries(provider.headers ?? {}).map(([key, value]) => ({
+      key,
+      value,
+    }))
+  );
+
+  const setRow = (index: number, row: { key: string; value: string }) => {
+    setRows((prev) => prev.map((r, i) => (i === index ? row : r)));
+  };
+
+  // Persist the named rows when they differ from the stored headers. An empty
+  // set clears the field (stored as `null`).
+  const persist = (nextRows: { key: string; value: string }[]) => {
+    const headers: Record<string, string> = {};
+    for (const row of nextRows) {
+      const key = row.key.trim();
+      if (key !== "") headers[key] = row.value;
+    }
+    const current = provider.headers ?? {};
+    const currentKeys = Object.keys(current);
+    const same =
+      Object.keys(headers).length === currentKeys.length &&
+      currentKeys.every((key) => headers[key] === current[key]);
+    if (same) return;
+    void updateProvider(provider.id, {
+      headers: Object.keys(headers).length > 0 ? headers : null,
+    });
+  };
+
+  const removeRow = (index: number) => {
+    const next = rows.filter((_, i) => i !== index);
+    setRows(next);
+    persist(next);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium">Custom headers</label>
+      {rows.map((row, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Input
+            value={row.key}
+            placeholder="X-Header-Name"
+            aria-label={`${provider.name} header ${index + 1} name`}
+            onChange={(e) => setRow(index, { ...row, key: e.target.value })}
+            onBlur={() => persist(rows)}
+          />
+          <Input
+            value={row.value}
+            placeholder="Value"
+            aria-label={`${provider.name} header ${index + 1} value`}
+            onChange={(e) => setRow(index, { ...row, value: e.target.value })}
+            onBlur={() => persist(rows)}
+          />
+          <Tooltip content="Remove header">
+            <button
+              type="button"
+              aria-label={`Remove header ${index + 1}`}
+              onClick={() => removeRow(index)}
+              className="text-muted-foreground hover:bg-accent hover:text-foreground inline-flex size-6 shrink-0 items-center justify-center rounded transition-colors"
+            >
+              <Trash2 className="size-4" />
+            </button>
+          </Tooltip>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start"
+        onClick={() => setRows((prev) => [...prev, { key: "", value: "" }])}
+      >
+        <Plus /> Add header
+      </Button>
+      <div className="text-muted-foreground text-xs">
+        Sent with every request to this provider.
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -65,6 +65,7 @@ export interface DesktopRPCType {
           providerId: string;
           apiKey?: string | null;
           baseUrl?: string | null;
+          headers?: Record<string, string> | null;
           name?: string | null;
           api?:
             | "anthropic-messages"

--- a/packages/core/src/server/agent/stream.ts
+++ b/packages/core/src/server/agent/stream.ts
@@ -35,9 +35,19 @@ export async function* streamAgent(
     getBaseUrl?: (
       provider: string
     ) => Promise<string | undefined> | string | undefined;
+    /**
+     * Resolve a provider's extra HTTP headers (e.g. from user config). Returns
+     * `undefined`/empty to send no extra headers.
+     */
+    getHeaders?: (
+      provider: string
+    ) =>
+      | Promise<Record<string, string> | undefined>
+      | Record<string, string>
+      | undefined;
   }
 ): AsyncGenerator<AgentEvent> {
-  const { models, signal, getApiKey, getBaseUrl } = options;
+  const { models, signal, getApiKey, getBaseUrl, getHeaders } = options;
 
   if (request.context.messages.length > 0) {
     const lastMessage =
@@ -69,6 +79,14 @@ export async function* streamAgent(
     model.baseUrl = baseUrl;
   }
 
+  // User-configured extra headers, injected per call through the stream
+  // options below (never by mutating the shared model object). pi merges
+  // `options.headers` over `model.headers`; explicit per-call headers from the
+  // agent loop win over the configured ones on collision.
+  const configuredHeaders = await getHeaders?.(request.model.provider);
+  const hasConfiguredHeaders =
+    configuredHeaders && Object.keys(configuredHeaders).length > 0;
+
   const agentStream = agentLoopContinue(
     {
       ...request.context,
@@ -92,7 +110,16 @@ export async function* streamAgent(
     // streamFn is the legacy compat layer, which only knows a hardcoded
     // builtin provider→env-var map and ignores custom providers' auth.
     (streamModel, streamContext, streamOptions) =>
-      models.streamSimple(streamModel, streamContext, streamOptions)
+      models.streamSimple(
+        streamModel,
+        streamContext,
+        hasConfiguredHeaders
+          ? {
+              ...streamOptions,
+              headers: { ...configuredHeaders, ...streamOptions?.headers },
+            }
+          : streamOptions
+      )
   );
 
   try {

--- a/packages/core/src/types/models/provider-group.ts
+++ b/packages/core/src/types/models/provider-group.ts
@@ -17,6 +17,8 @@ export interface ModelProviderGroup {
   apiKey?: string;
   /** Custom base URL override. Empty/absent means the provider default. */
   baseUrl?: string;
+  /** Extra HTTP headers sent with every request to this provider. */
+  headers?: Record<string, string>;
   /** API compatibility mode for a custom provider. */
   api?: "anthropic-messages" | "openai-completions" | "openai-responses";
   /** Model ids the user has disabled. Everything not listed is enabled. */


### PR DESCRIPTION
## Motivation

Custom providers often sit behind gateways or proxies that require extra HTTP headers (tenant tags, gateway auth, routing hints). There was no way to configure them: `ProviderConfig` had no field, the UI had no editor, and `streamAgent` had no injection point.

## Design

**Configured at the provider level, applied at request time** — mirroring how `baseUrl` already works (provider-level setting, per-run application).

- `ProviderConfig.headers` (`settings/models.json`) stores the headers; `ModelManager` gains `getHeaders()` and `updateProvider({ headers })` (empty/null clears the field).
- `streamAgent()` gains a `getHeaders` resolver alongside `getApiKey`/`getBaseUrl`, and merges the configured headers into the `streamSimple` options per call — never by mutating the shared model object, so nothing leaks across runs. pi applies `options.headers` over `model.headers`, and explicit per-call headers still win over configured ones on collision.
- The RPC layer (`updateProvider` params, `ModelProviderGroup`) carries the field both ways.
- The provider settings panel gains a **Custom headers** key-value editor for custom providers (rows persist on blur / removal; unnamed rows stay local). Builtin providers can use the same config field by editing `settings/models.json` directly; giving them UI is a trivial follow-up if wanted.

Note: pi-ai's `createProvider({ headers })` was not used on purpose — provider-level headers are stored on the provider object but are not consumed by the API implementations' request path (they read `model.headers` / `options.headers` only), so injection through stream options is the reliable seam.

## Verification

End-to-end against a local `Bun.serve` capture server, through the production path (`ModelManager` reading a real `models.json` → `streamAgent` → OpenAI SDK): a provider configured with `{ "x-custom-test": "42", "x-tenant": "team-a" }` sends both headers on the wire. `eslint .` and `tsc --noEmit` (both packages) pass.