### PR TITLE
[react-doctor] Fix no-adjust-state-on-prop-change in run-evaluation-dialog

### DIFF
--- a/apps/desktop/src/components/thread-playground/run-evaluation-dialog.tsx
+++ b/apps/desktop/src/components/thread-playground/run-evaluation-dialog.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon, CheckIcon, EyeIcon, SaveIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { format } from "timeago.js";
 
@@ -62,15 +62,21 @@ export function RunEvaluationDialog({
   const [note, setNote] = useState("");
   const [inspectingRun, setInspectingRun] = useState<RunSnapshot | null>(null);
 
-  useEffect(() => {
-    if (!open) {
-      setInspectingRun(null);
-      return;
-    }
+  const [prevOpen, setPrevOpen] = useState(false);
+  const [prevEvaluation, setPrevEvaluation] = useState(evaluation);
+
+  // Reinitialize the dialog when it opens or the evaluation changes. Adjusting
+  // during render (not via useEffect) avoids a stale frame between the two
+  // commits. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  if (open !== prevOpen || evaluation !== prevEvaluation) {
+    setPrevOpen(open);
+    setPrevEvaluation(evaluation);
     setInspectingRun(null);
-    setVerdict(evaluation?.verdict ?? null);
-    setNote(evaluation?.note ?? "");
-  }, [evaluation?.id, evaluation?.note, evaluation?.verdict, open]);
+    if (open) {
+      setVerdict(evaluation?.verdict ?? null);
+      setNote(evaluation?.note ?? "");
+    }
+  }
 
   const title = useMemo(() => {
     if (!leftRun || !rightRun) {


### PR DESCRIPTION
## Issue
`react-doctor` — `no-adjust-state-on-prop-change` (Bugs, **error** severity) in `run-evaluation-dialog.tsx:67,70`.

The dialog reset its form state (`verdict`, `note`, `inspectingRun`) inside a `useEffect` keyed on `open`/`evaluation`. Because effects run *after* commit, users briefly see a stale frame between the two commits whenever the dialog opens or the compared evaluation changes.

## Fix
Replace the reset-in-`useEffect` with the React-canonical render-time `prev`-prop comparison, mirroring the pattern already landed for `tool-editor-dialog.tsx` (PR #23):

- Track `prevOpen` / `prevEvaluation` in state.
- When `open` or `evaluation` changes, reset during render so the state reinitializes in the *same* commit — no stale frame.
- `evaluation` is a reference-stable `useMemo` in the parent (`run-history-list-view.tsx`), so reference comparison is equivalent to the old field-level deps.

Behavior is preserved exactly: on close, `inspectingRun` clears; on open, `verdict`/`note` re-sync from the saved evaluation.

## Verification
- **Worktree (frozen install), `apps/desktop` `tsc --noEmit`:** changed file clean; delta vs clean baseline = 0.
- **Re-scan:** `no-adjust-state-on-prop-change` on this file **2 → 0**; health score **51 → 52**; total diagnostics 639 → 633; **zero new diagnostics**.
- **Owner-checkout cross-check:** applied read-only, `tsc` delta vs clean baseline = **0** (pre-existing unrelated `clip-filepaths` / unused-var errors present with or without the fix), then reverted — working tree clean.

No test framework in this repo (per AGENTS.md); gate is `tsc` + re-scan.
