### PR TITLE
feat(analytics): anonymous PostHog product analytics with settings opt-out

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,9 +53,8 @@ Any of the following, in order of convenience:
    Persisted immediately; the client is torn down and nothing further is sent.
 2. Set the environment variable `LLM_SPACE_ANALYTICS_DISABLED=1` - a hard
    override that wins over everything else.
-3. Set `LLM_SPACE_POSTHOG_KEY=""` (empty), or building from source, blank out
-   `DEFAULT_POSTHOG_KEY` in `apps/desktop/src/bun/analytics/config.ts` - with
-   no key, no client is ever created.
+3. Set `LLM_SPACE_POSTHOG_KEY=""` (empty) - with no key, no client is ever
+   created.
 
 ## For forks
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,64 @@
+# Telemetry
+
+llm-space collects a small amount of **anonymous, behaviour-only** usage data
+to understand which features are used and where the app fails. This document
+describes exactly what is sent, what is never sent, and how to turn it off.
+
+The implementation is intentionally auditable: every event must be declared in
+the typed map in [`apps/desktop/src/shared/analytics.ts`](apps/desktop/src/shared/analytics.ts),
+and the **only** code that talks to the network is the bun main-process module
+[`apps/desktop/src/bun/analytics/`](apps/desktop/src/bun/analytics/). Events go
+to PostHog (EU Cloud, `eu.i.posthog.com`).
+
+## How you are identified
+
+By a random UUID minted on first launch and stored in
+`~/.llm-space/settings/analytics.json`. It is not derived from anything on your
+machine and is never linked to a user identity. PostHog person profiles are
+disabled (`$process_person_profile: false`) and GeoIP lookup is disabled.
+Deleting the file (or the whole `~/.llm-space` directory) resets the id.
+
+## What is sent
+
+Every event carries three anonymous build/platform facts: the app version,
+`process.platform` (e.g. `darwin`), and `process.arch` (e.g. `arm64`), plus:
+
+| Event | Properties |
+|---|---|
+| `app_opened` | `isFirstOpen` - whether this launch minted the install id |
+| `thread_run` | `provider`, `model` (see note below), `outcome` (`completed` / `error` / `aborted`), `durationMs`, `messageCount`, `toolCount`, `hasSystemPrompt` |
+| `provider_added` | `providerId` (builtin id, or a generated UUID for custom), `kind` (`builtin` / `custom`) |
+| `mcp_server_added` | none |
+| `settings_opened` | none |
+| `onboarding_choice` | `choice` (which onboarding button was clicked) |
+
+**Note on `provider` / `model`:** these are reported verbatim only when they
+come from a shipped builtin catalog (e.g. `openai` / `gpt-4o`). Anything you
+typed in yourself - a custom provider, or a custom model added to a builtin
+provider - is collapsed to the literal string `"custom"` before capture.
+
+## What is never sent
+
+- Prompt text, message bodies, system prompts, or model responses
+- File names or file contents from your workspace
+- API keys, base URLs, or request headers
+- Names you typed in (custom provider names, custom model ids)
+- Your IP-derived location (GeoIP is disabled at capture time)
+
+## How to opt out
+
+Any of the following, in order of convenience:
+
+1. **Settings › General › "Share anonymous usage analytics"** - toggle off.
+   Persisted immediately; the client is torn down and nothing further is sent.
+2. Set the environment variable `LLM_SPACE_ANALYTICS_DISABLED=1` - a hard
+   override that wins over everything else.
+3. Set `LLM_SPACE_POSTHOG_KEY=""` (empty), or building from source, blank out
+   `DEFAULT_POSTHOG_KEY` in `apps/desktop/src/bun/analytics/config.ts` - with
+   no key, no client is ever created.
+
+## For forks
+
+The baked-in PostHog key is a write-only, client-side project key. If you fork
+llm-space, point telemetry at your own project via `LLM_SPACE_POSTHOG_KEY`, or
+disable it entirely as above.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,6 +41,7 @@
     "electrobun": "^1.18.1",
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.22.0",
+    "posthog-node": "^5.39.4",
     "radix-ui": "^1.6.0",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -24,6 +24,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { Welcome } from "@/components/welcome";
