### PR TITLE
feat(thread-playground): add auto-run mode for tool-calling threads

### DIFF
--- a/apps/desktop/src/components/thread-playground/auto-run-approval-dialog.tsx
+++ b/apps/desktop/src/components/thread-playground/auto-run-approval-dialog.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from "react";
+
+import { ConfirmDialog } from "@/components/confirm-dialog";
+
+import { useThreadStore, useThreadStoreActions } from "./stores";
+
+/**
+ * First-use gate for auto-run tool execution. Each tool name is approved once
+ * per thread session (i.e. until the tab closes); denying stops the episode
+ * with the tool calls left pending for manual handling.
+ */
+export function AutoRunApprovalDialog({
+  threadTitle,
+}: {
+  threadTitle: string;
+}) {
+  const approval = useThreadStore((s) => s.autoRunApproval);
+  const { respondToAutoRunApproval } = useThreadStoreActions();
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        respondToAutoRunApproval(false);
+      }
+    },
+    [respondToAutoRunApproval]
+  );
+  const handleConfirm = useCallback(() => {
+    respondToAutoRunApproval(true);
+  }, [respondToAutoRunApproval]);
+  return (
+    <ConfirmDialog
+      open={approval !== null}
+      onOpenChange={handleOpenChange}
+      title="Allow auto-run to call tools?"
+      description={
+        <>
+          Auto-run in “{threadTitle}” wants to call{" "}
+          <span className="text-foreground font-mono">
+            {(approval?.toolNames ?? []).join(", ")}
+          </span>
+          . Allowed tools run without asking again until this tab closes.
+        </>
+      }
+      cancelLabel="Stop auto-run"
+      confirmLabel="Allow"
+      confirmVariant="default"
+      onConfirm={handleConfirm}
+    />
+  );
+}

