### PR TITLE
[react-doctor] fix repo lint gate: drop unnecessary CSSProperties assertion

### DIFF
--- a/apps/desktop/src/components/thread-playground/message/message-list-view.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-view.tsx
@@ -13,7 +13,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
 } from "react";
 
 import { cn } from "@/lib/utils";
@@ -179,7 +178,7 @@ function DroppableMessageList({
                 // to size the placeholder and compute drag displacement — a
                 // `gap` is invisible to it and offsets every item mid-drag.
                 className="mb-3.5"
-                style={style as CSSProperties}
+                style={style}
               >
                 <MessageListItem
                   message={message}


### PR DESCRIPTION
## Issue (Priority 0 — red repo lint gate)

`bun run lint:check` fails on a **clean install / CI** with a pre-existing error unrelated to any react-doctor diagnostic:

```
apps/desktop/src/components/thread-playground/message/message-list-view.tsx
  182:24  error  This assertion is unnecessary since the receiver accepts the original type of the expression  @typescript-eslint/no-unnecessary-type-assertion
```

`@hello-pangea/dnd`'s `draggableProps.style` is already assignable to the `<div>`'s `style` prop, so the `as CSSProperties` cast is redundant. This red gate blocks CI and the react-doctor loop's verification step for every future fix.

> Note: it only surfaces on a fresh `bun install`; a stale local `node_modules` can mask it, which is why it hadn't been caught interactively.

## Fix

- Drop the `as CSSProperties` cast at `message-list-view.tsx:182`.
- Remove the now-unused `type CSSProperties` React import.

One issue, one file, minimal change.

## Verification (in isolated worktree off `origin/main`, fresh `bun install`)

- `bun run lint:check` — **green (exit 0)**, previously red.
- `apps/desktop` `tsc --noEmit` — **clean**.
- `packages/core` `tsc --noEmit` — **clean**.
- react-doctor score **unchanged (0)**: removing a cast + unused import adds no react-doctor diagnostics, so no regression.