### PR TITLE
Feat/traces

### DIFF
--- a/.agents/kaizen-loop/CAPABILITY_MAP.md
+++ b/.agents/kaizen-loop/CAPABILITY_MAP.md
@@ -1,7 +1,7 @@
 # LLM Space Capability Map
 
-- Last updated: 2026-07-05
-- Map status: updated after Langfuse Trace Import V1 and Langfuse Connected Source V1; first-thread editing is stable, MCP remains intentionally tools-only with remote diagnostics, manual paused tool-step continuation is first-class, provider-reported token/cost/cache usage is captured on assistant steps and saved-run traces, manual Langfuse trace import has a dedicated Trace Panel/debug workbench path, and connected Langfuse projects can explicitly sync selected traces into the same trace-owned debug workbench.
+- Last updated: 2026-07-06
+- Map status: updated after Langfuse Trace Import V1, Langfuse Connected Source V1, and Trace Workbench Header/Protocol Repair; first-thread editing is stable, MCP remains intentionally tools-only with remote diagnostics, manual paused tool-step continuation is first-class, provider-reported token/cost/cache usage is captured on assistant steps and saved-run traces, manual Langfuse trace import has a dedicated Trace Panel/debug workbench path, and connected Langfuse projects can explicitly sync selected traces into the same trace-owned debug workbench with copyable trace identity.
 - Evidence rule: entries marked `confirmed` cite current rendered-product or current-code evidence. Entries marked `stale` rely on previous logs or code paths not fully re-inspected in this loop. Entries marked `unknown` need a future product-surface check before they can drive a recommendation.
 
 ## First-Run Model Setup
@@ -237,7 +237,7 @@
 
 - Status: shipped V1
 - Freshness: confirmed
-- Last checked: 2026-07-05
+- Last checked: 2026-07-06
 - Evidence:
   - Current discovery screenshot `audits/2026-07-05-160904-langfuse-trace-import-discovery/01-current-native-debug-surface.png` shows the product can render a native reduced debug fixture with assistant thinking, tool calls, token usage, manual continuation state, and Run history.
   - Current discovery screenshot `audits/2026-07-05-160904-langfuse-trace-import-discovery/02-current-run-trace-inspector.png` shows the saved-run trace inspector can render a local `ThreadRunSnapshot` as a non-mutating debug view with usage and step evidence.
@@ -253,7 +253,8 @@
   - `packages/core/src/parsers/json-thread-parser.ts` accepts any non-foreign JSON that satisfies the optional-field `Thread` schema; a Langfuse observations payload with top-level `data` can therefore be written as a native-looking but empty thread instead of being rejected or normalized.
   - `packages/core/src/parsers/normalize-thread.ts` normalizes OpenAI/Anthropic chat-like `messages`, tools, images, tool calls, and tool results, but has no Langfuse trace/observation normalization path.
   - External Langfuse docs reviewed on 2026-07-05 say Langfuse traces are containers of observations, Observations API v2 returns row-level spans/generations/events, and UI/Blob exports can produce JSON/JSONL data that includes observations and trace context.
-- Boundary: users can create local Trace Projects, manually import supported Langfuse JSON (`{ data: [...] }` or bare observation arrays) into the selected project, list imported traces in the dedicated Trace Panel, and open each trace directly as a trace tab that reuses `ThreadPlayground` over a lazy-created trace-owned `workbench.json`.
+  - Protocol repair on 2026-07-06 checked the current Langfuse OpenAPI: v2 observations expose field groups including `io`, but input/output are always raw strings and `parseIoAsJson=true` is deprecated and returns 400. `TraceManager` now decodes JSON-shaped raw strings locally when creating the workbench and repairs existing workbench text wrappers such as `{"content":"..."}` on read.
+- Boundary: users can create local Trace Projects, manually import supported Langfuse JSON (`{ data: [...] }` or bare observation arrays) into the selected project, list imported traces in the dedicated Trace Panel, and open each trace directly as a trace tab that reuses `ThreadPlayground` over a lazy-created trace-owned `workbench.json`. Langfuse raw-string IO is normalized into user/assistant/tool text where it clearly wraps message content.
 - Explicit non-goals: no live Langfuse sync, no automatic connect UI, no JSONL in V1, no write-back to Langfuse, no account-management flow, no OTLP collector, no full read-only trace timeline UI, no Trace/Debug/Runs detail tabs in V1, and no mixing trace-owned workbenches into `workspace/`.
 - Visible gaps: no background sync, no JSONL import, no full raw trace timeline, no import preview, no delete/rename/credential-rotation project management, no schema-specific coverage for every Langfuse export variant, and no global trace search.
 