+import { track } from "@/lib/analytics";
 import { electrobun } from "@/lib/electrobun";
 import {
   importThreadFileRecords,
@@ -238,10 +239,12 @@ function PageInner() {
     openSettings: ({ tab }) => {
       if (tab) setSettingsTab(tab);
       setSettingsOpen(true);
+      track("settings_opened", {});
     },
     openModelSettings: () => {
       setSettingsTab("models");
       setSettingsOpen(true);
+      track("settings_opened", {});
     },
     openCommandPalette: () => setCommandPaletteOpen(true),
     openOnboard: () => setOnboardOpen(true),

--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -178,6 +178,10 @@ function PageInner() {
 
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");
+  // One event per open transition, no matter which command opened Settings.
+  useEffect(() => {
+    if (settingsOpen) track({ event: "settings_opened", properties: {} });
+  }, [settingsOpen]);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [onboardOpen, setOnboardOpen] = useState(false);
   const [examplesOpen, setExamplesOpen] = useState(false);
@@ -239,12 +243,10 @@ function PageInner() {
     openSettings: ({ tab }) => {
       if (tab) setSettingsTab(tab);
       setSettingsOpen(true);
-      track("settings_opened", {});
     },
     openModelSettings: () => {
       setSettingsTab("models");
       setSettingsOpen(true);
-      track("settings_opened", {});
     },
     openCommandPalette: () => setCommandPaletteOpen(true),
     openOnboard: () => setOnboardOpen(true),

--- a/apps/desktop/src/bun/analytics/config.ts
+++ b/apps/desktop/src/bun/analytics/config.ts
@@ -1,0 +1,31 @@
+/**
+ * Analytics configuration, resolved once from the environment.
+ *
+ * The PostHog project API key is a *write-only, client-side* key (safe to ship
+ * in the app), but we still read it from the environment so forks and dev
+ * builds can point at their own project — or disable telemetry entirely by
+ * leaving it unset. `env/hydrate` runs before this is read, so a key exported
+ * in the user's login shell is visible here.
+ */
+
+/** PostHog EU ingestion host (the user chose EU Cloud data residency). */
+export const POSTHOG_HOST = "https://eu.i.posthog.com";
+
+/**
+ * The project API key. This is a *write-only, client-side* PostHog key — safe
+ * to ship in the app — so it's baked in as the default and overridable via env
+ * (forks/dev builds point at their own project). Set it to `""` here, or set
+ * `LLM_SPACE_ANALYTICS_DISABLED=1`, to disable analytics entirely.
+ */
+const DEFAULT_POSTHOG_KEY = "phc_t8sHZoJnt85kTQWtXjPmBHdha5sEvvcRFogKJiN9ihDY";
+
+export const POSTHOG_KEY =
+  process.env.LLM_SPACE_POSTHOG_KEY ?? DEFAULT_POSTHOG_KEY;
+
+/**
+ * Hard opt-out. Set `LLM_SPACE_ANALYTICS_DISABLED=1` (or `true`) to disable all
+ * telemetry regardless of the key — honoured before any client is constructed.
+ */
+export const ANALYTICS_DISABLED = ["1", "true", "yes"].includes(
+  (process.env.LLM_SPACE_ANALYTICS_DISABLED ?? "").toLowerCase()
+);

--- a/apps/desktop/src/bun/analytics/config.ts
+++ b/apps/desktop/src/bun/analytics/config.ts
@@ -13,9 +13,9 @@ export const POSTHOG_HOST = "https://eu.i.posthog.com";
 
 /**
  * The project API key. This is a *write-only, client-side* PostHog key — safe
- * to ship in the app — so it's baked in as the default and overridable via env
- * (forks/dev builds point at their own project). Set it to `""` here, or set
- * `LLM_SPACE_ANALYTICS_DISABLED=1`, to disable analytics entirely.
+ * to ship in the app. `LLM_SPACE_POSTHOG_KEY` repoints a fork or dev build at
+ * its own project; to turn telemetry off, use `LLM_SPACE_ANALYTICS_DISABLED`
+ * (below) rather than blanking the key.
  */
 const DEFAULT_POSTHOG_KEY = "phc_t8sHZoJnt85kTQWtXjPmBHdha5sEvvcRFogKJiN9ihDY";
 

--- a/apps/desktop/src/bun/analytics/index.ts
+++ b/apps/desktop/src/bun/analytics/index.ts
@@ -133,12 +133,19 @@ class Analytics {
   }
 
   private _saveConfig(): void {
-    const config: PersistedAnalytics = {
+    this._writeConfig({
       anonymousId: this._anonymousId,
       enabled: this._enabled,
-    };
+    });
+  }
+
+  private _writeConfig(config: PersistedAnalytics): void {
     mkdirSync(getSettingsDir(), { recursive: true });
-    writeFileSync(this._configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+    writeFileSync(
+      this._configPath,
+      `${JSON.stringify(config, null, 2)}\n`,
+      "utf8"
+    );
   }
 
   /**
@@ -176,8 +183,7 @@ class Analytics {
 
     const seeded: PersistedAnalytics = { anonymousId: randomUUID(), enabled };
     try {
-      mkdirSync(getSettingsDir(), { recursive: true });
-      writeFileSync(this._configPath, `${JSON.stringify(seeded, null, 2)}\n`, "utf8");
+      this._writeConfig(seeded);
     } catch {
       // Non-fatal: we'll just mint a fresh id again next launch.
     }

--- a/apps/desktop/src/bun/analytics/index.ts
+++ b/apps/desktop/src/bun/analytics/index.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { getSettingsDir } from "@llm-space/core/server";
+import { PostHog } from "posthog-node";
+
+import type {
+  AnalyticsEventMap,
+  AnalyticsEventName,
+  AnalyticsSettings,
+} from "../../shared/analytics";
+import { DEFAULT_ANALYTICS_SETTINGS } from "../../shared/analytics";
+
+import { ANALYTICS_DISABLED, POSTHOG_HOST, POSTHOG_KEY } from "./config";
+
+/** On-disk shape of `settings/analytics.json`. */
+interface PersistedAnalytics extends AnalyticsSettings {
+  /**
+   * A random, per-install id used as the analytics `distinctId`. Not a user
+   * identity — it never leaves this machine except as an anonymous event key,
+   * and deleting the file (or the whole llm-space root) resets it.
+   */
+  anonymousId: string;
+}
+
+/**
+ * Anonymous, behaviour-only product analytics — the single network egress for
+ * telemetry. See `shared/analytics.ts` for the privacy contract.
+ *
+ * Owns `settings/analytics.json` (the install id + the user's opt-out
+ * preference), mirroring `SearchSettingsManager`'s eager load-and-seed pattern.
+ * Nothing is ever sent unless a key is configured, the env opt-out is unset,
+ * *and* the user hasn't turned analytics off in Settings; otherwise every
+ * `capture` is a silent no-op. Capture is fire-and-forget and defensively
+ * wrapped so telemetry can never crash the app.
+ */
+class Analytics {
+  private readonly _anonymousId: string;
+  private _enabled: boolean;
+  private _client: PostHog | null = null;
+  /** Hard gate fixed for the process lifetime: key present and not env-disabled. */
+  private readonly _available = Boolean(POSTHOG_KEY) && !ANALYTICS_DISABLED;
+
+  constructor() {
+    const persisted = this._loadConfig();
+    this._anonymousId = persisted.anonymousId;
+    this._enabled = persisted.enabled;
+  }
+
+  /** The user-facing opt-out preference (independent of the hard gates). */
+  getSettings(): AnalyticsSettings {
+    return { enabled: this._enabled };
+  }
+
+  /**
+   * Toggle the user's opt-out preference and persist it. Turning it off flushes
+   * and tears down the client so nothing further is sent; turning it back on
+   * lets the next `capture` re-create it lazily.
+   */
+  setEnabled(enabled: boolean): AnalyticsSettings {
+    if (enabled === this._enabled) return this.getSettings();
+    this._enabled = enabled;
+    this._saveConfig();
+    if (!enabled && this._client) {
+      const client = this._client;
+      this._client = null;
+      void client.shutdown().catch(() => {
+        // Best-effort teardown on opt-out.
+      });
+    }
+    return this.getSettings();
+  }
+
+  /**
+   * Record an anonymous event. Extra PostHog magic properties keep this from
+   * ever building a person profile — events stay strictly anonymous.
+   */
+  capture<K extends AnalyticsEventName>(
+    event: K,
+    properties: AnalyticsEventMap[K]
+  ): void {
+    if (!this._available || !this._enabled) return;
+    // Desktop app: flush eagerly so events aren't lost when the window closes.
+    this._client ??= new PostHog(POSTHOG_KEY, {
+      host: POSTHOG_HOST,
+      flushAt: 1,
+      flushInterval: 5_000,
+    });
+    try {
+      this._client.capture({
+        distinctId: this._anonymousId,
+        event,
+        properties: {
+          ...properties,
+          // Never materialize a person profile for an anonymous install id.
+          $process_person_profile: false,
+        },
+        // Don't infer location from the ingestion IP.
+        disableGeoip: true,
+      });
+    } catch {
+      // Telemetry must never break the app.
+    }
+  }
+
+  /** Flush and tear down the client on shutdown. Best-effort. */
+  async shutdown(): Promise<void> {
+    try {
+      await this._client?.shutdown();
+    } catch {
+      // Ignore — we're exiting anyway.
+    }
+  }
+
+  private get _configPath(): string {
+    return path.join(getSettingsDir(), "analytics.json");
+  }
+
+  private _saveConfig(): void {
+    const config: PersistedAnalytics = {
+      anonymousId: this._anonymousId,
+      enabled: this._enabled,
+    };
+    mkdirSync(getSettingsDir(), { recursive: true });
+    writeFileSync(this._configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  }
+
+  /**
+   * Read `settings/analytics.json`, minting an install id and seeding the file
+   * on first run. A missing/partial file falls back to defaults; a corrupt or
+   * unreadable file is best-effort and never blocks startup.
+   */
+  private _loadConfig(): PersistedAnalytics {
+    try {
+      const parsed = JSON.parse(
+        readFileSync(this._configPath, "utf8")
+      ) as Partial<PersistedAnalytics>;
+      if (parsed.anonymousId) {
+        return {
+          anonymousId: parsed.anonymousId,
+          enabled:
+            typeof parsed.enabled === "boolean"
+              ? parsed.enabled
+              : DEFAULT_ANALYTICS_SETTINGS.enabled,
+        };
+      }
+    } catch {
+      // Missing, corrupt, or unreadable — fall through and seed a fresh file.
+    }
+
+    const seeded: PersistedAnalytics = {
+      anonymousId: randomUUID(),
+      ...DEFAULT_ANALYTICS_SETTINGS,
+    };
+    try {
+      mkdirSync(getSettingsDir(), { recursive: true });
+      writeFileSync(this._configPath, `${JSON.stringify(seeded, null, 2)}\n`, "utf8");
+    } catch {
+      // Non-fatal: we'll just mint a fresh id again next launch.
+    }
+    return seeded;
+  }
+}
+
+export const analytics = new Analytics();

--- a/apps/desktop/src/bun/analytics/index.ts
+++ b/apps/desktop/src/bun/analytics/index.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { getSettingsDir } from "@llm-space/core/server";
 import { PostHog } from "posthog-node";
 
+import electrobunConfig from "../../../electrobun.config";
 import type {
   AnalyticsEventMap,
   AnalyticsEventName,
@@ -13,6 +14,16 @@ import type {
 import { DEFAULT_ANALYTICS_SETTINGS } from "../../shared/analytics";
 
 import { ANALYTICS_DISABLED, POSTHOG_HOST, POSTHOG_KEY } from "./config";
+
+/**
+ * Merged into every event so metrics can be sliced by release and OS. Only
+ * anonymous build/platform facts - never anything user- or machine-identifying.
+ */
+const COMMON_PROPERTIES = {
+  appVersion: electrobunConfig.app.version,
+  platform: process.platform,
+  arch: process.arch,
+} as const;
 
 /** On-disk shape of `settings/analytics.json`. */
 interface PersistedAnalytics extends AnalyticsSettings {
@@ -36,6 +47,8 @@ interface PersistedAnalytics extends AnalyticsSettings {
  * wrapped so telemetry can never crash the app.
  */
 class Analytics {
+  /** True when this launch minted the install id (first run, or an id reset). */
+  readonly isFirstRun: boolean;
   private readonly _anonymousId: string;
   private _enabled: boolean;
   private _client: PostHog | null = null;
@@ -43,9 +56,10 @@ class Analytics {
   private readonly _available = Boolean(POSTHOG_KEY) && !ANALYTICS_DISABLED;
 
   constructor() {
-    const persisted = this._loadConfig();
+    const { persisted, isFirstRun } = this._loadConfig();
     this._anonymousId = persisted.anonymousId;
     this._enabled = persisted.enabled;
+    this.isFirstRun = isFirstRun;
   }
 
   /** The user-facing opt-out preference (independent of the hard gates). */
@@ -81,17 +95,18 @@ class Analytics {
     properties: AnalyticsEventMap[K]
   ): void {
     if (!this._available || !this._enabled) return;
-    // Desktop app: flush eagerly so events aren't lost when the window closes.
-    this._client ??= new PostHog(POSTHOG_KEY, {
-      host: POSTHOG_HOST,
-      flushAt: 1,
-      flushInterval: 5_000,
-    });
     try {
+      // Desktop app: flush eagerly so events aren't lost when the window closes.
+      this._client ??= new PostHog(POSTHOG_KEY, {
+        host: POSTHOG_HOST,
+        flushAt: 1,
+        flushInterval: 5_000,
+      });
       this._client.capture({
         distinctId: this._anonymousId,
         event,
         properties: {
+          ...COMMON_PROPERTIES,
           ...properties,
           // Never materialize a person profile for an anonymous install id.
           $process_person_profile: false,
@@ -131,35 +146,42 @@ class Analytics {
    * on first run. A missing/partial file falls back to defaults; a corrupt or
    * unreadable file is best-effort and never blocks startup.
    */
-  private _loadConfig(): PersistedAnalytics {
+  private _loadConfig(): {
+    persisted: PersistedAnalytics;
+    isFirstRun: boolean;
+  } {
+    let parsed: Partial<PersistedAnalytics> = {};
     try {
-      const parsed = JSON.parse(
+      parsed = JSON.parse(
         readFileSync(this._configPath, "utf8")
       ) as Partial<PersistedAnalytics>;
-      if (parsed.anonymousId) {
-        return {
-          anonymousId: parsed.anonymousId,
-          enabled:
-            typeof parsed.enabled === "boolean"
-              ? parsed.enabled
-              : DEFAULT_ANALYTICS_SETTINGS.enabled,
-        };
-      }
     } catch {
-      // Missing, corrupt, or unreadable — fall through and seed a fresh file.
+      // Missing, corrupt, or unreadable - treat as empty and reseed below.
     }
 
-    const seeded: PersistedAnalytics = {
-      anonymousId: randomUUID(),
-      ...DEFAULT_ANALYTICS_SETTINGS,
-    };
+    // Honour a persisted opt-out independently of the install id: a partial
+    // file (e.g. a hand-edited or truncated one that lost its id) must never
+    // silently re-enroll a user who turned analytics off.
+    const enabled =
+      typeof parsed.enabled === "boolean"
+        ? parsed.enabled
+        : DEFAULT_ANALYTICS_SETTINGS.enabled;
+
+    if (parsed.anonymousId) {
+      return {
+        persisted: { anonymousId: parsed.anonymousId, enabled },
+        isFirstRun: false,
+      };
+    }
+
+    const seeded: PersistedAnalytics = { anonymousId: randomUUID(), enabled };
     try {
       mkdirSync(getSettingsDir(), { recursive: true });
       writeFileSync(this._configPath, `${JSON.stringify(seeded, null, 2)}\n`, "utf8");
     } catch {
       // Non-fatal: we'll just mint a fresh id again next launch.
     }
-    return seeded;
+    return { persisted: seeded, isFirstRun: true };
   }
 }
 

--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -5,4 +5,15 @@ import "./env/hydrate";
 // Seed a fresh workspace (before `./app` pulls in storage/RPC).
 import "./workspace/seed";
 import "./app";
+import { analytics } from "./analytics";
 /* eslint-enable import-x/order */
+
+// Anonymous launch signal, and a best-effort flush so queued events aren't lost
+// when the app exits. See `shared/analytics.ts` for the privacy contract.
+analytics.capture("app_opened", { platform: process.platform });
+
+for (const signal of ["SIGINT", "SIGTERM", "beforeExit"] as const) {
+  process.once(signal, () => {
+    void analytics.shutdown();
+  });
+}

--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -5,15 +5,18 @@ import "./env/hydrate";
 // Seed a fresh workspace (before `./app` pulls in storage/RPC).
 import "./workspace/seed";
 import "./app";
+import { app } from "electrobun/bun";
 import { analytics } from "./analytics";
 /* eslint-enable import-x/order */
 
-// Anonymous launch signal, and a best-effort flush so queued events aren't lost
-// when the app exits. See `shared/analytics.ts` for the privacy contract.
-analytics.capture("app_opened", { platform: process.platform });
+// Anonymous launch signal. See `shared/analytics.ts` for the privacy contract.
+analytics.capture("app_opened", { isFirstOpen: analytics.isFirstRun });
 
-for (const signal of ["SIGINT", "SIGTERM", "beforeExit"] as const) {
-  process.once(signal, () => {
-    void analytics.shutdown();
-  });
-}
+// Best-effort flush on the real quit path: GUI quits (Cmd+Q, window close) run
+// through Electrobun's `quit()`, which emits `before-quit` - and Electrobun's
+// own SIGINT/SIGTERM handlers call `quit()` too, so this hook covers them all.
+// (Node-style `beforeExit` would never fire here: the PostHog flush-interval
+// timer keeps the event loop alive.)
+app.on("before-quit", () => {
+  void analytics.shutdown();
+});

--- a/apps/desktop/src/bun/models/model-manager.ts
+++ b/apps/desktop/src/bun/models/model-manager.ts
@@ -231,6 +231,20 @@ export class ModelManager {
   }
 
   /**
+   * Whether a model id comes from a shipped builtin provider's static catalog,
+   * as opposed to being typed in by the user (custom providers, and user-added
+   * models on builtin providers). Only catalog ids are safe for telemetry to
+   * record verbatim.
+   */
+  isBuiltinCatalogModel(providerId: string, modelId: string): boolean {
+    if (!this.isBuiltin(providerId)) return false;
+    const provider = BUILTIN_PROVIDERS[providerId];
+    return provider
+      ? provider.getModels().some((model) => model.id === modelId)
+      : false;
+  }
+
+  /**
    * Enable or disable a single model within a provider. Disabling records the
    * model id in the provider's `disabledModels`; enabling removes it. Model
    * enablement is a renderer-facing filter only — it does not affect the

--- a/apps/desktop/src/bun/rpc/index.ts
+++ b/apps/desktop/src/bun/rpc/index.ts
@@ -2,6 +2,7 @@ import { ModelProviderGroup } from "@llm-space/core";
 import { BrowserView, Utils } from "electrobun/bun";
 
 import type { DesktopRPCType } from "../../shared/rpc";
+import { analytics } from "../analytics";
 import { moveToTrash, revealInFileManager } from "../fs";
 import { mcpManager } from "../mcp";
 import { modelManager } from "../models";
@@ -58,10 +59,13 @@ export const mainWindowRPC: MainWindowRPC =
         builtinProviders: async () => modelManager.getBuiltinProviders(),
         addProvider: async ({ providerId }) => {
           modelManager.addBuiltInProvider({ id: providerId });
+          analytics.capture("provider_added", { providerId, kind: "builtin" });
           return getModelProviderGroups();
         },
         addCustomProvider: async ({ id, name, baseUrl, api }) => {
           modelManager.addCustomProvider({ id, name, baseUrl, api });
+          // Only the provider id is recorded — never the base URL or name.
+          analytics.capture("provider_added", { providerId: id, kind: "custom" });
           return getModelProviderGroups();
         },
         updateProvider: async ({
@@ -153,7 +157,11 @@ export const mainWindowRPC: MainWindowRPC =
           return null;
         },
         mcpListServers: () => mcpManager.listServers(),
-        mcpAddServer: ({ server }) => mcpManager.addServer(server),
+        mcpAddServer: ({ server }) => {
+          const servers = mcpManager.addServer(server);
+          analytics.capture("mcp_server_added", {});
+          return servers;
+        },
         mcpUpdateServer: async ({ serverId, server }) =>
           mcpManager.updateServer(serverId, server),
         mcpRemoveServer: async ({ serverId }) =>
@@ -166,6 +174,9 @@ export const mainWindowRPC: MainWindowRPC =
         builtInListTools: () => listBuiltInTools(),
         builtInCallTool: ({ name, arguments: args }) =>
           callBuiltInTool({ name, arguments: args }),
+        getAnalyticsSettings: () => Promise.resolve(analytics.getSettings()),
+        setAnalyticsSettings: ({ enabled }) =>
+          Promise.resolve(analytics.setEnabled(enabled)),
         getSearchSettings: () => searchSettings.get(),
         setSearchSettings: ({ settings }) => searchSettings.set(settings),
         skillsGetSettings: () => Promise.resolve(skillsManager.getConfig()),
@@ -221,6 +232,8 @@ export const mainWindowRPC: MainWindowRPC =
           );
         },
         abortStreamThread: (payload) => abortStreamThread(payload),
+        captureAnalyticsEvent: ({ event, properties }) =>
+          analytics.capture(event, properties),
         executeCommand: async (command) => {
           const { executeCommandInBun } = await import("../commands");
           const { mainWindow } = await import("../app/window");

--- a/apps/desktop/src/bun/streaming/stream-thread.ts
+++ b/apps/desktop/src/bun/streaming/stream-thread.ts
@@ -51,10 +51,20 @@ export async function runStreamThread(
     });
   } finally {
     activeStreams.delete(streamId);
-    // Anonymous shape/outcome metadata only — never any message content.
+    // Anonymous shape/outcome metadata only - never any message content. The
+    // provider/model pair is reported verbatim only when it comes from a
+    // shipped builtin catalog; user-typed ids collapse to "custom" so a
+    // private provider or model name can never leave the machine.
     analytics.capture("thread_run", {
-      provider: request.model.provider,
-      model: request.model.id,
+      provider: modelManager.isBuiltin(request.model.provider)
+        ? request.model.provider
+        : "custom",
+      model: modelManager.isBuiltinCatalogModel(
+        request.model.provider,
+        request.model.id
+      )
+        ? request.model.id
+        : "custom",
       outcome,
       durationMs: Date.now() - startedAt,
       messageCount: request.context.messages.length,

--- a/apps/desktop/src/bun/streaming/stream-thread.ts
+++ b/apps/desktop/src/bun/streaming/stream-thread.ts
@@ -51,20 +51,9 @@ export async function runStreamThread(
     });
   } finally {
     activeStreams.delete(streamId);
-    // Anonymous shape/outcome metadata only - never any message content. The
-    // provider/model pair is reported verbatim only when it comes from a
-    // shipped builtin catalog; user-typed ids collapse to "custom" so a
-    // private provider or model name can never leave the machine.
+    // Anonymous shape/outcome metadata only - never any message content.
     analytics.capture("thread_run", {
-      provider: modelManager.isBuiltin(request.model.provider)
-        ? request.model.provider
-        : "custom",
-      model: modelManager.isBuiltinCatalogModel(
-        request.model.provider,
-        request.model.id
-      )
-        ? request.model.id
-        : "custom",
+      ..._scrubModelForTelemetry(request.model),
       outcome,
       durationMs: Date.now() - startedAt,
       messageCount: request.context.messages.length,
@@ -72,6 +61,25 @@ export async function runStreamThread(
       hasSystemPrompt: Boolean(request.context.systemPrompt),
     });
   }
+}
+
+/**
+ * Collapse a run's model selector for telemetry. Only ids from a shipped
+ * builtin catalog are reported verbatim; user-typed providers and models
+ * become the literal "custom" so a private name never leaves the machine.
+ */
+function _scrubModelForTelemetry(model: { provider: string; id: string }): {
+  provider: string;
+  model: string;
+} {
+  return {
+    provider: modelManager.isBuiltin(model.provider)
+      ? model.provider
+      : "custom",
+    model: modelManager.isBuiltinCatalogModel(model.provider, model.id)
+      ? model.id
+      : "custom",
+  };
 }
 
 /** Abort an in-flight stream started by {@link runStreamThread}. */

--- a/apps/desktop/src/bun/streaming/stream-thread.ts
+++ b/apps/desktop/src/bun/streaming/stream-thread.ts
@@ -5,6 +5,7 @@ import type {
   StreamThreadRequestPayload,
   StreamThreadResponsePayload,
 } from "../../shared/rpc";
+import { analytics } from "../analytics";
 import { modelManager } from "../models";
 
 /** Abort controllers for in-flight streams, keyed by `streamId`. */
@@ -21,6 +22,10 @@ export async function runStreamThread(
   const { streamId, request } = payload;
   const abortController = new AbortController();
   activeStreams.set(streamId, abortController);
+  const startedAt = Date.now();
+  // Resolved in each terminal branch, then reported once in `finally` so a
+  // single run always yields exactly one anonymous `thread_run` event.
+  let outcome: "completed" | "error" | "aborted" = "error";
   try {
     for await (const event of streamAgent(request, {
       models: await modelManager.getAvailableModels(),
@@ -31,10 +36,12 @@ export async function runStreamThread(
     })) {
       send({ streamId, type: "event", event });
     }
+    outcome = "completed";
     send({ streamId, type: "done" });
   } catch (error) {
     // The client aborted and has already torn down its listener; stay quiet.
     if (abortController.signal.aborted) {
+      outcome = "aborted";
       return;
     }
     send({
@@ -44,6 +51,16 @@ export async function runStreamThread(
     });
   } finally {
     activeStreams.delete(streamId);
+    // Anonymous shape/outcome metadata only — never any message content.
+    analytics.capture("thread_run", {
+      provider: request.model.provider,
+      model: request.model.id,
+      outcome,
+      durationMs: Date.now() - startedAt,
+      messageCount: request.context.messages.length,
+      toolCount: request.context.tools.length,
+      hasSystemPrompt: Boolean(request.context.systemPrompt),
+    });
   }
 }
 

--- a/apps/desktop/src/client/analytics.ts
+++ b/apps/desktop/src/client/analytics.ts
@@ -1,0 +1,19 @@
+import { electrobun } from "@/lib/electrobun";
+import type { AnalyticsSettings } from "@/shared/analytics";
+
+function _rpc() {
+  if (!electrobun.rpc) {
+    throw new Error("Electrobun RPC is not initialized");
+  }
+  return electrobun.rpc;
+}
+
+export async function getAnalyticsSettings(): Promise<AnalyticsSettings> {
+  return _rpc().request.getAnalyticsSettings({});
+}
+
+export async function setAnalyticsSettings(
+  enabled: boolean
+): Promise<AnalyticsSettings> {
+  return _rpc().request.setAnalyticsSettings({ enabled });
+}

--- a/apps/desktop/src/components/onboard-dialog.tsx
+++ b/apps/desktop/src/components/onboard-dialog.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 
 import { useCommands } from "@/commands";
 import { Dialog, DialogClose, DialogContent } from "@/components/ui/dialog";
+import { track } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 import {
@@ -91,10 +92,12 @@ export function OnboardDialog({
   }, [builtinProviders]);
 
   const handleConfigureModels = useCallback(() => {
+    track("onboarding_choice", { choice: "configure_models" });
     onOpenChange(false);
     executeCommand({ type: "openSettings", args: { tab: "models" } });
   }, [executeCommand, onOpenChange]);
   const handleLearnMore = useCallback(() => {
+    track("onboarding_choice", { choice: "learn_more" });
     executeCommand({ type: "openDocument", args: {} });
   }, [executeCommand]);
 

--- a/apps/desktop/src/components/onboard-dialog.tsx
+++ b/apps/desktop/src/components/onboard-dialog.tsx
@@ -92,14 +92,25 @@ export function OnboardDialog({
   }, [builtinProviders]);
 
   const handleConfigureModels = useCallback(() => {
-    track("onboarding_choice", { choice: "configure_models" });
+    track({
+      event: "onboarding_choice",
+      properties: { choice: "configure_models" },
+    });
     onOpenChange(false);
     executeCommand({ type: "openSettings", args: { tab: "models" } });
   }, [executeCommand, onOpenChange]);
   const handleLearnMore = useCallback(() => {
-    track("onboarding_choice", { choice: "learn_more" });
+    track({ event: "onboarding_choice", properties: { choice: "learn_more" } });
     executeCommand({ type: "openDocument", args: {} });
   }, [executeCommand]);
+  const handleOpenAnalyticsSettings = useCallback(() => {
+    track({
+      event: "onboarding_choice",
+      properties: { choice: "analytics_settings" },
+    });
+    onOpenChange(false);
+    executeCommand({ type: "openSettings", args: { tab: "general" } });
+  }, [executeCommand, onOpenChange]);
 
   const handleAddProvider = useCallback(
     async (provider: ModelProviderGroup) => {
@@ -151,37 +162,49 @@ export function OnboardDialog({
             </Button>
           </DialogClose>
           <div className="absolute right-6 bottom-6 left-6 flex flex-col gap-3 md:right-8 md:bottom-8 md:left-12 md:flex-row md:items-end md:justify-between">
-            <div className="flex shrink-0 flex-wrap items-center gap-4">
-              {models.length === 0 ? (
+            <div className="flex shrink-0 flex-col gap-2.5">
+              <div className="flex flex-wrap items-center gap-4">
+                {models.length === 0 ? (
+                  <Button
+                    className="border-ring/75 h-11 rounded-2xl border bg-white/10! px-6 backdrop-blur-xs"
+                    variant="outline"
+                    size="lg"
+                    onClick={handleConfigureModels}
+                  >
+                    <SettingsIcon className="size-3" />
+                    Configure models
+                  </Button>
+                ) : (
+                  <DialogClose asChild>
+                    <RainbowButton
+                      variant="outline"
+                      className="dark:bg-[red]!"
+                      size="lg"
+                    >
+                      Get started
+                      <ArrowRightIcon className="size-3.5" />
+                    </RainbowButton>
+                  </DialogClose>
+                )}
                 <Button
-                  className="border-ring/75 h-11 rounded-2xl border bg-white/10! px-6 backdrop-blur-xs"
+                  className="h-11 rounded-2xl border border-white/20 bg-white/10! px-8 backdrop-blur-xs"
                   variant="outline"
                   size="lg"
-                  onClick={handleConfigureModels}
+                  onClick={handleLearnMore}
                 >
-                  <SettingsIcon className="size-3" />
-                  Configure models
+                  Learn more
                 </Button>
-              ) : (
-                <DialogClose asChild>
-                  <RainbowButton
-                    variant="outline"
-                    className="dark:bg-[red]!"
-                    size="lg"
-                  >
-                    Get started
-                    <ArrowRightIcon className="size-3.5" />
-                  </RainbowButton>
-                </DialogClose>
-              )}
-              <Button
-                className="h-11 rounded-2xl border border-white/20 bg-white/10! px-8 backdrop-blur-xs"
-                variant="outline"
-                size="lg"
-                onClick={handleLearnMore}
-              >
-                Learn more
-              </Button>
+              </div>
+              <div className="text-xs text-white/65">
+                We collect anonymous usage data to improve the app.{" "}
+                <button
+                  type="button"
+                  className="underline underline-offset-2 transition-colors hover:text-white/90"
+                  onClick={handleOpenAnalyticsSettings}
+                >
+                  Manage in settings
+                </button>
+              </div>
             </div>
             <_OnboardSetupPanel
               className="w-full md:w-[22rem] md:shrink-0"

--- a/apps/desktop/src/components/settings/general-page.tsx
+++ b/apps/desktop/src/components/settings/general-page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { toast } from "sonner";
 
-import {
-  getAnalyticsSettings,
-  setAnalyticsSettings,
-} from "@/client/analytics";
+import { getAnalyticsSettings, setAnalyticsSettings } from "@/client/analytics";
 import {
   isModelAvailable,
   useDefaultModel,
@@ -160,10 +163,9 @@ function AnalyticsToggle() {
   }, []);
 
   const handleChange = useCallback(async (next: boolean) => {
-    setEnabled(next); // Optimistic; reconcile with the persisted value below.
+    setEnabled(next); // Optimistic; the RPC echoes the input, so no reconcile.
     try {
-      const saved = await setAnalyticsSettings(next);
-      setEnabled(saved.enabled);
+      await setAnalyticsSettings(next);
     } catch (error) {
       setEnabled(!next);
       toast.error("Failed to update analytics setting", {
@@ -287,8 +289,8 @@ export function GeneralPage() {
           <span className="flex flex-col gap-0.5">
             Share anonymous usage analytics
             <span className="text-muted-foreground text-xs">
-              Helps improve the app. Only anonymous actions are sent - never your
-              prompts, messages, or API keys.
+              Helps improve the app. Only anonymous actions are sent - never
+              your prompts, messages, or API keys.
             </span>
           </span>
         }

--- a/apps/desktop/src/components/settings/general-page.tsx
+++ b/apps/desktop/src/components/settings/general-page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { toast } from "sonner";
 
+import {
+  getAnalyticsSettings,
+  setAnalyticsSettings,
+} from "@/client/analytics";
 import {
   isModelAvailable,
   useDefaultModel,
@@ -27,6 +32,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { DEFAULT_ANALYTICS_SETTINGS } from "@/shared/analytics";
 
 import { ModelAvatar } from "../thread-playground/model-avatar";
 import { Button } from "../ui/button";
@@ -130,6 +137,51 @@ function DefaultModelSelect() {
   );
 }
 
+/**
+ * Opt out of anonymous, behaviour-only product analytics. The switch reflects
+ * the user's stored preference; toggling it persists immediately via RPC. See
+ * `shared/analytics.ts` for exactly what is (and isn't) collected.
+ */
+function AnalyticsToggle() {
+  const [enabled, setEnabled] = useState(DEFAULT_ANALYTICS_SETTINGS.enabled);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getAnalyticsSettings()
+      .then((loaded) => {
+        if (!cancelled) setEnabled(loaded.enabled);
+      })
+      .catch(() => {
+        // Keep the default; a load failure is non-fatal for the toggle.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChange = useCallback(async (next: boolean) => {
+    setEnabled(next); // Optimistic; reconcile with the persisted value below.
+    try {
+      const saved = await setAnalyticsSettings(next);
+      setEnabled(saved.enabled);
+    } catch (error) {
+      setEnabled(!next);
+      toast.error("Failed to update analytics setting", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    }
+  }, []);
+
+  return (
+    <Switch
+      checked={enabled}
+      onCheckedChange={(next) => void handleChange(next)}
+      aria-label="Share anonymous usage analytics"
+    />
+  );
+}
+
 export function GeneralPage() {
   const { theme, setTheme } = useTheme();
   const { fidelity, setFidelity } = useRenderingFidelity();
@@ -226,6 +278,22 @@ export function GeneralPage() {
             <SelectItem value="en-US">English (US)</SelectItem>
           </SelectContent>
         </Select>
+      </SettingsRow>
+
+      <Separator />
+
+      <SettingsRow
+        label={
+          <span className="flex flex-col gap-0.5">
+            Share anonymous usage analytics
+            <span className="text-muted-foreground text-xs">
+              Helps improve the app. Only anonymous actions are sent - never your
+              prompts, messages, or API keys.
+            </span>
+          </span>
+        }
+      >
+        <AnalyticsToggle />
       </SettingsRow>
     </SettingsPage>
   );

--- a/apps/desktop/src/lib/analytics.ts
+++ b/apps/desktop/src/lib/analytics.ts
@@ -1,0 +1,27 @@
+import type {
+  AnalyticsEventMap,
+  AnalyticsEventName,
+} from "@/shared/analytics";
+
+import { electrobun } from "./electrobun";
+
+/**
+ * Record an anonymous, behaviour-only analytics event from the renderer.
+ *
+ * This does not send anything itself — it forwards the event to the bun main
+ * process (the single, auditable telemetry egress) over a fire-and-forget RPC
+ * message. Safe to call before RPC is ready and can never throw into UI code.
+ * See `shared/analytics.ts` for the privacy contract.
+ */
+export function track<K extends AnalyticsEventName>(
+  event: K,
+  properties: AnalyticsEventMap[K]
+): void {
+  try {
+    // `send` is fire-and-forget; the union member is reconstructed on the bun
+    // side, so the `event`/`properties` pairing is asserted at this boundary.
+    electrobun.rpc?.send.captureAnalyticsEvent({ event, properties } as never);
+  } catch {
+    // Telemetry must never break the UI.
+  }
+}

--- a/apps/desktop/src/lib/analytics.ts
+++ b/apps/desktop/src/lib/analytics.ts
@@ -1,7 +1,4 @@
-import type {
-  AnalyticsEventMap,
-  AnalyticsEventName,
-} from "@/shared/analytics";
+import type { AnalyticsEvent } from "@/shared/analytics";
 
 import { electrobun } from "./electrobun";
 
@@ -13,14 +10,9 @@ import { electrobun } from "./electrobun";
  * message. Safe to call before RPC is ready and can never throw into UI code.
  * See `shared/analytics.ts` for the privacy contract.
  */
-export function track<K extends AnalyticsEventName>(
-  event: K,
-  properties: AnalyticsEventMap[K]
-): void {
+export function track(event: AnalyticsEvent): void {
   try {
-    // `send` is fire-and-forget; the union member is reconstructed on the bun
-    // side, so the `event`/`properties` pairing is asserted at this boundary.
-    electrobun.rpc?.send.captureAnalyticsEvent({ event, properties } as never);
+    electrobun.rpc?.send.captureAnalyticsEvent(event);
   } catch {
     // Telemetry must never break the UI.
   }

--- a/apps/desktop/src/shared/analytics.ts
+++ b/apps/desktop/src/shared/analytics.ts
@@ -6,19 +6,30 @@
  * - identified by a random per-install id, never a user identity;
  * - event properties describe *what kind of action* happened, never its
  *   content. No prompt text, message bodies, system prompts, file contents,
- *   API keys, base URLs, or headers ever appear here.
+ *   API keys, base URLs, or headers ever appear here;
+ * - user-typed identifiers (custom provider or model names) are collapsed to
+ *   the literal `"custom"` before capture - only ids from shipped builtin
+ *   catalogs are ever reported verbatim.
+ *
+ * Every event additionally carries anonymous build/platform facts (app
+ * version, `process.platform`, `process.arch`) merged in by `bun/analytics`.
  *
  * Every event funnels through the bun main process (`bun/analytics`), which is
  * the single, auditable network egress. Renderer-only events reach it over the
  * `captureAnalyticsEvent` RPC message; bun-side events call `analytics.capture`
  * directly.
+ *
+ * The full user-facing description of what is collected and how to opt out
+ * lives in `TELEMETRY.md` at the repo root - keep it in sync with this map.
  */
 export interface AnalyticsEventMap {
   /** The desktop app finished booting. */
-  app_opened: { platform: NodeJS.Platform };
+  app_opened: { isFirstOpen: boolean };
   /**
    * A single agent run finished. Carries only anonymous shape/outcome metadata —
    * the model selector, the run outcome, and coarse counts. Never any content.
+   * `provider`/`model` are builtin-catalog ids, or the literal `"custom"` for
+   * anything the user typed in themselves.
    */
   thread_run: {
     provider: string;

--- a/apps/desktop/src/shared/analytics.ts
+++ b/apps/desktop/src/shared/analytics.ts
@@ -1,0 +1,60 @@
+/**
+ * The analytics event contract, shared by both runtime contexts.
+ *
+ * Privacy contract — this is a local-first LLM workbench, so telemetry is
+ * strictly **anonymous, behaviour-only**:
+ * - identified by a random per-install id, never a user identity;
+ * - event properties describe *what kind of action* happened, never its
+ *   content. No prompt text, message bodies, system prompts, file contents,
+ *   API keys, base URLs, or headers ever appear here.
+ *
+ * Every event funnels through the bun main process (`bun/analytics`), which is
+ * the single, auditable network egress. Renderer-only events reach it over the
+ * `captureAnalyticsEvent` RPC message; bun-side events call `analytics.capture`
+ * directly.
+ */
+export interface AnalyticsEventMap {
+  /** The desktop app finished booting. */
+  app_opened: { platform: NodeJS.Platform };
+  /**
+   * A single agent run finished. Carries only anonymous shape/outcome metadata —
+   * the model selector, the run outcome, and coarse counts. Never any content.
+   */
+  thread_run: {
+    provider: string;
+    model: string;
+    outcome: "completed" | "error" | "aborted";
+    durationMs: number;
+    messageCount: number;
+    toolCount: number;
+    hasSystemPrompt: boolean;
+  };
+  /** The user configured a model provider. */
+  provider_added: { providerId: string; kind: "builtin" | "custom" };
+  /** The user added an MCP server. */
+  mcp_server_added: Record<string, never>;
+  /** The user opened the settings dialog. */
+  settings_opened: Record<string, never>;
+  /** The user made a choice on the first-run onboarding screen. */
+  onboarding_choice: { choice: string };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventMap;
+
+/**
+ * User-controlled analytics preference, persisted to `settings/analytics.json`
+ * alongside the anonymous install id. `enabled` is the opt-*out* switch surfaced
+ * in Settings; it defaults to on but is always subordinate to the hard gates
+ * (no `POSTHOG_KEY`, or `LLM_SPACE_ANALYTICS_DISABLED`), which force telemetry
+ * off regardless.
+ */
+export interface AnalyticsSettings {
+  enabled: boolean;
+}
+
+export const DEFAULT_ANALYTICS_SETTINGS: AnalyticsSettings = { enabled: true };
+
+/** A single, self-describing analytics event: a name plus its typed payload. */
+export type AnalyticsEvent = {
+  [K in AnalyticsEventName]: { event: K; properties: AnalyticsEventMap[K] };
+}[AnalyticsEventName];

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -10,6 +10,7 @@ import type {
 } from "@llm-space/core";
 import type { RPCSchema } from "electrobun";
 
+import type { AnalyticsEvent, AnalyticsSettings } from "./analytics";
 import type { Command } from "./commands";
 import type {
   McpCallToolResponse,
@@ -194,6 +195,15 @@ export interface DesktopRPCType {
         };
         response: { contentText: string };
       };
+      // The user's anonymous-analytics opt-out preference (see `shared/analytics.ts`).
+      getAnalyticsSettings: {
+        params: Record<string, never>;
+        response: AnalyticsSettings;
+      };
+      setAnalyticsSettings: {
+        params: { enabled: boolean };
+        response: AnalyticsSettings;
+      };
       // The search provider + API keys backing the built-in web tools.
       getSearchSettings: {
         params: Record<string, never>;
@@ -303,6 +313,9 @@ export interface DesktopRPCType {
       // A unified command dispatched from the webview to run in the bun process
       // (e.g. window zoom / reload). See `shared/commands.ts`.
       executeCommand: Command;
+      // Fire-and-forget: a renderer-only, anonymous analytics event. The bun
+      // side is the single network egress for telemetry. See `shared/analytics.ts`.
+      captureAnalyticsEvent: AnalyticsEvent;
     };
   }>;
   webview: RPCSchema<{

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "electrobun": "^1.18.1",
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.22.0",
+        "posthog-node": "^5.39.4",
         "radix-ui": "^1.6.0",
         "react": "catalog:",
         "react-dom": "catalog:",
@@ -709,6 +710,10 @@
     "@pierre/diffs": ["@pierre/diffs@1.2.8", "https://registry.npmmirror.com/@pierre/diffs/-/diffs-1.2.8.tgz", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-HVaWzZ1cW5GDKodivaPCN1hU05DGvoLiG/uvVBNZODD+qY2NTr36KYgATGhb79Vr8OCKNG3qATTWJEwbkMGfzA=="],
 
     "@pierre/theme": ["@pierre/theme@1.0.3", "https://registry.npmmirror.com/@pierre/theme/-/theme-1.0.3.tgz", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+
+    "@posthog/core": ["@posthog/core@1.39.6", "", { "dependencies": { "@posthog/types": "^1.392.0" } }, "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw=="],
+
+    "@posthog/types": ["@posthog/types@1.392.1", "", {}, "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w=="],
 
     "@preact/signals": ["@preact/signals@2.9.2", "https://registry.npmmirror.com/@preact/signals/-/signals-2.9.2.tgz", { "dependencies": { "@preact/signals-core": "^1.14.3" }, "peerDependencies": { "preact": ">= 10.25.0 || >=11.0.0-0" } }, "sha512-DvFPISNMSh3vPqRwPa1tAVAHl85aDq4pTyNu1bTGfrKr64F3EOCHjdUl9aUdohKBf1v9PRGLYuGFcJpfztkdoQ=="],
 
@@ -2563,6 +2568,8 @@
     "postcss-selector-parser": ["postcss-selector-parser@7.1.4", "https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "https://registry.npmmirror.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "posthog-node": ["posthog-node@5.39.4", "", { "dependencies": { "@posthog/core": "^1.39.5" }, "peerDependencies": { "rxjs": "^7.0.0" }, "optionalPeers": ["rxjs"] }, "sha512-+fCQ7htBFRQQFbIzl1T0TA7bDwYyaB9XP308ZFMCUoB5LzTzOFxBa6TYVrxdH/VQl43WXTp6sf0QsG2Z4XlNBg=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.1.0.tgz", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 


### PR DESCRIPTION
## What

Adds anonymous, behaviour-only product analytics (PostHog, EU Cloud) to the desktop app, plus a user-facing opt-out toggle in **Settings › General**, a first-run disclosure line in the onboarding dialog, and a `TELEMETRY.md` documenting everything.

All telemetry funnels through a **single, auditable egress in the bun main process**. Renderer events are forwarded over a fire-and-forget `captureAnalyticsEvent` RPC message (typed end-to-end via the `AnalyticsEvent` discriminated union - no casts); bun-side handlers call `analytics.capture` directly.

## Privacy contract

- **Anonymous**: identified by a random per-install id (`settings/analytics.json`), never a user identity. Person profiles disabled (`$process_person_profile: false`), geoip off.
- **Content never leaves the machine**: only anonymous action/shape metadata is sent - never prompts, message text, system prompts, file contents, API keys, base URLs, or headers.
- **User-typed names never leave the machine**: `thread_run` reports provider/model verbatim only when they come from a shipped builtin catalog; custom providers and user-added model ids collapse to the literal `"custom"` (`_scrubModelForTelemetry`).
- **Opt-out is durable**: a partial/corrupt `analytics.json` preserves a persisted `enabled: false`; only the install id is re-minted.
- **Off by default unless configured**: no `POSTHOG_KEY` -> no client, no network. Hard env opt-out via `LLM_SPACE_ANALYTICS_DISABLED=1`; key repointable via `LLM_SPACE_POSTHOG_KEY`.
- **User opt-out**: toggle in Settings › General, persisted and honored at runtime (client is torn down on disable); disclosed on the first-run onboarding screen with a "Manage in settings" link.
- **Documented**: `TELEMETRY.md` lists every event, property, and opt-out path; `shared/analytics.ts` is the typed source of truth.

## Events

Every event carries anonymous common properties (`appVersion` from `electrobun.config.ts`, `platform`, `arch`), plus:

- `app_opened` (`isFirstOpen`)
- `thread_run` (scrubbed provider/model, `outcome`, `durationMs`, message/tool counts, `hasSystemPrompt`)
- `provider_added`, `mcp_server_added`, `settings_opened`, `onboarding_choice`

## Design

- `Analytics` singleton owns `settings/analytics.json` following the `SearchSettingsManager` load-and-seed pattern (install id + opt-out preference + `isFirstRun`).
- `captureAnalyticsEvent` is a genuine fire-and-forget RPC message (mirrors `abortStreamThread` / `executeCommand`), not a `Command`.
- `thread_run` is captured in `runStreamThread`'s `finally` - the single seam that sees every terminal outcome - keeping core (`streamAgent`) free of desktop egress concerns.
- `settings_opened` fires once per open transition via an effect on the `settingsOpen` state, so every current and future opener (menu, palette, shortcut) is counted exactly once.
- Flush-on-quit hooks Electrobun's `app.on("before-quit")` (the event GUI quits and Electrobun's own signal handlers actually emit); the whole capture path, including client construction, is wrapped so telemetry can never throw into callers.

## Verification

- `tsc --noEmit` + `eslint` clean.
- Direct PostHog EU ingestion returns `HTTP 200 {"status":"Ok"}`; the real `posthog-node` client flushes + shuts down cleanly.
- Toggle smoke-tested: default on; disable -> `capture` is a silent no-op; both `enabled: true` and `enabled: false` persist across process restarts.
- Opt-out resilience smoke-tested in an isolated `LLM_SPACE_ROOT`: a partial `{"enabled": false}` file keeps the opt-out and only re-mints the id.

## Follow-ups

- `error_kind` coarse classification (auth/network/provider) on failed runs - needs an error taxonomy across pi-ai providers.
- The baked-in default `POSTHOG_KEY` is a write-only client-side key (safe to ship). Forks: repoint via `LLM_SPACE_POSTHOG_KEY` (see `TELEMETRY.md`).
