### PR TITLE
feat(thread-playground): allow removing individual run history entries

### DIFF
--- a/apps/desktop/src/components/thread-playground/run-history-list-view.tsx
+++ b/apps/desktop/src/components/thread-playground/run-history-list-view.tsx
@@ -1,11 +1,12 @@
 import type { ThreadSnapshot } from "@llm-space/core";
-import { XIcon } from "lucide-react";
+import { Trash2Icon, XIcon } from "lucide-react";
 import { memo, useMemo } from "react";
 import { format } from "timeago.js";
 
 import { cn } from "@/lib/utils";
 
 import { useAutoAnimation } from "../../lib/use-auto-animation";
+import { Tooltip } from "../tooltip";
 import { Button } from "../ui/button";
 import { Item, ItemContent, ItemDescription, ItemGroup } from "../ui/item";
 
@@ -50,7 +51,7 @@ function _runMessageCountLabel(thread: ThreadSnapshot): string {
 function _RunHistoryListView({ onClose }: { onClose: () => void }) {
   const [containerRef] = useAutoAnimation();
   const runHistory = useThreadStore((s) => s.runHistory);
-  const { restoreThread } = useThreadStoreActions();
+  const { restoreThread, removeRun } = useThreadStoreActions();
   const runs = useMemo(() => runHistory.slice().reverse(), [runHistory]);
 
   return (
@@ -117,6 +118,26 @@ function _RunHistoryListView({ onClose }: { onClose: () => void }) {
                   <span className="shrink-0 tabular-nums">
                     {messageCountLabel}
                   </span>
+                  <Tooltip content="Remove run">
+                    <button
+                      type="button"
+                      aria-label={`Remove run from ${time}`}
+                      className="hover:text-foreground focus-visible:ring-ring/30 flex size-3.5 shrink-0 items-center justify-center self-center rounded-sm opacity-0 transition-opacity outline-none group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        removeRun(run);
+                      }}
+                      onKeyDown={(event) => {
+                        // Keep Enter/Space from bubbling to the item's
+                        // restore handler; other keys propagate as usual.
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.stopPropagation();
+                        }
+                      }}
+                    >
+                      <Trash2Icon className="size-3" />
+                    </button>
+                  </Tooltip>
                 </div>
               </Item>
             );

--- a/apps/desktop/src/components/thread-playground/stores/thread-store.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-store.ts
@@ -58,6 +58,7 @@ export interface ThreadState {
   undo(): void;
   redo(): void;
   restoreThread(thread: Thread): void;
+  removeRun(run: RunSnapshot): void;
   appendMessage(): void;
   insertMessageBefore(beforeMessageId: string): void;
   moveMessage(fromIndex: number, toIndex: number): void;
@@ -583,6 +584,31 @@ export function createThreadStore(
             changeHistory: recordSnapshot(get().changeHistory, next),
           });
         },
+        removeRun(run: RunSnapshot) {
+          if (get().status === "running") {
+            return;
+          }
+          const current = get().runHistory;
+          const runHistory = current.filter((r) => r !== run);
+          if (runHistory.length === current.length) {
+            return;
+          }
+          // Deleting a run is not an undoable edit — undo/redo re-attach the
+          // live runHistory anyway — so update the current snapshot in place
+          // instead of recording a new step.
+          const thread = withRunHistory(get().thread, runHistory);
+          const history = get().changeHistory;
+          set({
+            thread,
+            runHistory,
+            changeHistory: {
+              ...history,
+              snapshots: history.snapshots.map((snapshot, index) =>
+                index === history.index ? thread : snapshot
+              ),
+            },
+          });
+        },
         abort() {
           const { status, abortController } = get();
           if (status !== "running") {
@@ -617,6 +643,7 @@ const selectActions = (s: ThreadState) => ({
   undo: s.undo,
   redo: s.redo,
   restoreThread: s.restoreThread,
+  removeRun: s.removeRun,
 
   appendMessage: s.appendMessage,
   insertMessageBefore: s.insertMessageBefore,


### PR DESCRIPTION
## Motivation

Run history entries could only be appended (each completed run records a snapshot, capped at 20) and restored — there was no way to remove one. The only ways to get rid of an entry were the automatic oldest-first eviction or hand-editing the thread JSON on disk.

## Design

**A per-entry remove action in the store, revealed on hover in the panel** — following the existing remove patterns (Remove tool / Remove message / Remove image).

- `thread-store.ts` gains a `removeRun(run)` action: it filters the entry out of `runHistory` (by reference), re-attaches the remaining history to the thread via `withRunHistory()` so the existing debounced persistence picks the change up, and no-ops while a run is streaming (same guard as `restoreThread`/`undo`/`redo`).
- Removal is intentionally **not** an undo step: undo/redo re-attach the live `runHistory` anyway, so the action updates the current `changeHistory` snapshot in place — the same pattern undo/redo use — preserving the `snapshots[index] === thread` invariant.
- `run-history-list-view.tsx` renders a small trash button at the far right of each entry's metadata row: `opacity-0` until item hover (or keyboard focus), wrapped in the app `Tooltip` ("Remove run"). Click and Enter/Space stop propagation so removing an entry never triggers the surrounding item's restore action.
- Removing the last entry drops the `runHistory` field from the persisted file entirely (existing `withRunHistory` behavior).

## Verification

Exercised in the real desktop renderer over CDP (`bun run dev:cef` with an isolated `LLM_SPACE_ROOT`): the trash button stays hidden until hover and reveals on the hovered entry only; clicking it — and activating it via Enter on the focused button — removes exactly that entry without firing restore; the debounced write persists the change to the thread JSON; removing every entry shows the "No runs yet" empty state and drops the `runHistory` key from the file. `eslint .` and `tsc --noEmit` pass.