### PR TITLE
[react-doctor] Fix no-adjust-state-on-prop-change in tool-editor-dialog

### DIFF
--- a/apps/desktop/src/components/thread-playground/tool/tool-editor-dialog.tsx
+++ b/apps/desktop/src/components/thread-playground/tool/tool-editor-dialog.tsx
@@ -45,6 +45,22 @@ export function ToolEditorDialog({
   const threadModel = useThreadStore((s) => s.thread.model);
   const [text, setText] = useState("");
   const [originalName, setOriginalName] = useState<string | null>(null);
+  // Track the last (open, tool) we initialized from so we can reinitialize
+  // during render instead of in an effect.
+  const [prevOpen, setPrevOpen] = useState(false);
+  const [prevTool, setPrevTool] = useState(tool);
+
+  // Reinitialize the editor when the dialog opens or the edited tool changes.
+  // Adjusting during render (not via useEffect) avoids a stale frame between
+  // the two commits. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (open !== prevOpen || tool !== prevTool) {
+    setPrevOpen(open);
+    setPrevTool(tool);
+    if (open) {
+      setOriginalName(tool ? tool.name : null);
+      setText(JSON.stringify(tool ?? DEFAULT_TOOL, null, 2));
+    }
+  }
 
   const {
     text: generated,
@@ -90,19 +106,6 @@ export function ToolEditorDialog({
       userPrompt: `<user-input>\n${prompt}\n</user-input>`,
     });
   };
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    if (tool) {
-      setOriginalName(tool.name);
-      setText(JSON.stringify(tool, null, 2));
-    } else {
-      setOriginalName(null);
-      setText(JSON.stringify(DEFAULT_TOOL, null, 2));
-    }
-  }, [open, tool]);
 
   const handleSave = () => {
     let parsed: FunctionTool;


### PR DESCRIPTION
## Issue
`no-adjust-state-on-prop-change` (severity **error**, category Bugs) at `apps/desktop/src/components/thread-playground/tool/tool-editor-dialog.tsx`.

The dialog reset `originalName`/`text` inside a `useEffect` keyed on `(open, tool)`. Because the sync runs after commit, users briefly see a stale value between the two renders. react-doctor's guidance: *"Adjust the state inline during render with a `prev`-prop comparison."* ([React docs](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes))

## Fix
Replace the effect with the React-recommended render-time `prev`-prop comparison. `prevOpen` initializes to `false` (the dialog always mounts closed via `dialogOpen`), so the reset fires exactly when the dialog opens or the edited tool identity changes - behaviorally identical to the old effect, minus the stale frame. One file touched; no types/casts/deps changed.

## Verification (no test framework in this repo)
- **Worktree (frozen install):** `tsc --noEmit` clean for the changed file; react-doctor re-scan: the 2 `tool-editor-dialog` errors -> **0**, zero new diagnostics.
- **Owner-checkout cross-check:** applied read-only, `tsc --noEmit` delta vs clean baseline = **0** (pre-existing `clip-filepaths`/unused-var errors are unrelated stale-install noise in other files), then reverted.

## Score
Health score **51 -> 51** (held). Raw error diagnostics **12 -> 8** (this pattern is double-counted across two tsconfig projects; 2 real errors fixed).