### PR TITLE
fix(thread-playground): skip run history for runs that fail pre-flight validation

### DIFF
--- a/apps/desktop/src/components/thread-playground/stores/thread-store.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-store.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import {
   AssistantMessage,
+  isRunnableConversation,
   Message,
   reduceMessages,
+  RUN_LAST_MESSAGE_ERROR,
   streamThread,
   Tool as ToolSchema,
   uuid,
@@ -441,17 +443,30 @@ export function createThreadStore(
             toast.error("Select a model to run");
             return;
           }
-          const abortController = new AbortController();
-          set({ status: "running", abortController });
-
-          // Truncate trailing messages when re-running from a given message.
+          // Pre-flight: resolve the message list the run would use (including
+          // the rerun-from truncation) and validate it before entering the
+          // running state, so an unrunnable thread is a complete no-op — no
+          // truncation, no undo step, no run-history entry.
           let messages = [...(get().thread.context?.messages ?? [])];
+          let truncated = false;
           if (fromMessageId) {
             const index = messages.findIndex((m) => m.id === fromMessageId);
             if (index !== -1 && index !== messages.length - 1) {
               messages = messages.slice(0, index + 1);
-              setMessages(messages);
+              truncated = true;
             }
+          }
+          if (!isRunnableConversation(messages)) {
+            toast.error("Error", { description: RUN_LAST_MESSAGE_ERROR });
+            return;
+          }
+          const abortController = new AbortController();
+          set({ status: "running", abortController });
+
+          // Commit the truncation while running so it folds into the run's
+          // single undo step instead of becoming its own snapshot.
+          if (truncated) {
+            setMessages(messages);
           }
           const runStartMessageCount = messages.length;
 
@@ -463,6 +478,10 @@ export function createThreadStore(
 
           let streamingMessage: AssistantMessage | null = null;
           let content: ReducedMessageContent[] = [];
+          // Whether the stream produced at least one event — i.e. the run
+          // actually started. A run that dies earlier (transport/auth/network
+          // failure) is not recorded in the run history.
+          let sawEvent = false;
 
           // Coalesce live-preview updates to at most one per animation frame.
           // A fast stream delivers a burst of events that the transport drains
@@ -499,6 +518,7 @@ export function createThreadStore(
               { signal: abortController.signal, transport: options.transport }
             );
             for await (const chunk of response) {
+              sawEvent = true;
               const reduced = reduceMessages(chunk, {
                 streamingMessage,
                 content,
@@ -544,26 +564,41 @@ export function createThreadStore(
             // undo step, and record a run snapshot. No-op for undo if the
             // thread is unchanged.
             const finalThread = get().thread;
-            const runUsage = aggregateMessageUsage(
-              (finalThread.context?.messages ?? []).slice(runStartMessageCount)
-            );
-            const runHistory = recordRun(
-              get().runHistory,
-              finalThread,
-              Date.now(),
-              { usage: runUsage }
-            );
-            const evaluations = normalizeEvaluations(
-              get().evaluations,
-              runHistory
-            );
-            const thread = withRunHistory(finalThread, runHistory, evaluations);
-            set({
-              thread,
-              changeHistory: recordSnapshot(get().changeHistory, thread),
-              runHistory,
-              evaluations,
-            });
+            if (sawEvent) {
+              const runUsage = aggregateMessageUsage(
+                (finalThread.context?.messages ?? []).slice(
+                  runStartMessageCount
+                )
+              );
+              const runHistory = recordRun(
+                get().runHistory,
+                finalThread,
+                Date.now(),
+                { usage: runUsage }
+              );
+              const evaluations = normalizeEvaluations(
+                get().evaluations,
+                runHistory
+              );
+              const thread = withRunHistory(
+                finalThread,
+                runHistory,
+                evaluations
+              );
+              set({
+                thread,
+                changeHistory: recordSnapshot(get().changeHistory, thread),
+                runHistory,
+                evaluations,
+              });
+            } else {
+              set({
+                changeHistory: recordSnapshot(
+                  get().changeHistory,
+                  finalThread
+                ),
+              });
+            }
           }
         },
         undo() {

--- a/packages/core/src/client/api.ts
+++ b/packages/core/src/client/api.ts
@@ -5,6 +5,10 @@ import type { ModelConfig } from "../types/models";
 import type { ThreadContext } from "../types/threads";
 
 import { convertToPiContext } from "./converters";
+import {
+  isRunnableConversation,
+  RUN_LAST_MESSAGE_ERROR,
+} from "./run-eligibility";
 import { createHttpTransport, type AgentTransport } from "./transport";
 
 export async function* streamThread(
@@ -15,16 +19,10 @@ export async function* streamThread(
     transport?: AgentTransport;
   } = {}
 ): AsyncGenerator<AgentEvent> {
-  const context = convertToPiContext(args.context);
-  if (context.messages.length > 0) {
-    const lastMessage = context.messages[context.messages.length - 1]!;
-    // 最后一条消息必须是 userMessage
-    if (lastMessage.role === "assistant") {
-      throw new Error(
-        "The last message must be a user message or a tool call result."
-      );
-    }
+  if (!isRunnableConversation(args.context.messages)) {
+    throw new Error(RUN_LAST_MESSAGE_ERROR);
   }
+  const context = convertToPiContext(args.context);
   const request: AgentStreamRequest = {
     model: {
       provider: args.model.provider,

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -1,4 +1,5 @@
 export * from "./api";
 export * from "./reducer";
+export * from "./run-eligibility";
 export * from "./transport";
 export type { AgentEvent } from "@earendil-works/pi-agent-core";

--- a/packages/core/src/client/run-eligibility.ts
+++ b/packages/core/src/client/run-eligibility.ts
@@ -1,0 +1,21 @@
+import type { Message } from "../types/messages";
+
+/** Error for starting a run on a conversation that cannot accept one. */
+export const RUN_LAST_MESSAGE_ERROR =
+  "The last message must be a user message or a tool call result.";
+
+/**
+ * Whether a conversation can start a run: it must be empty or end with a user
+ * message or a tool call result. An assistant message with tool calls converts
+ * into trailing `toolResult` messages (see `convertToPiContext`), so it
+ * qualifies; a plain assistant message does not.
+ */
+export function isRunnableConversation(
+  messages: Message[] | undefined
+): boolean {
+  const last = messages?.[messages.length - 1];
+  if (!last || last.role === "user") {
+    return true;
+  }
+  return (last.toolCalls?.length ?? 0) > 0;
+}

--- a/packages/core/src/server/agent/stream.ts
+++ b/packages/core/src/server/agent/stream.ts
@@ -6,6 +6,7 @@ import {
 } from "@earendil-works/pi-agent-core";
 import type { Api, Message, Model, Models, Tool } from "@earendil-works/pi-ai";
 
+import { RUN_LAST_MESSAGE_ERROR } from "../../client/run-eligibility";
 import type { AgentStreamRequest } from "../../types/agent";
 
 /**
@@ -53,9 +54,7 @@ export async function* streamAgent(
     const lastMessage =
       request.context.messages[request.context.messages.length - 1]!;
     if (lastMessage.role === "assistant") {
-      throw new Error(
-        "The last message must be a user message or a tool call result."
-      );
+      throw new Error(RUN_LAST_MESSAGE_ERROR);
     }
   }
 


### PR DESCRIPTION
## Problem

Clicking **Run** on a thread whose last message is a plain assistant message shows the expected error toast — `The last message must be a user message or a tool call result.` — but the failed run is still appended to the run history (and persisted into the thread file).

Root cause: the validation error is thrown inside `run()`'s `try` block (by `streamThread`), while the run snapshot is recorded unconditionally in the `finally` block, so every pre-flight failure still lands in `runHistory`.

## Changes

- **`@llm-space/core`**: new `client/run-eligibility.ts` exporting `isRunnableConversation()` + `RUN_LAST_MESSAGE_ERROR` — a conversation is runnable when empty, ending with a user message, or ending with an assistant message that has tool calls (which convert into trailing `toolResult` messages). `streamThread` reuses it (kept as a defensive throw), and the server-side `streamAgent` boundary check now shares the same error text instead of a hardcoded copy.
- **`thread-store.ts` `run()`**: validates the message list (including the prospective rerun-from truncation) *before* entering the running state — an unrunnable run is now a complete no-op: no truncation, no undo step, no run-history entry, just the toast.
- **`finally` hardening**: a run snapshot is recorded only when the stream produced at least one event, so failures before the first event (transport/auth/network) no longer pollute run history either. Truncation still folds into a single undo step in that case.

## Verification

- One-off store-level script (fake transport) covering 5 scenarios: invalid last-assistant run, invalid rerun-from (no truncation side effects), valid user-last run, tool-continuation run, and transport failure before the first event — all assertions fail on `main`, all pass on this branch.
- `bun run lint:check` clean on changed files; `tsc --noEmit` clean for both `packages/core` and `apps/desktop`.

## Possible follow-ups (out of scope)

- Disable the Run button (with a tooltip) via `isRunnableConversation` instead of toast-on-click.
- Reuse the shared helper for the per-message "Run from this message" enablement.