--- a/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
@@ -17,8 +17,6 @@ import {
 import { memo, useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { callBuiltInTool } from "@/client/built-in-tools";
-import { callMcpTool } from "@/client/mcp";
 import { openFirecrawlLimitDialog } from "@/components/firecrawl-limit-dialog";
 import { useRenderingFidelity } from "@/components/theme-provider";
 import { isFirecrawlLimitError } from "@/lib/firecrawl";
@@ -31,7 +29,8 @@ import { CollapsibleContent } from "../../ui/collapsible-content";
 import { Marker, MarkerContent, MarkerIcon } from "../../ui/marker";
 import { ShineBorder } from "../../ui/shine-border";
 import { Skeleton } from "../../ui/skeleton";
-import { useThreadStore, useThreadStoreActions } from "../stores";
+import { isThreadBusy, useThreadStore, useThreadStoreActions } from "../stores";
+import { callThreadTool } from "../tool/call-thread-tool";
 
 import { ImageContentList } from "./image-content-view";
 import { MessageListItemHeader } from "./message-list-item-header";
@@ -258,7 +257,7 @@ function _ToolStepContinuation({
   readonly?: boolean;
   onContinue: () => void;
 }) {
-  const status = useThreadStore((state) => state.status);
+  const busy = useThreadStore(isThreadBusy);
   const tools = useThreadStore((state) => state.thread.context?.tools);
   const callableTools = useMemo(() => {
     const toolsByName = new Map((tools ?? []).map((tool) => [tool.name, tool]));
@@ -275,12 +274,9 @@ function _ToolStepContinuation({
   const { updateToolCallOutputText } = useThreadStoreActions();
   const [callingTools, setCallingTools] = useState(false);
   const summary = useMemo(() => summarizeToolCalls(toolCalls), [toolCalls]);
-  const disabled = readonly || status === "running" || !summary.canContinue;
+  const disabled = readonly || busy || !summary.canContinue;
   const canCallTools =
-    !readonly &&
-    status !== "running" &&
-    !callingTools &&
-    callableTools.length > 1;
+    !readonly && !busy && !callingTools && callableTools.length > 1;
   const readyCount = summary.readyCount + summary.errorCount;
   const missingLabel =
     summary.needsResponseCount === 1
@@ -300,33 +296,10 @@ function _ToolStepContinuation({
     setCallingTools(true);
     try {
       const results = await Promise.all(
-        callableTools.map(async ({ tool, toolCall }) => {
-          try {
-            if (tool.type === "mcp") {
-              const result = await callMcpTool({
-                serverId: tool.serverId,
-                toolName: tool.toolName,
-                arguments: toolCall.input.arguments,
-              });
-              return {
-                toolCall,
-                text: result.contentText,
-                isError: result.isError ?? false,
-              };
-            }
-            const result = await callBuiltInTool({
-              name: tool.name,
-              arguments: toolCall.input.arguments,
-            });
-            return { toolCall, text: result.contentText, isError: false };
-          } catch (error) {
-            return {
-              toolCall,
-              text: error instanceof Error ? error.message : "Tool call failed",
-              isError: true,
-            };
-          }
-        })
+        callableTools.map(async ({ tool, toolCall }) => ({
+          toolCall,
+          ...(await callThreadTool(tool, toolCall.input.arguments)),
+        }))
       );
       let errorCount = 0;
       let firecrawlLimitCount = 0;

--- a/apps/desktop/src/components/thread-playground/stores/thread-store.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-store.ts
@@ -16,6 +16,7 @@ import {
   type ReducedMessageContent,
   type Thread,
   type Tool,
+  type ToolCall,
   type UserMessage,
 } from "@llm-space/core";
 import { createContext, useContext } from "react";
@@ -25,7 +26,15 @@ import { createStore, useStore, type StoreApi } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { useShallow } from "zustand/shallow";
 
+import { openFirecrawlLimitDialog } from "@/components/firecrawl-limit-dialog";
+import { isFirecrawlLimitError } from "@/lib/firecrawl";
+
+import { getToolCallStatus } from "../message/tool-call-status";
 import { aggregateMessageUsage } from "../token-usage";
+import type {
+  CallableTool,
+  CallableToolResult,
+} from "../tool/call-thread-tool";
 
 import {
   createInitialHistory,
@@ -45,11 +54,56 @@ import {
 const toolValidator = Compile(ToolSchema);
 
 export type ThreadStoreStatus = "idle" | "running";
+
+export type ThreadRunMode = "step" | "auto";
+
+/** Hard cap on model calls per auto-run episode. */
+export const MAX_AUTO_RUN_ROUNDS = 10;
+
+/** Consecutive failed rounds of one tool before an auto-run episode stops. */
+const MAX_AUTO_RUN_TOOL_FAILURE_ROUNDS = 2;
+
+/** Live auto-run episode state; store-only, never serialized. */
+export interface AutoRunState {
+  /** 1-based model-call round the episode is currently on. */
+  round: number;
+}
+
+/** A pending request to approve auto-running the named tools. */
+export interface AutoRunApprovalRequest {
+  /** Distinct tool names awaiting the user's permission to auto-run. */
+  toolNames: string[];
+}
+
+/** How a single run ended; drives whether an auto-run episode continues. */
+type RunOutcome = "completed" | "failed" | "aborted" | "skipped";
+
+/**
+ * Whether a run or an auto-run episode is in flight. Unlike `status`, this
+ * stays true across an episode's round boundaries (tool execution, approval),
+ * so it is the gate for readonly UI and for run/undo/history actions.
+ */
+export function isThreadBusy(
+  state: Pick<ThreadState, "status" | "autoRun">
+): boolean {
+  return state.status === "running" || state.autoRun !== null;
+}
+
 export interface ThreadState {
   thread: Thread;
   streamingMessage: AssistantMessage | null;
   status: ThreadStoreStatus;
   abortController: AbortController | null;
+  /**
+   * How run() behaves: "step" stops at every tool call for manual handling;
+   * "auto" executes MCP / built-in tool calls and continues until the model
+   * produces a final answer (or an episode guard stops it). Session-only.
+   */
+  runMode: ThreadRunMode;
+  /** The in-flight auto-run episode; null when none is active. */
+  autoRun: AutoRunState | null;
+  /** Tool approval awaiting the user's answer; rendered by the playground. */
+  autoRunApproval: AutoRunApprovalRequest | null;
   collapsedMessageIds: string[];
   /**
    * Id of the message whose editor should grab focus on mount — set only by
@@ -65,6 +119,8 @@ export interface ThreadState {
   evaluations: EvaluationRecord[];
 
   run(fromMessageId?: string): Promise<void>;
+  setRunMode(runMode: ThreadRunMode): void;
+  respondToAutoRunApproval(approved: boolean): void;
   undo(): void;
   redo(): void;
   restoreThread(thread: Thread): void;
@@ -118,10 +174,21 @@ export function createThreadStore(
     resolveModel?: (
       saved: ModelConfig | null | undefined
     ) => ModelConfig | null;
+    /**
+     * Execute one MCP / built-in tool call on behalf of auto-run. Injected
+     * like `transport` so the store stays free of RPC imports; without it
+     * auto-run stops at tool calls like step-by-step.
+     */
+    callTool?: (
+      tool: CallableTool,
+      args: Record<string, unknown>
+    ) => Promise<CallableToolResult>;
   } = {}
 ): ThreadStore {
   const normalizedInputThread = normalizeThread(initialThread);
-  const initialRunHistory = normalizeRunHistory(normalizedInputThread.runHistory);
+  const initialRunHistory = normalizeRunHistory(
+    normalizedInputThread.runHistory
+  );
   const initialEvaluations = normalizeEvaluations(
     normalizedInputThread.evaluations,
     initialRunHistory
@@ -216,6 +283,516 @@ export function createThreadStore(
         message.content.length > 0 ||
         (message.toolCalls?.length ?? 0) > 0;
 
+      /**
+       * Write tool call outputs onto an assistant message in one update — so
+       * a batch (e.g. one auto-run round) costs a single state set and undo
+       * snapshot. An omitted `isError` keeps the call's existing error flag.
+       */
+      const writeToolCallOutputs = (
+        messageId: string,
+        outputs: { toolCallId: string; text: string; isError?: boolean }[]
+      ) => {
+        const message = getMessage(messageId);
+        if (message?.role !== "assistant") {
+          return;
+        }
+        const outputsById = new Map(
+          outputs.map((output) => [output.toolCallId, output])
+        );
+        if (!message.toolCalls?.some((tc) => outputsById.has(tc.id))) {
+          return;
+        }
+        updateMessage(messageId, (m) => {
+          const assistant = m as AssistantMessage;
+          return {
+            ...assistant,
+            toolCalls: assistant.toolCalls?.map((toolCall) => {
+              const output = outputsById.get(toolCall.id);
+              if (!output) {
+                return toolCall;
+              }
+              return {
+                ...toolCall,
+                output: {
+                  content: [{ type: "text", text: output.text }],
+                  isError: output.isError ?? toolCall.output?.isError,
+                },
+              };
+            }),
+          };
+        });
+      };
+
+      // --- auto-run episode -----------------------------------------------
+
+      // Episode plumbing lives in the closure (not in state): only the store's
+      // own actions touch it, and approvals are remembered per store — i.e.
+      // per open tab, gone when the tab closes.
+      let autoRunController: AbortController | null = null;
+      let autoRunApprovalRespond: ((approved: boolean) => void) | null = null;
+      const autoRunApprovedToolKeys = new Set<string>();
+
+      /**
+       * Stable identity for approval memory. Keyed by what actually executes
+       * — not the display name — so a same-named tool swapped to a different
+       * MCP server between episodes has to be approved again.
+       */
+      const autoRunToolKey = (tool: CallableTool): string =>
+        tool.type === "mcp"
+          ? `mcp:${tool.serverId}:${tool.toolName}`
+          : `builtin:${tool.name}`;
+
+      interface AutoRunContinuation {
+        messageId: string;
+        pendingCalls: { toolCall: ToolCall; tool: CallableTool }[];
+      }
+
+      /**
+       * Resolve how an auto-run episode continues from the current thread:
+       * the trailing assistant message's unanswered tool calls, provided every
+       * one of them maps to an executable (MCP / built-in) tool. Returns null
+       * when the thread ends in a final answer — or when any call needs a
+       * manual response, degrading the episode back to step-by-step.
+       */
+      const getAutoRunContinuation = (): AutoRunContinuation | null => {
+        if (!options.callTool) {
+          return null;
+        }
+        const messages = get().thread.context?.messages ?? [];
+        const last = messages[messages.length - 1];
+        if (last?.role !== "assistant" || !last.toolCalls?.length) {
+          return null;
+        }
+        const toolsByName = new Map(
+          (get().thread.context?.tools ?? []).map((tool) => [tool.name, tool])
+        );
+        const pendingCalls: AutoRunContinuation["pendingCalls"] = [];
+        for (const toolCall of last.toolCalls) {
+          if (getToolCallStatus(toolCall) !== "needsResponse") {
+            continue;
+          }
+          const tool = toolsByName.get(toolCall.input.name);
+          if (tool?.type !== "mcp" && tool?.type !== "builtin") {
+            return null;
+          }
+          pendingCalls.push({ toolCall, tool });
+        }
+        return { messageId: last.id, pendingCalls };
+      };
+
+      /**
+       * Ask the user to approve auto-running the named tools, resolving false
+       * when denied — or when the episode aborts while the dialog is open.
+       */
+      const requestAutoRunApproval = (
+        toolNames: string[],
+        signal: AbortSignal
+      ): Promise<boolean> =>
+        new Promise((resolve) => {
+          if (signal.aborted) {
+            resolve(false);
+            return;
+          }
+          const settle = (approved: boolean) => {
+            autoRunApprovalRespond = null;
+            signal.removeEventListener("abort", onAbort);
+            set({ autoRunApproval: null });
+            resolve(approved);
+          };
+          const onAbort = () => settle(false);
+          autoRunApprovalRespond = settle;
+          signal.addEventListener("abort", onAbort);
+          set({ autoRunApproval: { toolNames } });
+        });
+
+      /** Resolve to null as soon as the signal aborts. */
+      const raceWithAbort = async <T>(
+        promise: Promise<T>,
+        signal: AbortSignal
+      ): Promise<T | null> => {
+        // An already-aborted signal never fires its listener; bail up front.
+        if (signal.aborted) {
+          return null;
+        }
+        let onAbort!: () => void;
+        try {
+          return await Promise.race([
+            promise,
+            new Promise<null>((resolve) => {
+              onAbort = () => resolve(null);
+              signal.addEventListener("abort", onAbort, { once: true });
+            }),
+          ]);
+        } finally {
+          signal.removeEventListener("abort", onAbort);
+        }
+      };
+
+      /**
+       * Execute a round's pending tool calls and persist their outputs.
+       * Returns whether the episode may continue with another model call.
+       */
+      const callPendingToolCalls = async (
+        continuation: AutoRunContinuation,
+        signal: AbortSignal,
+        failedRoundsByTool: Map<string, number>
+      ): Promise<"continue" | "stop"> => {
+        const callTool = options.callTool;
+        if (!callTool) {
+          return "stop";
+        }
+        const results = await raceWithAbort(
+          Promise.all(
+            continuation.pendingCalls.map(async ({ toolCall, tool }) => ({
+              toolCall,
+              tool,
+              result: await callTool(tool, toolCall.input.arguments),
+            }))
+          ),
+          signal
+        );
+        // Stopping mid-execution discards the results: nothing is written, so
+        // the calls stay open for manual handling. (The tools may still have
+        // run on the bun side — the RPC itself cannot be cancelled.)
+        if (!results || signal.aborted) {
+          return "stop";
+        }
+        let firecrawlLimited = false;
+        const toolErroredThisRound = new Map<string, boolean>();
+        for (const { tool, result } of results) {
+          toolErroredThisRound.set(
+            tool.name,
+            (toolErroredThisRound.get(tool.name) ?? false) || result.isError
+          );
+          if (result.isError && isFirecrawlLimitError(result.text)) {
+            firecrawlLimited = true;
+          }
+        }
+        writeToolCallOutputs(
+          continuation.messageId,
+          results.map(({ toolCall, result }) => ({
+            toolCallId: toolCall.id,
+            text: result.text,
+            isError: result.isError,
+          }))
+        );
+        if (firecrawlLimited) {
+          // The dialog explains the failure and how to fix it; error outputs
+          // are already persisted above for inspection.
+          openFirecrawlLimitDialog();
+          return "stop";
+        }
+        // A failure streak survives only across consecutive rounds in which
+        // the tool kept failing; succeeding — or a round that doesn't call
+        // the tool at all — resets it.
+        for (const name of [...failedRoundsByTool.keys()]) {
+          if (toolErroredThisRound.get(name) !== true) {
+            failedRoundsByTool.delete(name);
+          }
+        }
+        for (const [name, errored] of toolErroredThisRound) {
+          if (!errored) {
+            continue;
+          }
+          const failedRounds = (failedRoundsByTool.get(name) ?? 0) + 1;
+          failedRoundsByTool.set(name, failedRounds);
+          if (failedRounds >= MAX_AUTO_RUN_TOOL_FAILURE_ROUNDS) {
+            toast.error("Auto-run stopped", {
+              description: `"${name}" failed ${failedRounds} rounds in a row.`,
+            });
+            return "stop";
+          }
+        }
+        return "continue";
+      };
+
+      /** Toast when an episode ends on tool calls auto-run cannot answer. */
+      const notifyManualToolCalls = () => {
+        const messages = get().thread.context?.messages ?? [];
+        const last = messages[messages.length - 1];
+        if (last?.role !== "assistant" || !last.toolCalls?.length) {
+          return;
+        }
+        const pending = last.toolCalls.filter(
+          (toolCall) => getToolCallStatus(toolCall) === "needsResponse"
+        ).length;
+        if (pending > 0) {
+          toast.info("Auto-run paused", {
+            description:
+              pending === 1
+                ? "1 tool call needs a manual response."
+                : `${pending} tool calls need a manual response.`,
+          });
+        }
+      };
+
+      /**
+       * Run a single model turn (one round). This is the whole of a "step"
+       * mode run; auto-run episodes chain it. Reports how the run ended so
+       * the episode knows whether to continue.
+       */
+      const runOnce = async (fromMessageId?: string): Promise<RunOutcome> => {
+        // Resolve the model to run with: the thread's own when available,
+        // else the default/first available. A thread with no resolvable model
+        // cannot run.
+        const model = options.resolveModel?.(get().thread.model) ?? null;
+        if (!model) {
+          toast.error("Select a model to run");
+          return "skipped";
+        }
+        // Pre-flight: resolve the message list the run would use (including
+        // the rerun-from truncation) and validate it before entering the
+        // running state, so an unrunnable thread is a complete no-op — no
+        // truncation, no undo step, no run-history entry.
+        let messages = [...(get().thread.context?.messages ?? [])];
+        let truncated = false;
+        if (fromMessageId) {
+          const index = messages.findIndex((m) => m.id === fromMessageId);
+          if (index !== -1 && index !== messages.length - 1) {
+            messages = messages.slice(0, index + 1);
+            truncated = true;
+          }
+        }
+        if (!isRunnableConversation(messages)) {
+          toast.error("Error", { description: RUN_LAST_MESSAGE_ERROR });
+          return "skipped";
+        }
+        const abortController = new AbortController();
+        set({ status: "running", abortController });
+
+        // Commit the truncation while running so it folds into the run's
+        // single undo step instead of becoming its own snapshot.
+        if (truncated) {
+          setMessages(messages);
+        }
+        const runStartMessageCount = messages.length;
+
+        // Append a finished assistant message to the thread.
+        const commit = (message: AssistantMessage) => {
+          messages = [...messages, message];
+          setMessages(messages);
+        };
+
+        let streamingMessage: AssistantMessage | null = null;
+        let content: ReducedMessageContent[] = [];
+        // Whether the stream produced at least one event — i.e. the run
+        // actually started. A run that dies earlier (transport/auth/network
+        // failure) is not recorded in the run history.
+        let sawEvent = false;
+        // Whether the run ended in an error. The agent loop emits lifecycle
+        // events before the model call, and a model API failure completes
+        // the stream normally with the error tucked into the message
+        // (surfaced as a throw by reduceMessages on agent_end) — so
+        // `sawEvent` alone can't tell a failed run from a successful one.
+        // A failed run is never recorded in the run history.
+        let failed = false;
+
+        // Coalesce live-preview updates to at most one per animation frame.
+        // A fast stream delivers a burst of events that the transport drains
+        // synchronously; calling set() on every one fires a synchronous
+        // useSyncExternalStore re-render per event within a single microtask
+        // chain, which never crosses the task boundary React uses to reset
+        // its nested-update counter — tripping "Maximum update depth
+        // exceeded". Batching by frame also lets the UI paint between chunks.
+        const canRaf = typeof requestAnimationFrame === "function";
+        let previewFrame: number | null = null;
+        const flushPreview = () => {
+          previewFrame = null;
+          set({ streamingMessage });
+        };
+        const schedulePreview = () => {
+          if (!canRaf) {
+            set({ streamingMessage });
+            return;
+          }
+          previewFrame ??= requestAnimationFrame(flushPreview);
+        };
+        const cancelPreview = () => {
+          if (previewFrame !== null) {
+            cancelAnimationFrame(previewFrame);
+            previewFrame = null;
+          }
+        };
+        try {
+          const response = streamThread(
+            {
+              context: { ...get().thread.context, messages },
+              model,
+            },
+            { signal: abortController.signal, transport: options.transport }
+          );
+          for await (const chunk of response) {
+            sawEvent = true;
+            const reduced = reduceMessages(chunk, {
+              streamingMessage,
+              content,
+            });
+            if (!reduced) {
+              continue;
+            }
+            if (reduced.type === "message_start" && streamingMessage) {
+              commit(streamingMessage);
+              // The committed message now lives in `messages`; drop the stale
+              // preview so it isn't rendered twice before the next frame.
+              cancelPreview();
+              set({ streamingMessage: null });
+            }
+            streamingMessage = reduced.message;
+            content = reduced.content;
+            schedulePreview();
+          }
+          if (streamingMessage) {
+            commit(streamingMessage);
+          }
+        } catch (error) {
+          if (abortController.signal.aborted) {
+            if (streamingMessage && hasContent(streamingMessage)) {
+              commit(streamingMessage);
+            }
+          } else {
+            failed = true;
+            console.error(error);
+            if (error instanceof Error) {
+              toast.error("Error", { description: error.message });
+            }
+          }
+        } finally {
+          // Drop any pending frame before the terminal clear so a late flush
+          // can't resurrect a stale streamingMessage after we reset to null.
+          cancelPreview();
+          set({
+            streamingMessage: null,
+            status: "idle",
+            abortController: null,
+          });
+          // Fold the whole run (truncation + generated messages) into one
+          // undo step, and record a run snapshot. No-op for undo if the
+          // thread is unchanged.
+          const finalThread = get().thread;
+          if (sawEvent && !failed) {
+            const runUsage = aggregateMessageUsage(
+              (finalThread.context?.messages ?? []).slice(runStartMessageCount)
+            );
+            const runHistory = recordRun(
+              get().runHistory,
+              finalThread,
+              Date.now(),
+              { usage: runUsage }
+            );
+            const evaluations = normalizeEvaluations(
+              get().evaluations,
+              runHistory
+            );
+            const thread = withRunHistory(finalThread, runHistory, evaluations);
+            set({
+              thread,
+              changeHistory: recordSnapshot(get().changeHistory, thread),
+              runHistory,
+              evaluations,
+            });
+          } else {
+            set({
+              changeHistory: recordSnapshot(get().changeHistory, finalThread),
+            });
+          }
+        }
+        if (abortController.signal.aborted) {
+          return "aborted";
+        }
+        return failed ? "failed" : "completed";
+      };
+
+      /**
+       * Drive an auto-run episode: run a round, execute its tool calls, and
+       * loop until the model produces a final answer or a guard stops it —
+       * the round cap, repeated tool failures, the Firecrawl limit, a denied
+       * approval, a failed run, or the user stopping the thread. Tool calls
+       * that need a manual response end the episode like step-by-step.
+       */
+      const runAuto = async (fromMessageId?: string): Promise<void> => {
+        const controller = new AbortController();
+        autoRunController = controller;
+        // Tool name → consecutive failed rounds. Errors are fed back so the
+        // model can react, but a tool that keeps failing would otherwise burn
+        // model calls retrying forever.
+        const failedRoundsByTool = new Map<string, number>();
+        const lastMessageId = () => {
+          const messages = get().thread.context?.messages ?? [];
+          return messages[messages.length - 1]?.id ?? null;
+        };
+        try {
+          let from = fromMessageId;
+          for (let round = 1; ; round++) {
+            const lastMessageIdBeforeRun = lastMessageId();
+            set({ autoRun: { round } });
+            const outcome = await runOnce(from);
+            from = undefined;
+            if (outcome !== "completed" || controller.signal.aborted) {
+              return;
+            }
+            const continuation = getAutoRunContinuation();
+            if (!continuation) {
+              // Final answer — or tool calls that need a manual response, in
+              // which case the episode degrades back to step-by-step.
+              notifyManualToolCalls();
+              return;
+            }
+            if (
+              continuation.pendingCalls.length === 0 &&
+              continuation.messageId === lastMessageIdBeforeRun
+            ) {
+              // The round appended nothing (e.g. an empty stream) and there is
+              // nothing left to execute — bail instead of burning model calls
+              // until the round cap.
+              return;
+            }
+            const unapprovedTools = [
+              ...new Map(
+                continuation.pendingCalls
+                  .filter(
+                    ({ tool }) =>
+                      !autoRunApprovedToolKeys.has(autoRunToolKey(tool))
+                  )
+                  .map(({ tool }) => [autoRunToolKey(tool), tool])
+              ).values(),
+            ];
+            if (unapprovedTools.length > 0) {
+              const approved = await requestAutoRunApproval(
+                [...new Set(unapprovedTools.map((tool) => tool.name))],
+                controller.signal
+              );
+              if (!approved) {
+                return;
+              }
+              for (const tool of unapprovedTools) {
+                autoRunApprovedToolKeys.add(autoRunToolKey(tool));
+              }
+            }
+            if (continuation.pendingCalls.length > 0) {
+              const result = await callPendingToolCalls(
+                continuation,
+                controller.signal,
+                failedRoundsByTool
+              );
+              if (result === "stop") {
+                return;
+              }
+            }
+            // Cap model calls, not tool calls: the round's results are
+            // already filled above, so a plain Run resumes cleanly.
+            if (round >= MAX_AUTO_RUN_ROUNDS) {
+              toast.info("Auto-run paused", {
+                description: `Reached ${MAX_AUTO_RUN_ROUNDS} model calls. Tool results are filled — run again to continue.`,
+              });
+              return;
+            }
+          }
+        } finally {
+          autoRunController = null;
+          set({ autoRun: null });
+        }
+      };
+
       // --- store --------------------------------------------------------------
 
       return {
@@ -223,6 +800,9 @@ export function createThreadStore(
         streamingMessage: null,
         status: "idle",
         abortController: null,
+        runMode: "step",
+        autoRun: null,
+        autoRunApproval: null,
         collapsedMessageIds: [],
         autoFocusMessageId: null,
         changeHistory: createInitialHistory(normalizedInitialThread),
@@ -395,30 +975,7 @@ export function createThreadStore(
           });
         },
         updateToolCallOutputTextContent(messageId, toolCallId, text, isError) {
-          const message = getMessage(messageId);
-          if (message?.role !== "assistant") {
-            return;
-          }
-          if (!message.toolCalls?.some((tc) => tc.id === toolCallId)) {
-            return;
-          }
-          updateMessage(messageId, (m) => {
-            const assistant = m as AssistantMessage;
-            return {
-              ...assistant,
-              toolCalls: assistant.toolCalls?.map((toolCall) =>
-                toolCall.id === toolCallId
-                  ? {
-                      ...toolCall,
-                      output: {
-                        content: [{ type: "text", text }],
-                        isError: isError ?? toolCall.output?.isError,
-                      },
-                    }
-                  : toolCall
-              ),
-            };
-          });
+          writeToolCallOutputs(messageId, [{ toolCallId, text, isError }]);
         },
         toggleMessageRole(id: string) {
           updateMessage(
@@ -439,185 +996,26 @@ export function createThreadStore(
           });
         },
         async run(fromMessageId?: string) {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             throw new Error("Thread is already running");
           }
-          // Resolve the model to run with: the thread's own when available,
-          // else the default/first available. A thread with no resolvable model
-          // cannot run.
-          const model = options.resolveModel?.(get().thread.model) ?? null;
-          if (!model) {
-            toast.error("Select a model to run");
+          if (get().runMode === "auto") {
+            await runAuto(fromMessageId);
             return;
           }
-          // Pre-flight: resolve the message list the run would use (including
-          // the rerun-from truncation) and validate it before entering the
-          // running state, so an unrunnable thread is a complete no-op — no
-          // truncation, no undo step, no run-history entry.
-          let messages = [...(get().thread.context?.messages ?? [])];
-          let truncated = false;
-          if (fromMessageId) {
-            const index = messages.findIndex((m) => m.id === fromMessageId);
-            if (index !== -1 && index !== messages.length - 1) {
-              messages = messages.slice(0, index + 1);
-              truncated = true;
-            }
-          }
-          if (!isRunnableConversation(messages)) {
-            toast.error("Error", { description: RUN_LAST_MESSAGE_ERROR });
+          await runOnce(fromMessageId);
+        },
+        setRunMode(runMode: ThreadRunMode) {
+          if (isThreadBusy(get())) {
             return;
           }
-          const abortController = new AbortController();
-          set({ status: "running", abortController });
-
-          // Commit the truncation while running so it folds into the run's
-          // single undo step instead of becoming its own snapshot.
-          if (truncated) {
-            setMessages(messages);
-          }
-          const runStartMessageCount = messages.length;
-
-          // Append a finished assistant message to the thread.
-          const commit = (message: AssistantMessage) => {
-            messages = [...messages, message];
-            setMessages(messages);
-          };
-
-          let streamingMessage: AssistantMessage | null = null;
-          let content: ReducedMessageContent[] = [];
-          // Whether the stream produced at least one event — i.e. the run
-          // actually started. A run that dies earlier (transport/auth/network
-          // failure) is not recorded in the run history.
-          let sawEvent = false;
-          // Whether the run ended in an error. The agent loop emits lifecycle
-          // events before the model call, and a model API failure completes
-          // the stream normally with the error tucked into the message
-          // (surfaced as a throw by reduceMessages on agent_end) — so
-          // `sawEvent` alone can't tell a failed run from a successful one.
-          // A failed run is never recorded in the run history.
-          let failed = false;
-
-          // Coalesce live-preview updates to at most one per animation frame.
-          // A fast stream delivers a burst of events that the transport drains
-          // synchronously; calling set() on every one fires a synchronous
-          // useSyncExternalStore re-render per event within a single microtask
-          // chain, which never crosses the task boundary React uses to reset
-          // its nested-update counter — tripping "Maximum update depth
-          // exceeded". Batching by frame also lets the UI paint between chunks.
-          const canRaf = typeof requestAnimationFrame === "function";
-          let previewFrame: number | null = null;
-          const flushPreview = () => {
-            previewFrame = null;
-            set({ streamingMessage });
-          };
-          const schedulePreview = () => {
-            if (!canRaf) {
-              set({ streamingMessage });
-              return;
-            }
-            previewFrame ??= requestAnimationFrame(flushPreview);
-          };
-          const cancelPreview = () => {
-            if (previewFrame !== null) {
-              cancelAnimationFrame(previewFrame);
-              previewFrame = null;
-            }
-          };
-          try {
-            const response = streamThread(
-              {
-                context: { ...get().thread.context, messages },
-                model,
-              },
-              { signal: abortController.signal, transport: options.transport }
-            );
-            for await (const chunk of response) {
-              sawEvent = true;
-              const reduced = reduceMessages(chunk, {
-                streamingMessage,
-                content,
-              });
-              if (!reduced) {
-                continue;
-              }
-              if (reduced.type === "message_start" && streamingMessage) {
-                commit(streamingMessage);
-                // The committed message now lives in `messages`; drop the stale
-                // preview so it isn't rendered twice before the next frame.
-                cancelPreview();
-                set({ streamingMessage: null });
-              }
-              streamingMessage = reduced.message;
-              content = reduced.content;
-              schedulePreview();
-            }
-            if (streamingMessage) {
-              commit(streamingMessage);
-            }
-          } catch (error) {
-            if (abortController.signal.aborted) {
-              if (streamingMessage && hasContent(streamingMessage)) {
-                commit(streamingMessage);
-              }
-            } else {
-              failed = true;
-              console.error(error);
-              if (error instanceof Error) {
-                toast.error("Error", { description: error.message });
-              }
-            }
-          } finally {
-            // Drop any pending frame before the terminal clear so a late flush
-            // can't resurrect a stale streamingMessage after we reset to null.
-            cancelPreview();
-            set({
-              streamingMessage: null,
-              status: "idle",
-              abortController: null,
-            });
-            // Fold the whole run (truncation + generated messages) into one
-            // undo step, and record a run snapshot. No-op for undo if the
-            // thread is unchanged.
-            const finalThread = get().thread;
-            if (sawEvent && !failed) {
-              const runUsage = aggregateMessageUsage(
-                (finalThread.context?.messages ?? []).slice(
-                  runStartMessageCount
-                )
-              );
-              const runHistory = recordRun(
-                get().runHistory,
-                finalThread,
-                Date.now(),
-                { usage: runUsage }
-              );
-              const evaluations = normalizeEvaluations(
-                get().evaluations,
-                runHistory
-              );
-              const thread = withRunHistory(
-                finalThread,
-                runHistory,
-                evaluations
-              );
-              set({
-                thread,
-                changeHistory: recordSnapshot(get().changeHistory, thread),
-                runHistory,
-                evaluations,
-              });
-            } else {
-              set({
-                changeHistory: recordSnapshot(
-                  get().changeHistory,
-                  finalThread
-                ),
-              });
-            }
-          }
+          set({ runMode });
+        },
+        respondToAutoRunApproval(approved: boolean) {
+          autoRunApprovalRespond?.(approved);
         },
         undo() {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             return;
           }
           const result = undoHistory(get().changeHistory);
@@ -640,7 +1038,7 @@ export function createThreadStore(
           });
         },
         redo() {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             return;
           }
           const result = redoHistory(get().changeHistory);
@@ -663,7 +1061,7 @@ export function createThreadStore(
           });
         },
         restoreThread(thread: Thread) {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             return;
           }
           const next = withRunHistory(
@@ -681,7 +1079,7 @@ export function createThreadStore(
           });
         },
         removeRun(run: RunSnapshot) {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             return;
           }
           const current = get().runHistory;
@@ -711,7 +1109,7 @@ export function createThreadStore(
           });
         },
         saveEvaluation(input) {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             return;
           }
           const evaluations = upsertEvaluation(
@@ -739,7 +1137,7 @@ export function createThreadStore(
           });
         },
         removeEvaluation(evaluation: EvaluationRecord) {
-          if (get().status === "running") {
+          if (isThreadBusy(get())) {
             return;
           }
           const current = get().evaluations;
@@ -768,6 +1166,9 @@ export function createThreadStore(
           });
         },
         abort() {
+          // Stop any auto-run episode first so a round boundary doesn't start
+          // another model call, then cancel the in-flight stream (if any).
+          autoRunController?.abort();
           const { status, abortController } = get();
           if (status !== "running") {
             return;
@@ -797,6 +1198,8 @@ export function useThreadStore<T>(selector: (s: ThreadState) => T): T {
 
 const selectActions = (s: ThreadState) => ({
   run: s.run,
+  setRunMode: s.setRunMode,
+  respondToAutoRunApproval: s.respondToAutoRunApproval,
   abort: s.abort,
   undo: s.undo,
   redo: s.redo,

--- a/apps/desktop/src/components/thread-playground/thread-playground.tsx
+++ b/apps/desktop/src/components/thread-playground/thread-playground.tsx
@@ -31,7 +31,9 @@ import {
   ResizablePanelGroup,
 } from "../ui/resizable";
 import { Spinner } from "../ui/spinner";
+import { Switch } from "../ui/switch";
 
+import { AutoRunApprovalDialog } from "./auto-run-approval-dialog";
 import { MessageListView } from "./message/message-list-view";
 import { ThreadPlaygroundSkeleton } from "./misc/skeleton";
 import { TitleEditor, type TitleValidator } from "./misc/title-editor";
@@ -42,10 +44,13 @@ import {
   canRedo,
   canUndo,
   createThreadStore,
+  isThreadBusy,
+  MAX_AUTO_RUN_ROUNDS,
   ThreadStoreContext,
   useThreadStore,
   useThreadStoreActions,
 } from "./stores";
+import { callThreadTool } from "./tool/call-thread-tool";
 import { ToolListView } from "./tool/tool-list-view";
 import { useShortcuts } from "./use-shortcuts";
 import { useThreadPlaygroundEvents } from "./use-thread-playground-events";
@@ -118,7 +123,12 @@ function _ThreadPlayground({
     createThreadStore(initialValue, {
       transport,
       resolveModel: (saved) =>
-        resolveModelConfig(providersRef.current, saved, defaultModelRef.current),
+        resolveModelConfig(
+          providersRef.current,
+          saved,
+          defaultModelRef.current
+        ),
+      callTool: callThreadTool,
     })
   );
   useThreadPlaygroundEvents(store, {
@@ -126,6 +136,14 @@ function _ThreadPlayground({
     onStreamingStart,
     onStreamingEnd,
   });
+  // Stop any in-flight run when the playground unmounts (tab closed or
+  // refreshed onto a fresh store) — an auto-run episode would otherwise keep
+  // chaining model calls and tool executions against the abandoned store.
+  useEffect(() => {
+    return () => {
+      store.getState().abort();
+    };
+  }, [store]);
   return (
     <ThreadStoreContext.Provider value={store}>
       <ThreadPlaygroundContent {...props} />
@@ -150,14 +168,21 @@ function ThreadPlaygroundContent({
   "initialValue" | "onChange" | "onStreamingStart" | "onStreamingEnd"
 >) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const status = useThreadStore((s) => s.status);
+  // Busy spans a whole auto-run episode (round gaps included), not just an
+  // in-flight stream — every run/readonly gate below keys off it.
+  const busy = useThreadStore(isThreadBusy);
+  const runMode = useThreadStore((s) => s.runMode);
+  // Presence only — the per-round counter lives in AutoRunRoundIndicator so
+  // round bumps don't re-render this whole subtree.
+  const hasAutoRun = useThreadStore((s) => s.autoRun !== null);
   const savedModel = useThreadStore((s) => s.thread.model);
   const fallbackModel = useFirstAvailableModel();
   // A thread can run once a model resolves (its own, or the first available).
   const hasModel = Boolean(savedModel ?? fallbackModel);
   const undoable = useThreadStore((s) => canUndo(s.changeHistory));
   const redoable = useThreadStore((s) => canRedo(s.changeHistory));
-  const { run, abort, undo, redo, syncTitle } = useThreadStoreActions();
+  const { run, abort, undo, redo, syncTitle, setRunMode } =
+    useThreadStoreActions();
   const title = useMemo(
     () => titleFromProps ?? threadTitleFromPath(path),
     [path, titleFromProps]
@@ -166,18 +191,24 @@ function ThreadPlaygroundContent({
     syncTitle(title);
   }, [syncTitle, title]);
   const readonly = useMemo(() => {
-    return readonlyFromProps || status === "running";
-  }, [readonlyFromProps, status]);
+    return readonlyFromProps || busy;
+  }, [readonlyFromProps, busy]);
   const handleRun = useCallback(async () => {
     await run();
   }, []);
+  const handleRunModeChange = useCallback(
+    (checked: boolean) => {
+      setRunMode(checked ? "auto" : "step");
+    },
+    [setRunMode]
+  );
   // Expose run as a command, but only from the active tab so a global
   // `runThread` targets it (and no-ops when no tab is active). Skip while
   // already running to avoid run()'s "already running" throw.
   useRegisterCommands(
     {
       runThread: () => {
-        if (status !== "running") void run();
+        if (!busy) void run();
       },
     },
     active
@@ -277,11 +308,36 @@ function ThreadPlaygroundContent({
                 </Button>
               </Tooltip>
             </div>
-            <div className="flex items-center px-3">
+            <div className="flex items-center gap-3 px-3">
+              <div
+                className={cn(
+                  "flex items-center",
+                  readonlyFromProps && "hidden"
+                )}
+              >
+                {hasAutoRun ? (
+                  <AutoRunRoundIndicator />
+                ) : (
+                  <Tooltip content="Auto-run: call MCP and built-in tools automatically and continue until a final answer">
+                    <div className="flex items-center gap-1.5">
+                      <Switch
+                        size="sm"
+                        aria-label="Toggle auto-run"
+                        checked={runMode === "auto"}
+                        disabled={busy}
+                        onCheckedChange={handleRunModeChange}
+                      />
+                      <span className="text-muted-foreground text-xs">
+                        Auto
+                      </span>
+                    </div>
+                  </Tooltip>
+                )}
+              </div>
               <Tooltip
                 content={
                   <div>
-                    {status === "running" ? "Stop running" : "Run this thread"}
+                    {busy ? "Stop running" : "Run this thread"}
                     <KbdGroup>
                       <Kbd className="text-foreground!">⌘ Enter</Kbd>
                     </KbdGroup>
@@ -293,20 +349,16 @@ function ThreadPlaygroundContent({
                     "w-20 px-3 py-3.5",
                     readonlyFromProps && "hidden"
                   )}
-                  aria-label={
-                    status === "running" ? "Stop running thread" : "Run thread"
-                  }
-                  disabled={
-                    readonlyFromProps || (status !== "running" && !hasModel)
-                  }
-                  onClick={status === "running" ? handleStop : handleRun}
+                  aria-label={busy ? "Stop running thread" : "Run thread"}
+                  disabled={readonlyFromProps || (!busy && !hasModel)}
+                  onClick={busy ? handleStop : handleRun}
                 >
-                  {status === "running" ? (
+                  {busy ? (
                     <Spinner className="size-3" />
                   ) : (
                     <PlayIcon className="size-3" />
                   )}
-                  {status === "running" ? "Stop" : "Run"}
+                  {busy ? "Stop" : "Run"}
                 </Button>
               </Tooltip>
             </div>
@@ -365,6 +417,20 @@ function ThreadPlaygroundContent({
           <RunHistoryListView onClose={closeHistory} />
         </ResizablePanel>
       </ResizablePanelGroup>
+      <AutoRunApprovalDialog threadTitle={title} />
     </div>
+  );
+}
+
+/** Isolated so per-round updates don't re-render the whole playground. */
+function AutoRunRoundIndicator() {
+  const round = useThreadStore((s) => s.autoRun?.round ?? null);
+  if (round === null) {
+    return null;
+  }
+  return (
+    <span className="text-muted-foreground text-xs tabular-nums">
+      Round {round}/{MAX_AUTO_RUN_ROUNDS}
+    </span>
   );
 }

--- a/apps/desktop/src/components/thread-playground/tool/call-thread-tool.ts
+++ b/apps/desktop/src/components/thread-playground/tool/call-thread-tool.ts
@@ -1,0 +1,42 @@
+import type { BuiltinTool, McpTool } from "@llm-space/core";
+
+import { callBuiltInTool } from "@/client/built-in-tools";
+import { callMcpTool } from "@/client/mcp";
+
+/** A tool the renderer can execute without a manually-entered response. */
+export type CallableTool = McpTool | BuiltinTool;
+
+export interface CallableToolResult {
+  text: string;
+  isError: boolean;
+}
+
+/**
+ * Execute one MCP or built-in tool call, normalizing thrown errors into an
+ * error result so callers can persist it as the tool response.
+ */
+export async function callThreadTool(
+  tool: CallableTool,
+  args: Record<string, unknown>
+): Promise<CallableToolResult> {
+  try {
+    if (tool.type === "mcp") {
+      const result = await callMcpTool({
+        serverId: tool.serverId,
+        toolName: tool.toolName,
+        arguments: args,
+      });
+      return { text: result.contentText, isError: result.isError ?? false };
+    }
+    const result = await callBuiltInTool({
+      name: tool.name,
+      arguments: args,
+    });
+    return { text: result.contentText, isError: false };
+  } catch (error) {
+    return {
+      text: error instanceof Error ? error.message : "Tool call failed",
+      isError: true,
+    };
+  }
+}

--- a/apps/desktop/src/components/thread-playground/use-shortcuts.ts
+++ b/apps/desktop/src/components/thread-playground/use-shortcuts.ts
@@ -1,14 +1,14 @@
 import { useCallback } from "react";
 import type { KeyboardEvent } from "react";
 
-import { useThreadStore, useThreadStoreActions } from "./stores";
+import { isThreadBusy, useThreadStore, useThreadStoreActions } from "./stores";
 
 /**
  * Keyboard shortcuts for the thread playground, wired to the container's
  * keydown capture handler.
  */
 export function useShortcuts({ readonly }: { readonly: boolean }) {
-  const status = useThreadStore((s) => s.status);
+  const busy = useThreadStore(isThreadBusy);
   const { run, abort } = useThreadStoreActions();
 
   return useCallback(
@@ -27,7 +27,7 @@ export function useShortcuts({ readonly }: { readonly: boolean }) {
           return;
         }
         event.preventDefault();
-        if (status === "running") {
+        if (busy) {
           try {
             abort();
           } catch {
@@ -39,7 +39,7 @@ export function useShortcuts({ readonly }: { readonly: boolean }) {
         return;
       }
     },
-    [abort, readonly, run, status]
+    [abort, busy, readonly, run]
   );
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in **Auto** run mode to the thread playground. In step mode (the default, unchanged), every tool call still pauses the loop for manual handling. With the new **Auto** switch (next to the Run button) turned on, a run that ends in tool calls automatically:

1. executes every MCP / built-in tool call (same executor as the manual "Call all" button),
2. persists all results in one batched update (one undo snapshot per round),
3. re-runs the model — looping until a final answer or a guard stops the episode.

The Run button becomes a `Stop` button for the whole episode, and a `Round n/10` indicator replaces the switch while an episode is active.

## Safety guards

| Guard | Behavior |
|---|---|
| Opt-in, session-only | Mode defaults to step, lives only in the per-tab store, never serialized into thread files |
| First-use approval | A dialog asks before auto-running new tools; memory is keyed by tool identity (`serverId`+`toolName` for MCP), per tab — a same-named tool swapped to another server re-prompts |
| Round cap | 10 model calls per episode; the last round's tool results stay filled so a plain Run resumes cleanly |
| Failure stop | A tool that fails 2 consecutive rounds stops the episode (errors are still fed back so the model can react once) |
| Firecrawl limit | Quota errors stop the episode and surface the existing Firecrawl dialog |
| Manual tools | Any tool call that needs a manual response ends the episode with an explanatory toast (degrades to step-by-step) |
| No progress | An empty model stream ends the episode instead of burning calls to the cap |
| Abort | Stop button / ⌘Enter / playground unmount (tab close, refresh) abort both the in-flight stream and the episode; results of an aborted tool batch are discarded so the calls stay open for manual handling |

## Implementation notes

- **`tool/call-thread-tool.ts`** — the MCP / built-in execution + error-normalization branch extracted from `ToolStepContinuation`, now shared by "Call all" and auto-run.
- **`stores/thread-store.ts`** — `run()` dispatches by `runMode`; the old body became the internal `runOnce()` (verbatim, plus an outcome return); `runAuto()` orchestrates the episode. The executor is injected via `options.callTool`, mirroring the existing `transport` injection. New `isThreadBusy()` keeps readonly UI, shortcuts, undo/redo, and run-history actions gated across round gaps where `status` is `"idle"`. Tool outputs are written via a batched `writeToolCallOutputs` (also backing the existing public action).
- **`auto-run-approval-dialog.tsx`** — `ConfirmDialog`-based approval gate rendered by the playground.
- Per-round `Round n/10` state is isolated in `AutoRunRoundIndicator` so round bumps don't re-render the playground subtree.

## Testing

- `bunx tsc --noEmit` (apps/desktop) passes.
- `eslint` passes on all changed files; `prettier --check` clean. (The pre-existing `message-list-view.tsx:182` lint error on `main` from 86d48ed is untouched.)
- No test framework in the repo; manual verification recommended: step mode unchanged; auto episode with MCP/built-in tools; deny/allow approval; Stop during stream, during tool execution, and during the approval dialog; mixed manual+MCP tool set; round cap resume.

## Follow-ups (out of scope)

- Firecrawl-limit classification is now pattern-matched in three call sites; a `kind` field on `CallableToolResult` would centralize it.
- The single-call buttons in `tool-call-list-item.tsx` keep their own executor branch (intentionally different UX: toast instead of persisting an error output).
- Pre-existing: generate/examples buttons aren't disabled while busy; run-history restore/remove buttons rely on silent store guards.