@@ -261,7 +262,7 @@
 
 - Status: shipped V1
 - Freshness: confirmed
-- Last checked: 2026-07-05
+- Last checked: 2026-07-06
 - Evidence:
   - Pre-implementation CEF discovery screenshot `audits/2026-07-05-221840-langfuse-connect-v1/01-current-trace-panel-empty.png` showed the Trace Panel empty state only supported creating a local Trace Project and manually importing Langfuse JSON; there was no connect/test/sync entry.
   - Pre-implementation CEF snapshot on 2026-07-05 showed the Trace Panel toolbar actions were `New Trace Project` and `Import Langfuse Export`; there was no API credential path.
@@ -282,7 +283,9 @@
   - Polish audit screenshots `audits/2026-07-05-232553-trace-panel-polish/11-clean-connected-list.png`, `13-clean-sync-dialog-final.png`, `14-clean-connect-dialog.png`, and `15-clean-empty-traces.png` confirm the Trace Panel now has a visible panel title, clearer project/source hierarchy, labeled Langfuse connection fields, and a two-path sync dialog for exact trace-id sync or search/select sync.
   - Follow-up screenshot `audits/2026-07-05-232553-trace-panel-polish/16-connect-dialog-no-project-name.png` confirms connected Langfuse setup now only asks for base URL, public key, and secret key; the local project name is derived after validation.
   - Clean CEF verification on port `9372` confirmed no horizontal overflow at 1280px and no relevant console errors after the polish pass; screenshots and DOM text showed only redacted key previews.
-- Boundary: users can create a connected Langfuse Trace Project by entering base URL/public key/secret key, validate before save, persist the local connection in `project.json`, explicitly sync by trace id or by selecting from a bounded recent remote trace search, upsert the same remote trace without duplicating local rows, and open the synced trace in the existing trace-owned Debug workbench.
+  - Trace header/protocol repair evidence on 2026-07-06: CEF screenshot `audits/2026-07-06-trace-head-protocol/01-existing-cef-trace-head.png` shows the trace source header moved into `ThreadPlayground`, with the trace id rendered as a compact badge and a `Copy trace ID` action; DOM check showed no horizontal overflow.
+  - Focused Bun regressions on 2026-07-06 verified trace title rename updates `trace.json`, `workbench.json`, and the listed trace title; v2 raw-string IO imports produce normal system/user/assistant text; existing workbenches with JSON wrapper text are repaired on read.
+- Boundary: users can create a connected Langfuse Trace Project by entering base URL/public key/secret key, validate before save, persist the local connection in `project.json`, explicitly sync by trace id or by selecting from a bounded recent remote trace search, upsert the same remote trace without duplicating local rows, and open the synced trace in the existing trace-owned Debug workbench. Trace tabs expose editable trace titles, source context inside the workbench header, and a copyable trace-id badge.
 - Explicit non-goals: no background daemon or automatic initial sync, no write-back to Langfuse, no org-wide multi-project account picker in V1, no full secret display after save, no OAuth, no OTLP collector, no raw timeline UI, no automatic deletion of local traces when remote traces disappear, and no exhaustive historical backfill.
 - Visible gaps: date-range/cursor UI for large projects, credential rotation/delete/rename project management, richer sync diagnostics/history beyond latest redacted status, full raw trace timeline, global trace search, and JSONL/export variant expansion.
 

--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -411,6 +411,7 @@ function PageInner() {
                 reorder={tabs.reorder}
                 onNewFile={handleNewFile}
                 onMove={tabs.handleMove}
+                onTraceTitleChange={tabs.handleTraceTitleChange}
                 onToggleSidebar={handleToggleSidebar}
               />
             )}

