### PR TITLE
fix(thread-playground): skip run history for runs that fail at runtime

### DIFF
--- a/apps/desktop/src/components/thread-playground/stores/thread-store.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-store.ts
@@ -483,6 +483,13 @@ export function createThreadStore(
           // actually started. A run that dies earlier (transport/auth/network
           // failure) is not recorded in the run history.
           let sawEvent = false;
+          // Whether the run ended in an error. The agent loop emits lifecycle
+          // events before the model call, and a model API failure completes
+          // the stream normally with the error tucked into the message
+          // (surfaced as a throw by reduceMessages on agent_end) — so
+          // `sawEvent` alone can't tell a failed run from a successful one.
+          // A failed run is never recorded in the run history.
+          let failed = false;
 
           // Coalesce live-preview updates to at most one per animation frame.
           // A fast stream delivers a burst of events that the transport drains
@@ -547,6 +554,7 @@ export function createThreadStore(
                 commit(streamingMessage);
               }
             } else {
+              failed = true;
               console.error(error);
               if (error instanceof Error) {
                 toast.error("Error", { description: error.message });
@@ -565,7 +573,7 @@ export function createThreadStore(
             // undo step, and record a run snapshot. No-op for undo if the
             // thread is unchanged.
             const finalThread = get().thread;
-            if (sawEvent) {
+            if (sawEvent && !failed) {
               const runUsage = aggregateMessageUsage(
                 (finalThread.context?.messages ?? []).slice(
                   runStartMessageCount


### PR DESCRIPTION
## Problem

Follow-up to #11. That PR only kept *pre-flight* failures out of the run history — a run that fails **at runtime** (e.g. a model API error: bad key, rate limit, network drop) still lands in `runHistory` and gets persisted into the thread file.

Root cause: #11 gated recording on `sawEvent` (the stream produced at least one event), but that's the wrong proxy for "the run succeeded":

- `pi-agent-core` emits `agent_start` / `turn_start` **before** the model API call, so `sawEvent` is `true` for virtually every runtime failure.
- A model API error doesn't make the stream throw — the agent loop completes the event stream normally (`message_start` → `message_end` → `turn_end` → `agent_end`) with the error embedded in the assistant message's `errorMessage`. It only surfaces as a throw when `reduceMessages` processes `agent_end` — after `sawEvent` is already set.

So the only failures #11 actually filtered were those thrown before the very first event (pre-flight validation, model-not-found, transport handshake).

## Changes

**`thread-store.ts` `run()`**: track a `failed` flag, set in the `catch`'s non-abort branch — the same path that shows the error toast — and record a run snapshot only when `sawEvent && !failed`.

The resulting invariant is simple: **if the user sees an error toast, the run never enters run history.** Everything else keeps its existing behavior:

- aborted runs still record (partial content is committed on purpose),
- abort-before-first-event still records nothing (`sawEvent` still guards that),
- a failed run leaves the thread untouched (the `agent_end` throw skips the post-loop commit), and the rerun-from truncation still folds into a single undo step via the `else` branch.

## Verification

- One-off store-level script (fake transport replaying the exact `pi-agent-core` event sequences) covering 4 scenarios: model API error mid-stream (fails on `main`: `runHistory=1`; passes here: `runHistory=0`), successful run (still records), failure before the first event (still skipped), user abort mid-stream (still records).
- Reviewed the fix against the transport layers: bun-side `runStreamThread` sends exactly one terminal message (`done` XOR `error`) and the RPC transport checks `error` before `done`, so every runtime failure deterministically reaches the `catch` that sets `failed`.
- `bun run lint:check` clean; `tsc --noEmit` clean for the changed file.

## Out of scope

`reduceMessages` only throws on `agent_end` when `errorMessage` is truthy — an error outcome carrying an empty-string message would still record as a success (pre-existing edge, no toast shown either; left as is).