### PR TITLE
feat(tabs): middle-click close and tab switch commands

### DIFF
--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -154,7 +154,15 @@ function PageInner() {
   // The active tab is read through a ref so command handlers never go stale.
   const activeTabIdRef = useRef(tabs.activeId);
   activeTabIdRef.current = tabs.activeId;
-  const { close, closeOthers, closeAll, openTrace, reopenClosed } = tabs;
+  const {
+    close,
+    closeOthers,
+    closeAll,
+    openTrace,
+    reopenClosed,
+    activateNext,
+    activatePrevious,
+  } = tabs;
 
   // Collapse / expand the left side panel.
   const sidebarPanelRef = usePanelRef();
@@ -223,6 +231,8 @@ function PageInner() {
     },
     closeAllTabs: () => closeAll(),
     reopenClosedTab: () => void reopenClosed(),
+    selectNextTab: () => activateNext(),
+    selectPreviousTab: () => activatePrevious(),
     toggleSidebar: () => toggleSidebar(),
     openSettings: ({ tab }) => {
       if (tab) setSettingsTab(tab);

--- a/apps/desktop/src/bun/app/menu.ts
+++ b/apps/desktop/src/bun/app/menu.ts
@@ -159,6 +159,19 @@ ApplicationMenu.setApplicationMenu([
         type: "divider",
       },
       {
+        label: "Select Previous Tab",
+        action: "selectPreviousTab",
+        accelerator: "CommandOrControl+Option+Left",
+      },
+      {
+        label: "Select Next Tab",
+        action: "selectNextTab",
+        accelerator: "CommandOrControl+Option+Right",
+      },
+      {
+        type: "divider",
+      },
+      {
         role: "toggleFullScreen",
         accelerator: "CommandOrControl+Shift+F",
       },
@@ -220,6 +233,8 @@ const MENU_ACTION_COMMANDS: Record<string, Command> = {
   closeOtherTabs: { type: "closeOtherTabs", args: {} },
   closeAllTabs: { type: "closeAllTabs", args: {} },
   reopenClosedTabs: { type: "reopenClosedTab", args: {} },
+  selectNextTab: { type: "selectNextTab", args: {} },
+  selectPreviousTab: { type: "selectPreviousTab", args: {} },
   openDocument: { type: "openDocument", args: {} },
   openGitHubProject: {
     type: "openLink",

--- a/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
@@ -169,17 +169,9 @@ export function ThreadTabs({
   }, [tabs.length, handleTabsHeaderDoubleClick]);
 
   const handleContextMenu = useCallback((event: MouseEvent<HTMLDivElement>) => {
-    const target = event.target;
-    if (!(target instanceof HTMLElement)) {
-      setContextMenuId(null);
-      event.preventDefault();
-      return;
-    }
-
-    const tab = target.closest<HTMLElement>(".chrome-tab[data-tab-id]");
-    const path = tab?.getAttribute("data-tab-id") ?? null;
-    setContextMenuId(path);
-    if (path === null) {
+    const id = _tabIdFromEventTarget(event.target);
+    setContextMenuId(id);
+    if (id === null) {
       event.preventDefault();
     }
   }, []);
@@ -190,24 +182,32 @@ export function ThreadTabs({
   // The chrome-tabs lib activates a tab on ANY mousedown, so a middle-click
   // close would flash the tab active before closing it. Stop the middle-button
   // mousedown during capture — before it reaches the lib's tab-level listener —
-  // and close on auxclick, which the browser still dispatches independently of
-  // the swallowed mousedown. preventDefault also disables middle-click
-  // autoscroll on Windows/Linux.
+  // and close when the matching middle mouseup lands on the same tab. mouseup
+  // is used instead of auxclick because the system WKWebView (the non-CEF
+  // renderer) only dispatches auxclick on WebKit ≥ 17.4. A middle-click chorded
+  // into a left-button drag (buttons & 1) is ignored entirely: closing a tab
+  // mid-drag would force the lib to end the drag against a stale tab list.
+  // preventDefault also disables middle-click autoscroll on Windows/Linux.
+  const middlePressedTabIdRef = useRef<string | null>(null);
   const handleMouseDownCapture = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
-      if (event.button !== 1) return;
-      if (_tabIdFromEventTarget(event.target) === null) return;
+      if (event.button !== 1 || (event.buttons & 1) !== 0) return;
+      const id = _tabIdFromEventTarget(event.target);
+      if (id === null) return;
+      middlePressedTabIdRef.current = id;
       event.preventDefault();
       event.stopPropagation();
     },
     []
   );
 
-  const handleAuxClick = useCallback(
+  const handleMouseUp = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
       if (event.button !== 1) return;
+      const pressed = middlePressedTabIdRef.current;
+      middlePressedTabIdRef.current = null;
       const id = _tabIdFromEventTarget(event.target);
-      if (id !== null) close(id);
+      if (id !== null && id === pressed) close(id);
     },
     [close]
   );
@@ -223,7 +223,7 @@ export function ThreadTabs({
             className="bg-tabs relative flex w-full"
             onContextMenu={handleContextMenu}
             onMouseDownCapture={handleMouseDownCapture}
-            onAuxClick={handleAuxClick}
+            onMouseUp={handleMouseUp}
           >
             <div
               className={cn(

--- a/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
@@ -185,13 +185,18 @@ export function ThreadTabs({
   // and close when the matching middle mouseup lands on the same tab. mouseup
   // is used instead of auxclick because the system WKWebView (the non-CEF
   // renderer) only dispatches auxclick on WebKit ≥ 17.4. A middle-click chorded
-  // into a left-button drag (buttons & 1) is ignored entirely: closing a tab
-  // mid-drag would force the lib to end the drag against a stale tab list.
+  // into a left-button drag (buttons & 1) is ignored on both the press and the
+  // release: closing a tab mid-drag would force the lib to end the drag against
+  // a stale tab list. Every middle press first clears the pending-close target,
+  // and every middle release clears it again, so a press that never released
+  // over the strip can't leak into a later gesture and close the wrong tab.
   // preventDefault also disables middle-click autoscroll on Windows/Linux.
   const middlePressedTabIdRef = useRef<string | null>(null);
   const handleMouseDownCapture = useCallback(
     (event: MouseEvent<HTMLDivElement>) => {
-      if (event.button !== 1 || (event.buttons & 1) !== 0) return;
+      if (event.button !== 1) return;
+      middlePressedTabIdRef.current = null;
+      if ((event.buttons & 1) !== 0) return;
       const id = _tabIdFromEventTarget(event.target);
       if (id === null) return;
       middlePressedTabIdRef.current = id;
@@ -206,6 +211,7 @@ export function ThreadTabs({
       if (event.button !== 1) return;
       const pressed = middlePressedTabIdRef.current;
       middlePressedTabIdRef.current = null;
+      if ((event.buttons & 1) !== 0) return;
       const id = _tabIdFromEventTarget(event.target);
       if (id !== null && id === pressed) close(id);
     },

--- a/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
@@ -45,6 +45,15 @@ const MOVE_TO_TRASH_LABEL = _isWindows
 // with the focus-visible ring stuck; keyboard focus (Tab) still rings them.
 const _preventFocusSteal = (e: MouseEvent) => e.preventDefault();
 
+function _tabIdFromEventTarget(target: EventTarget | null): string | null {
+  if (!(target instanceof HTMLElement)) return null;
+  return (
+    target
+      .closest<HTMLElement>(".chrome-tab[data-tab-id]")
+      ?.getAttribute("data-tab-id") ?? null
+  );
+}
+
 interface ThreadTabsProps {
   className?: string;
   tabs: AppTab[];
@@ -178,6 +187,31 @@ export function ThreadTabs({
   const hasOtherTabs =
     contextMenuId !== null && tabs.some((tab) => tab.id !== contextMenuId);
 
+  // The chrome-tabs lib activates a tab on ANY mousedown, so a middle-click
+  // close would flash the tab active before closing it. Stop the middle-button
+  // mousedown during capture — before it reaches the lib's tab-level listener —
+  // and close on auxclick, which the browser still dispatches independently of
+  // the swallowed mousedown. preventDefault also disables middle-click
+  // autoscroll on Windows/Linux.
+  const handleMouseDownCapture = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 1) return;
+      if (_tabIdFromEventTarget(event.target) === null) return;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    []
+  );
+
+  const handleAuxClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.button !== 1) return;
+      const id = _tabIdFromEventTarget(event.target);
+      if (id !== null) close(id);
+    },
+    [close]
+  );
+
   return (
     <div
       ref={containerRef}
@@ -188,6 +222,8 @@ export function ThreadTabs({
           <div
             className="bg-tabs relative flex w-full"
             onContextMenu={handleContextMenu}
+            onMouseDownCapture={handleMouseDownCapture}
+            onAuxClick={handleAuxClick}
           >
             <div
               className={cn(

--- a/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
+++ b/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
@@ -337,23 +337,24 @@ export function useThreadTabs(): ThreadTabs {
     setActiveId(id);
   }, []);
 
-  const activateSibling = useCallback((offset: number) => {
+  const activateSibling = useCallback((offset: 1 | -1) => {
     setActiveId((current) => {
       const list = tabsRef.current;
       if (list.length === 0) return current;
       const index = list.findIndex((tab) => tab.id === current);
+      // No resolvable active tab: enter the cycle from the end being stepped
+      // into, so "previous" still moves leftwards (to the last tab).
       const next =
         index === -1
-          ? list[0]
+          ? offset === 1
+            ? list[0]
+            : list[list.length - 1]
           : list[(index + offset + list.length) % list.length];
-      return next?.id ?? current;
+      return next.id;
     });
   }, []);
 
-  const activateNext = useCallback(
-    () => activateSibling(1),
-    [activateSibling]
-  );
+  const activateNext = useCallback(() => activateSibling(1), [activateSibling]);
 
   const activatePrevious = useCallback(
     () => activateSibling(-1),

--- a/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
+++ b/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
@@ -65,6 +65,10 @@ export interface ThreadTabs {
   reorder: (from: number, to: number) => void;
   /** Focus an already-open tab by id. */
   activate: (id: string) => void;
+  /** Focus the tab after the active one in visual order, wrapping around. */
+  activateNext: () => void;
+  /** Focus the tab before the active one in visual order, wrapping around. */
+  activatePrevious: () => void;
   /** Reload the tab's backing file/workbench, discarding unsaved local edits. */
   refresh: (id: string) => void;
   /** File-tree delete: close open thread tabs at or beneath `removed`. */
@@ -333,6 +337,29 @@ export function useThreadTabs(): ThreadTabs {
     setActiveId(id);
   }, []);
 
+  const activateSibling = useCallback((offset: number) => {
+    setActiveId((current) => {
+      const list = tabsRef.current;
+      if (list.length === 0) return current;
+      const index = list.findIndex((tab) => tab.id === current);
+      const next =
+        index === -1
+          ? list[0]
+          : list[(index + offset + list.length) % list.length];
+      return next?.id ?? current;
+    });
+  }, []);
+
+  const activateNext = useCallback(
+    () => activateSibling(1),
+    [activateSibling]
+  );
+
+  const activatePrevious = useCallback(
+    () => activateSibling(-1),
+    [activateSibling]
+  );
+
   const close = useCallback(
     (id: string) => {
       setTabs((prev) => {
@@ -477,6 +504,8 @@ export function useThreadTabs(): ThreadTabs {
     closeAll,
     reorder,
     activate,
+    activateNext,
+    activatePrevious,
     refresh,
     handleRemove,
     handleMove,

--- a/apps/desktop/src/shared/commands.ts
+++ b/apps/desktop/src/shared/commands.ts
@@ -159,6 +159,12 @@ export interface CloseAllTabsCommand extends GenericCommand<"closeAllTabs"> {}
 /** Reopen the most recently closed tab group. */
 export interface ReopenClosedTabCommand extends GenericCommand<"reopenClosedTab"> {}
 
+/** Activate the tab after the active one in visual order, wrapping around. */
+export interface SelectNextTabCommand extends GenericCommand<"selectNextTab"> {}
+
+/** Activate the tab before the active one in visual order, wrapping around. */
+export interface SelectPreviousTabCommand extends GenericCommand<"selectPreviousTab"> {}
+
 // --- View / app ------------------------------------------------------------
 
 /** Collapse or expand the left side panel. */
@@ -234,6 +240,8 @@ export type Command =
   | CloseOtherTabsCommand
   | CloseAllTabsCommand
   | ReopenClosedTabCommand
+  | SelectNextTabCommand
+  | SelectPreviousTabCommand
   | ToggleSidebarCommand
   | OpenSettingsCommand
   | OpenModelSettingsCommand
@@ -297,6 +305,8 @@ export const COMMAND_META: Record<
   closeOtherTabs: { label: "Close Other Tabs", target: "webview" },
   closeAllTabs: { label: "Close All Tabs", target: "webview" },
   reopenClosedTab: { label: "Reopen Closed Tab", target: "webview" },
+  selectNextTab: { label: "Select Next Tab", target: "webview" },
+  selectPreviousTab: { label: "Select Previous Tab", target: "webview" },
   toggleSidebar: { label: "Toggle Sidebar", target: "webview" },
   openSettings: { label: "Settings", target: "webview" },
   openModelSettings: { label: "Configure Model Settings", target: "webview" },


### PR DESCRIPTION
## What

Two Chrome-style tab-bar interactions:

1. **Middle-click closes a tab** — without the tab flashing active first. The tab strip library (`@sinm/react-chrome-tabs`) activates a tab on *any* mousedown, so the middle-button mousedown is stopped during React's capture phase before it reaches the library's tab-level listener; the close then happens when the matching middle **mouseup** lands on the same tab (mouseup rather than `auxclick`, because the system WKWebView — the non-CEF renderer — only dispatches `auxclick` on WebKit ≥ 17.4). A middle-click chorded into a held left-button drag is ignored, so a close can never force-end an in-flight drag against a stale tab list. Middle-click on empty strip area is a no-op.
2. **Select Next / Previous Tab commands** — new `selectNextTab` / `selectPreviousTab` commands following the same route as the existing `Cmd+W` close: native menu accelerator → menu action → command layer → RPC → renderer handler. Two new Window menu items carry `CommandOrControl+Option+Right/Left`. Switching cycles through tabs in visual order with wrap-around at both edges, and the commands are also available from the command palette.

Note: `Ctrl+Tab` was considered but Electrobun's native accelerator parser has no `Tab` key name (verified against `libNativeWrapper.dylib`'s key table), so it is intentionally out of scope.

## How it's verified

- `bun run lint:check`, `tsc --noEmit`, and `prettier --check` — output identical to the `main` baseline (the only findings are pre-existing, in untouched files).
- CDP-driven checks against the real CEF renderer (`bun run dev:cef` with an isolated `LLM_SPACE_ROOT`), re-run after each revision:
  - middle-click on an inactive tab: focus stays put while the button is held (no activation flicker), the tab closes on release, active tab unchanged;
  - middle-click on empty strip area: no-op;
  - middle press on tab A released over tab B: closes nothing;
  - middle-click chorded into a held left button (drag in progress): closes nothing;
  - `selectNextTab` / `selectPreviousTab` injected as the exact bun→webview `executeCommand` RPC packets: next/previous switching and wrap-around across both edges all pass.
- Not automated: pressing the real `Cmd+Option+←/→` keys (macOS automation permission unavailable). The `option`/`left`/`right` accelerator key names are confirmed present in Electrobun's native parser table; a manual keypress check is recommended.

## Known trade-offs / follow-ups

- On Windows/Linux builds the accelerator maps to `Ctrl+Alt+Left/Right`, which can collide with OS/driver hotkeys (e.g. display rotation); the Windows/Linux native accelerator parsing of the `Option` token could not be verified from a Mac. The menu items themselves work regardless.
- Pre-existing (not introduced here, dev-only): `close()` in `use-thread-tabs.ts` calls `pushClosed` inside the `setTabs` updater, which React StrictMode double-invokes — the reopen stack gets duplicate entries in dev. Worth a separate fix.