--- a/apps/desktop/src/bun/rpc/index.ts
+++ b/apps/desktop/src/bun/rpc/index.ts
@@ -170,6 +170,8 @@ export const mainWindowRPC: MainWindowRPC =
           traceManager.readTrace(projectId, traceKey),
         traceReadOrCreateWorkbench: ({ projectId, traceKey }) =>
           traceManager.readOrCreateWorkbench(projectId, traceKey),
+        traceUpdateTraceTitle: ({ projectId, traceKey, title }) =>
+          traceManager.updateTraceTitle(projectId, traceKey, title),
         traceWriteWorkbench: async ({ projectId, traceKey, thread }) => {
           await traceManager.writeWorkbench(projectId, traceKey, thread);
           return null;

--- a/apps/desktop/src/bun/traces/langfuse-client.ts
+++ b/apps/desktop/src/bun/traces/langfuse-client.ts
@@ -65,6 +65,9 @@ type LangfuseTraceFilter =
 
 const OBSERVATION_FIELDS =
   "core,basic,time,io,model,usage,trace_context,metrics";
+// Langfuse v2 observations return input/output as raw strings. The old
+// `parseIoAsJson=true` parameter now returns 400, so TraceManager decodes
+// JSON-shaped strings locally before building the editable workbench.
 const TRACE_LIST_FIELDS = "core,metrics";
 const DEFAULT_REMOTE_TRACE_LIMIT = 50;
 const MAX_REMOTE_TRACE_LIMIT = 100;

--- a/apps/desktop/src/bun/traces/trace-manager.ts
+++ b/apps/desktop/src/bun/traces/trace-manager.ts
@@ -401,7 +401,54 @@ export class TraceManager {
     const thread = JSON.parse(
       await fs.readFile(workbenchPath, "utf8")
     ) as Thread;
-    return { trace, thread };
+    const normalizedThread = _normalizeExistingWorkbenchThread(thread);
+    if (normalizedThread !== thread) {
+      await fs.writeFile(
+        workbenchPath,
+        JSON.stringify(normalizedThread, null, 2),
+        "utf8"
+      );
+    }
+    return { trace, thread: normalizedThread };
+  }
+
+  /**
+   * Rename a trace-facing debug workbench. The title belongs to trace metadata,
+   * not the filesystem key, so renaming never moves raw trace folders.
+   */
+  async updateTraceTitle(
+    projectId: string,
+    traceKey: string,
+    title: string
+  ): Promise<TraceWorkbenchResponse> {
+    await this._requireProject(projectId);
+    const normalizedTitle = _normalizeTraceTitle(title);
+    const trace = await this._readTrace(projectId, traceKey);
+    const nextTrace: TraceRecord = {
+      ...trace,
+      title: normalizedTitle,
+      updatedAt: Date.now(),
+    };
+    await fs.writeFile(
+      this._tracePath(projectId, traceKey),
+      JSON.stringify(nextTrace, null, 2),
+      "utf8"
+    );
+
+    const workbenchPath = this._workbenchPath(projectId, traceKey);
+    if (!existsSync(workbenchPath)) {
+      const raw = await this._readRawTrace(projectId, traceKey);
+      const thread = _createWorkbench(nextTrace, raw.rows);
+      await fs.writeFile(workbenchPath, JSON.stringify(thread, null, 2), "utf8");
+      return { trace: nextTrace, thread };
+    }
+
+    const currentThread = JSON.parse(
+      await fs.readFile(workbenchPath, "utf8")
+    ) as Thread;
+    const thread = _threadWithTitle(currentThread, normalizedTitle);
+    await fs.writeFile(workbenchPath, JSON.stringify(thread, null, 2), "utf8");
+    return { trace: nextTrace, thread };
   }
 
   /**
@@ -793,6 +840,120 @@ function _errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function _normalizeTraceTitle(value: string): string {
+  const title = value.trim();
+  if (!title) {
+    throw new Error("Trace title is required.");
+  }
+  if ([...title].some((char) => char.charCodeAt(0) < 32)) {
+    throw new Error("Trace title contains a control character.");
+  }
+  return title;
+}
+
+function _threadWithTitle(thread: Thread, title: string): Thread {
+  return {
+    ...thread,
+    title,
+    runHistory: thread.runHistory?.map((run) => ({
+      ...run,
+      thread: { ...run.thread, title },
+    })),
+  };
+}
+
+function _normalizeExistingWorkbenchThread(thread: Thread): Thread {
+  const normalized = _normalizeThreadMessages(thread);
+  let changed = normalized.changed;
+  const nextRunHistory = normalized.thread.runHistory?.map((run) => {
+    const normalizedRun = _normalizeThreadMessages(run.thread);
+    if (normalizedRun.changed) {
+      changed = true;
+      return { ...run, thread: normalizedRun.thread };
+    }
+    return run;
+  });
+  if (!changed) {
+    return thread;
+  }
+  return { ...normalized.thread, runHistory: nextRunHistory };
+}
+
+function _normalizeThreadMessages(thread: Thread): {
+  thread: Thread;
+  changed: boolean;
+} {
+  const messages = thread.context?.messages;
+  if (!messages) {
+    return { thread, changed: false };
+  }
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    const next = _normalizeMessageText(message);
+    if (next !== message) {
+      changed = true;
+    }
+    return next;
+  });
+  if (!changed) {
+    return { thread, changed: false };
+  }
+  return {
+    thread: {
+      ...thread,
+      context: { ...thread.context, messages: nextMessages },
+    },
+    changed: true,
+  };
+}
+
+function _normalizeMessageText(message: Message): Message {
+  const content = _normalizeTextContent(message.content);
+  let next =
+    content === message.content ? message : ({ ...message, content } as Message);
+  if (next.role !== "assistant" || !next.toolCalls) {
+    return next;
+  }
+  let toolCallsChanged = false;
+  const toolCalls = next.toolCalls.map((toolCall) => {
+    if (!toolCall.output) {
+      return toolCall;
+    }
+    const outputContent = _normalizeTextContent(toolCall.output.content);
+    if (outputContent === toolCall.output.content) {
+      return toolCall;
+    }
+    toolCallsChanged = true;
+    return {
+      ...toolCall,
+      output: { ...toolCall.output, content: outputContent },
+    };
+  });
+  if (!toolCallsChanged) {
+    return next;
+  }
+  next = { ...next, toolCalls };
+  return next;
+}
+
+function _normalizeTextContent<T extends { type: string; text?: string }>(
+  content: T[]
+): T[] {
+  let changed = false;
+  const next = content.map((item) => {
+    if (item.type !== "text" || typeof item.text !== "string") {
+      return item;
+    }
+    const text = _textFromJsonWrapper(item.text);
+    if (text === item.text) {
+      return item;
+    }
+    changed = true;
+    return { ...item, text };
+  });
+  return changed ? next : content;
+}
+
 function _createTraceRecord({
   projectId,
   key,
@@ -1001,9 +1162,10 @@ function _toolCallFromSpan(row: LangfuseObservation): ToolCall {
 }
 
 function _extractInputMessages(value: unknown): LangfuseObservation[] {
-  const root = _asRecord(value);
-  const rawMessages = Array.isArray(value)
-    ? value
+  const decoded = _jsonDecodedValue(value);
+  const root = _asRecord(decoded);
+  const rawMessages = Array.isArray(decoded)
+    ? decoded
     : root && Array.isArray(root.messages)
       ? root.messages
       : root && Array.isArray(root.input)
@@ -1015,7 +1177,8 @@ function _extractInputMessages(value: unknown): LangfuseObservation[] {
 }
 
 function _assistantOutputText(value: unknown): string {
-  const root = _asRecord(value);
+  const decoded = _jsonDecodedValue(value);
+  const root = _asRecord(decoded);
   if (root) {
     if (_firstString(root.role) === "assistant" && root.content !== undefined) {
       return _textFromValue(root.content);
@@ -1027,7 +1190,7 @@ function _assistantOutputText(value: unknown): string {
       return _textFromValue(message.content);
     }
   }
-  return _textFromValue(value);
+  return _textFromValue(decoded);
 }
 
 function _appendUserMessage(messages: Message[], text: string): void {
@@ -1043,19 +1206,12 @@ function _appendUserMessage(messages: Message[], text: string): void {
 }
 
 function _argumentsFromValue(value: unknown): Record<string, unknown> {
-  const record = _asRecord(value);
+  const decoded = _jsonDecodedValue(value);
+  const record = _asRecord(decoded);
   if (record) {
     return record;
   }
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value) as unknown;
-      return _asRecord(parsed) ?? { value };
-    } catch {
-      return { value };
-    }
-  }
-  return value === undefined ? {} : { value };
+  return decoded === undefined ? {} : { value: decoded };
 }
 
 function _usageFromRow(row: LangfuseObservation): ModelUsage | null {
@@ -1256,12 +1412,59 @@ function _timeValue(value: string | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function _jsonDecodedValue(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+  if (!/^[{["]/.exec(trimmed)) {
+    return value;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function _textFromJsonWrapper(text: string): string {
+  const decoded = _jsonDecodedValue(text);
+  if (decoded === text) {
+    return text;
+  }
+  if (typeof decoded === "string") {
+    return decoded;
+  }
+  const record = _asRecord(decoded);
+  if (
+    record &&
+    (record.content !== undefined ||
+      record.text !== undefined ||
+      Array.isArray(record.choices))
+  ) {
+    return _textFromValue(decoded);
+  }
+  if (Array.isArray(decoded) && decoded.some(_looksLikeTextContentRecord)) {
+    return _textFromValue(decoded);
+  }
+  return text;
+}
+
+function _looksLikeTextContentRecord(value: unknown): boolean {
+  const record = _asRecord(value);
+  return Boolean(record?.text !== undefined || record?.content !== undefined);
+}
+
 function _textFromValue(value: unknown): string {
   if (value == null) {
     return "";
   }
   if (typeof value === "string") {
-    return value;
+    const decoded = _jsonDecodedValue(value);
+    return decoded === value ? value : _textFromValue(decoded);
   }
   if (Array.isArray(value)) {
     return value

--- a/apps/desktop/src/client/traces.ts
+++ b/apps/desktop/src/client/traces.ts
@@ -58,6 +58,10 @@ export const traceClient = {
   readOrCreateWorkbench(projectId: string, traceKey: string) {
     return _rpc().request.traceReadOrCreateWorkbench({ projectId, traceKey });
   },
+  /** Rename a trace and keep its editable workbench title aligned. */
+  updateTraceTitle(projectId: string, traceKey: string, title: string) {
+    return _rpc().request.traceUpdateTraceTitle({ projectId, traceKey, title });
+  },
   /** Persist the trace workbench thread without changing the raw trace payload. */
   async writeWorkbench(
     projectId: string,

--- a/apps/desktop/src/components/thread-playground/misc/title-editor.tsx
+++ b/apps/desktop/src/components/thread-playground/misc/title-editor.tsx
@@ -1,23 +1,30 @@
 import { PencilIcon } from "lucide-react";
 import { memo, useCallback, useMemo, useRef, useState } from "react";
 
-import { validateThreadFileStem } from "@/lib/thread-file";
+import {
+  validateThreadFileStem,
+  type FileStemValidationResult,
+} from "@/lib/thread-file";
 import { cn } from "@/lib/utils";
 
 import { Tooltip } from "../../tooltip";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 
+export type TitleValidator = (value: string) => FileStemValidationResult;
+
 function _TitleEditor({
   className,
   title,
   readonly,
   onRename,
+  validateTitle = validateThreadFileStem,
 }: {
   className?: string;
   title: string;
   readonly?: boolean;
   onRename?: (title: string) => Promise<boolean>;
+  validateTitle?: TitleValidator;
 }) {
   const [editing, setEditing] = useState(false);
   const [draftTitle, setDraftTitle] = useState("");
@@ -26,8 +33,8 @@ function _TitleEditor({
   const cancelledRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const validation = useMemo(
-    () => validateThreadFileStem(draftTitle),
-    [draftTitle]
+    () => validateTitle(draftTitle),
+    [draftTitle, validateTitle]
   );
 
   const startEditing = useCallback(() => {
@@ -41,7 +48,7 @@ function _TitleEditor({
   }, []);
 
   const commitEditing = useCallback(async () => {
-    const result = validateThreadFileStem(draftTitle);
+    const result = validateTitle(draftTitle);
     if (!result.valid) {
       setError(result.error ?? "Invalid file name.");
       focusInput();
@@ -65,7 +72,7 @@ function _TitleEditor({
     } finally {
       setCommitting(false);
     }
-  }, [draftTitle, focusInput, onRename, title]);
+  }, [draftTitle, focusInput, onRename, title, validateTitle]);
 
   const cancelEditing = useCallback(() => {
     cancelledRef.current = true;

--- a/apps/desktop/src/components/thread-playground/thread-playground.tsx
+++ b/apps/desktop/src/components/thread-playground/thread-playground.tsx
@@ -2,7 +2,14 @@
 
 import type { AgentTransport, Thread } from "@llm-space/core";
 import { HistoryIcon, PlayIcon, Redo2Icon, Undo2Icon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { usePanelRef } from "react-resizable-panels";
 
 import { useRegisterCommands } from "@/commands";
@@ -26,7 +33,7 @@ import { Spinner } from "../ui/spinner";
 
 import { MessageListView } from "./message/message-list-view";
 import { ThreadPlaygroundSkeleton } from "./misc/skeleton";
-import { TitleEditor } from "./misc/title-editor";
+import { TitleEditor, type TitleValidator } from "./misc/title-editor";
 import { ModelConfigEditor } from "./model/model-config-editor";
 import { SystemPromptEditor } from "./prompt/system-prompt-editor";
 import { RunHistoryListView } from "./run-history-list-view";
@@ -46,6 +53,7 @@ export interface ThreadPlaygroundProps {
   className?: string;
   path: string;
   title?: string;
+  headerDetails?: ReactNode;
   initialValue: Thread;
   readonly?: boolean;
   /**
@@ -59,6 +67,7 @@ export interface ThreadPlaygroundProps {
 
   onChange?: (thread: Thread) => void;
   onRenameTitle?: (title: string) => Promise<boolean>;
+  validateTitle?: TitleValidator;
   onStreamingStart?: () => void;
   onStreamingEnd?: () => void;
 }
@@ -125,7 +134,9 @@ function ThreadPlaygroundContent({
   className,
   path,
   title: titleFromProps,
+  headerDetails,
   onRenameTitle,
+  validateTitle,
   readonly: readonlyFromProps = false,
   active = false,
 }: Omit<
@@ -198,14 +209,25 @@ function ThreadPlaygroundContent({
     >
       <ResizablePanelGroup>
         <ResizablePanel className="flex min-h-0 flex-col overflow-hidden">
-          <header className="flex h-12 w-full shrink-0 items-center border-b">
+          <header
+            className={cn(
+              "flex w-full shrink-0 items-center border-b",
+              headerDetails ? "min-h-14 py-1.5" : "h-12"
+            )}
+          >
             <div className="min-w-0 grow px-3">
               <TitleEditor
                 className="w-96 max-w-full"
                 title={title}
                 readonly={readonly || !onRenameTitle}
                 onRename={onRenameTitle}
+                validateTitle={validateTitle}
               />
+              {headerDetails ? (
+                <div className="mt-0.5 flex min-w-0 items-center">
+                  {headerDetails}
+                </div>
+              ) : null}
             </div>
             <div
               className={cn(

--- a/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
@@ -62,6 +62,11 @@ interface ThreadTabsProps {
   /** Create a new thread at the workspace root (auto-named, opened, selected). */
   onNewFile?: () => void;
   onMove?: (from: string, to: string) => void;
+  onTraceTitleChange?: (
+    projectId: string,
+    traceKey: string,
+    title: string
+  ) => void;
   onToggleSidebar?: () => void;
 }
 
@@ -81,6 +86,7 @@ export function ThreadTabs({
   reorder,
   onNewFile,
   onMove,
+  onTraceTitleChange,
   onToggleSidebar,
 }: ThreadTabsProps) {
   const { resolvedTheme } = useTheme();
@@ -310,6 +316,7 @@ export function ThreadTabs({
               active={tab.id === activeId}
               refreshNonce={tab.refreshNonce ?? 0}
               onClose={close}
+              onRenameTitle={onTraceTitleChange}
             />
           )
         )}

--- a/apps/desktop/src/components/thread-tabs/trace-tab-pane.tsx
+++ b/apps/desktop/src/components/thread-tabs/trace-tab-pane.tsx
@@ -2,12 +2,16 @@
 
 import type { Thread } from "@llm-space/core";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { CopyIcon } from "lucide-react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { createRpcTransport, traceClient } from "@/client";
 import { ThreadPlayground } from "@/components/thread-playground";
+import { Tooltip } from "@/components/tooltip";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { TraceRecord } from "@/shared/traces";
 
 const rpcTransport = createRpcTransport();
 
@@ -17,6 +21,7 @@ interface TraceTabPaneProps {
   active: boolean;
   refreshNonce?: number;
   onClose?: (tabId: string) => void;
+  onRenameTitle?: (projectId: string, traceKey: string, title: string) => void;
 }
 
 function _TraceTabPane({
@@ -25,6 +30,7 @@ function _TraceTabPane({
   active,
   refreshNonce = 0,
   onClose,
+  onRenameTitle,
 }: TraceTabPaneProps) {
   const tabId = `trace:${projectId}:${traceKey}`;
   const qc = useQueryClient();
@@ -75,6 +81,22 @@ function _TraceTabPane({
     [flushPending]
   );
 
+  const handleRenameTitle = useCallback(
+    async (title: string): Promise<boolean> => {
+      await flushPending();
+      const next = await traceClient.updateTraceTitle(
+        projectId,
+        traceKey,
+        title
+      );
+      qc.setQueryData(["trace", "workbench", projectId, traceKey], next);
+      void qc.invalidateQueries({ queryKey: ["trace", "traces", projectId] });
+      onRenameTitle?.(projectId, traceKey, next.trace.title);
+      return true;
+    },
+    [flushPending, onRenameTitle, projectId, qc, traceKey]
+  );
+
   useEffect(() => {
     return () => {
       void flushPending();
@@ -110,35 +132,84 @@ function _TraceTabPane({
   }, [projectId, qc, refreshNonce, traceKey]);
 
   const trace = data?.trace;
-  const contextLine = trace
-    ? [
-        "Langfuse",
-        trace.source.mode === "manual" ? "Manual Import" : "Connected",
-        `trace ${trace.source.traceId}`,
-        `imported ${new Date(trace.importedAt).toLocaleString()}`,
-      ].join(" · ")
-    : "Langfuse trace";
 
   return (
     <div className={cn("flex size-full flex-col", !active && "hidden")}>
-      <div className="bg-muted/30 border-b px-3 py-1.5">
-        <div className="text-muted-foreground truncate text-[0.6875rem]">
-          {contextLine}
-        </div>
-      </div>
       <ThreadPlayground
         key={reloadKey}
         className="bg-background min-h-0 flex-1 shadow-lg"
         loading={isLoading || !data}
         path={`trace/${projectId}/${traceKey}/workbench.json`}
         title={trace?.title ?? traceKey}
+        headerDetails={trace ? <TraceHeaderDetails trace={trace} /> : null}
         initialValue={data?.thread}
         active={active}
         transport={rpcTransport}
         onChange={handleChange}
+        onRenameTitle={handleRenameTitle}
+        validateTitle={_validateTraceTitle}
       />
     </div>
   );
 }
 
 export const TraceTabPane = memo(_TraceTabPane);
+
+function _TraceHeaderDetails({ trace }: { trace: TraceRecord }) {
+  const traceId = trace.source.traceId;
+  const copyTraceId = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(traceId);
+      toast.success("Trace ID copied");
+    } catch {
+      toast.error("Could not copy trace ID");
+    }
+  }, [traceId]);
+  const sourceLabel =
+    trace.source.mode === "manual" ? "Manual Import" : "Connected";
+  return (
+    <div className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[0.6875rem]">
+      <span className="shrink-0">Langfuse</span>
+      <span className="shrink-0">·</span>
+      <span className="shrink-0">{sourceLabel}</span>
+      <span className="shrink-0">·</span>
+      <span className="hidden shrink-0 sm:inline">
+        imported {new Date(trace.importedAt).toLocaleString()}
+      </span>
+      <span className="hidden shrink-0 sm:inline">·</span>
+      <span
+        className="border-border bg-muted/60 text-foreground min-w-0 max-w-72 truncate rounded-full border px-2 py-0.5 font-mono text-[0.625rem]"
+        title={traceId}
+      >
+        {traceId}
+      </span>
+      <Tooltip content="Copy Trace ID">
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Copy trace ID"
+          onClick={copyTraceId}
+        >
+          <CopyIcon className="size-3" />
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+const TraceHeaderDetails = memo(_TraceHeaderDetails);
+
+function _validateTraceTitle(value: string) {
+  const title = value.trim();
+  if (!title) {
+    return { valid: false, value: title, error: "Trace title is required." };
+  }
+  if ([...title].some((char) => char.charCodeAt(0) < 32)) {
+    return {
+      valid: false,
+      value: title,
+      error: "Trace title contains a control character.",
+    };
+  }
+  return { valid: true, value: title };
+}

--- a/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
+++ b/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
@@ -71,6 +71,12 @@ export interface ThreadTabs {
   handleRemove: (removed: string) => void;
   /** File-tree rename/move: rewrite open thread tab paths under `from` to `to`. */
   handleMove: (from: string, to: string) => void;
+  /** Trace metadata edit: update labels for already-open trace tabs. */
+  handleTraceTitleChange: (
+    projectId: string,
+    traceKey: string,
+    title: string
+  ) => void;
   /**
    * Reopen the most recently closed tab group, silently skipping files or traces
    * that no longer exist.
@@ -439,6 +445,18 @@ export function useThreadTabs(): ThreadTabs {
     });
   }, []);
 
+  const handleTraceTitleChange = useCallback(
+    (projectId: string, traceKey: string, title: string) => {
+      const id = _traceTabId(projectId, traceKey);
+      setTabs((prev) =>
+        prev.map((tab) =>
+          tab.id === id && tab.type === "trace" ? { ...tab, title } : tab
+        )
+      );
+    },
+    []
+  );
+
   const refresh = useCallback((id: string) => {
     setTabs((prev) =>
       prev.map((tab) =>
@@ -462,6 +480,7 @@ export function useThreadTabs(): ThreadTabs {
     refresh,
     handleRemove,
     handleMove,
+    handleTraceTitleChange,
     reopenClosed,
   };
 }

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -213,6 +213,11 @@ export interface DesktopRPCType {
         params: { projectId: string; traceKey: string };
         response: TraceWorkbenchResponse;
       };
+      // Rename a trace summary and keep its editable workbench title in sync.
+      traceUpdateTraceTitle: {
+        params: { projectId: string; traceKey: string; title: string };
+        response: TraceWorkbenchResponse;
+      };
       // Persist a trace workbench thread; raw trace data remains immutable.
       traceWriteWorkbench: {
         params: { projectId: string; traceKey: string; thread: Thread };


### PR DESCRIPTION
and workbench normalization

Add a `traceUpdateTraceTitle` RPC endpoint and client call that renames a
trace record and keeps its editable workbench thread title aligned. Inline
a `_threadWithTitle` helper that propagates the new title into child run histories.

During `readOrCreateWorkbench`, normalize existing workbench threads by unwrapping JSON-encoded text content (Langfuse v2 returns raw strings; `parseIoAsJson=true` is deprecated and returns 400). The fix applies at both the top-level message array and nested run-history threads, toggling
a `changed` flag so the normalized representation is written back only when actually modified.

Extract `TitleValidator` from `TitleEditor` so trace panes can inject a trace-specific validator that rejects control characters, ensuring no corrupt titles are written to disk. Wire the rename callback from `useThreadTabs` through `ThreadTabs` and `TraceTabPane`.

The `_jsonDecodedValue` helper in the Langfuse parser now also decodes JSON-shaped string values at the `input` field boundary (input messages can arrive as `[{"role": "user", "content": [...]}]` inside a top-level string), fixing a bug where wrapped JSON arrays were not treated as valid
message roots.