### PR TITLE
[react-doctor] Use flatMap over map().filter(Boolean) in trace-manager

### DIFF
--- a/apps/desktop/src/bun/traces/trace-manager.ts
+++ b/apps/desktop/src/bun/traces/trace-manager.ts
@@ -1312,7 +1312,10 @@ function _aggregateRowsUsage(
   rows: LangfuseObservation[]
 ): ModelUsage | undefined {
   return _aggregateUsages(
-    rows.map(_usageFromRow).filter(Boolean) as ModelUsage[]
+    rows.flatMap((row) => {
+      const usage = _usageFromRow(row);
+      return usage ? [usage] : [];
+    })
   );
 }
 
@@ -1553,15 +1556,16 @@ function _textFromValue(value: unknown): string {
   }
   if (Array.isArray(value)) {
     return value
-      .map((item) => {
+      .flatMap((item) => {
         const record = _asRecord(item);
-        return record?.text !== undefined
-          ? _textFromValue(record.text)
-          : record?.content !== undefined
-            ? _textFromValue(record.content)
-            : _textFromValue(item);
+        const text =
+          record?.text !== undefined
+            ? _textFromValue(record.text)
+            : record?.content !== undefined
+              ? _textFromValue(record.content)
+              : _textFromValue(item);
+        return text ? [text] : [];
       })
-      .filter(Boolean)
       .join("\n");
   }
   const record = _asRecord(value);
@@ -1576,8 +1580,7 @@ function _textFromValue(value: unknown): string {
 
 function _messageText(content: Message["content"]): string {
   return content
-    .map((item) => (item.type === "text" ? item.text : ""))
-    .filter(Boolean)
+    .flatMap((item) => (item.type === "text" && item.text ? [item.text] : []))
     .join("\n")
     .trim();
 }


### PR DESCRIPTION
## Issue
react-doctor `js-flatmap-filter` (warning) — three `.map(...).filter(Boolean)` chains in `apps/desktop/src/bun/traces/trace-manager.ts` iterate the list twice (one pass to map, one to drop falsy). Sites: `_aggregateRowsUsage` (1315), `_textFromValue` array branch (1555), `_messageText` (1578).

## Fix
Replace each with a single `flatMap` that maps-and-drops in one pass:
- `_aggregateRowsUsage`: `rows.map(_usageFromRow).filter(Boolean) as ModelUsage[]` → `rows.flatMap(row => { const u = _usageFromRow(row); return u ? [u] : []; })`. This also **removes the now-unnecessary `as ModelUsage[]` cast** — `_usageFromRow` returns `ModelUsage | null` (a local type), and `flatMap` narrows to `ModelUsage[]` natively, so the cast is no longer needed. (Not a dependency-sensitive assertion.)
- `_textFromValue` and `_messageText`: fold the trailing `.filter(Boolean)` into the flatMap's `text ? [text] : []` return. Faithful to `Boolean` truthiness on the produced strings.

Behavior is preserved exactly. Matches the existing `flatMap(x => cond ? [x] : [])` idiom already used in this file (`_aggregateMessageUsage`).

## Verification
- **Worktree (frozen install, off `origin/main`):** `apps/desktop` `tsc --noEmit` clean on the changed file; re-scan `js-flatmap-filter` 18→12 (all 6 raw sites in this file resolved, double-counted across two tsconfig projects), total 639→633, **zero new diagnostics**, score held **52**.
- **Owner-checkout cross-check:** applied read-only, `apps/desktop` `tsc` delta vs clean baseline = **0** (only pre-existing unrelated errors: `clip-filepaths` missing, `tool-call-list-item.tsx:52` unused var), then reverted; tree clean.

## Score
Before: **52 / Critical** — After: **52** (unchanged; total diagnostics 639 → 633).