### PR TITLE
feat(code-editor): scroll-on-focus for message list editors

### DIFF
--- a/apps/desktop/src/components/code-editor/editor.tsx
+++ b/apps/desktop/src/components/code-editor/editor.tsx
@@ -40,6 +40,12 @@ export interface CodeEditorProps {
   placeholder?: string;
   hideBorder?: boolean;
   hideFocusRing?: boolean;
+  /**
+   * Clip overflowing content at rest and only scroll (and show a scrollbar)
+   * once the editor is focused. Suits dense, stacked list items (message list);
+   * standalone editors should stay always-scrollable and leave this off.
+   */
+  scrollOnFocus?: boolean;
   language?: "markdown" | "json";
   streaming?: boolean;
   value: string;
@@ -56,6 +62,7 @@ function _CodeEditor(
     placeholder,
     hideBorder,
     hideFocusRing,
+    scrollOnFocus,
     language,
     value,
     streaming,
@@ -175,6 +182,12 @@ function _CodeEditor(
         ref={cmRef}
         className={cn(
           "h-full overflow-auto font-mono [&_.cm-editor]:h-full [&_.cm-focused]:outline-none!",
+          // scrollOnFocus: clip at rest, scroll (and show a scrollbar) only once
+          // focused. overflow-auto (not scroll) means a focused editor whose
+          // content already fits still shows no bar. .cm-scroller is CodeMirror's
+          // scroll element, so gating it alone is enough.
+          scrollOnFocus &&
+            "[&_.cm-scroller]:overflow-hidden focus-within:[&_.cm-scroller]:overflow-auto",
           // Horizontal padding lives on .cm-content (inside the scroller) so
           // the caret at column 0 is not clipped by the scroller's overflow.
           "p-0 py-1 [&_.cm-content]:px-2! [&_.cm-line]:p-0!"

--- a/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
@@ -174,6 +174,7 @@ function _MessageListItem({
               autoFocus={autoFocus}
               hideFocusRing
               hideBorder
+              scrollOnFocus
               placeholder={
                 placeholder ??
                 `Enter ${message.role === "user" ? "user" : "assistant"} message here`

--- a/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
@@ -41,6 +41,7 @@ function _ToolCallListItem({
           className="max-h-96 min-h-9.5 px-0!"
           hideBorder
           hideFocusRing
+          scrollOnFocus
           placeholder={`Enter the response of ${toolCall.input.name}()`}
           value={toolCall.output?.content?.map((c) => c.text).join("\n") ?? ""}
           onChange={handleOutputChange}


### PR DESCRIPTION
## What

Adds an opt-in `scrollOnFocus` prop to the shared `CodeEditor`. When set, the editor clips overflowing content at rest and only scrolls (and reveals a scrollbar) once focused.

The two **message-list** editors opt in:
- message text content (`message-list-item.tsx`)
- tool-call response (`tool-call-list-item.tsx`)

The standalone **system-prompt** and **tool-definition** editors are unchanged — they stay always-scrollable.

## Why

In the message list, every capped (`max-h`) editor was showing its own scrollbar, and unfocused messages could be scrolled. With `scrollOnFocus`, a message shows no scrollbar at rest and only becomes scrollable once you click into it. Because the gate uses `overflow-auto` (not `overflow-scroll`), a focused editor whose content already fits still shows no bar.

## Implementation notes

- Behavior is gated behind a prop rather than baked into the shared component, so it doesn't regress the standalone editors (which want always-on scrolling).
- Only CodeMirror's `.cm-scroller` is gated — it is the sole scroll element in CM6, so gating the wrapper too would be redundant.

## Testing

Lint (`bun run lint:check`) and typecheck (`tsc --noEmit`) pass. Behavior verified manually in the desktop app.