### PR TITLE
Fix audit findings

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "start": "vite build && electrobun dev",
     "dev": "electrobun dev --watch",
-    "dev:hmr": "concurrently \"bun run hmr\" \"bun run start\"",
+    "dev:hmr": "concurrently --kill-others-on-fail \"bun run hmr\" \"bun run start\"",
     "dev:cef": "LLM_SPACE_DESKTOP_RENDERER=cef LLM_SPACE_DESKTOP_CDP_PORT=${LLM_SPACE_DESKTOP_CDP_PORT:-9333} bun run dev:hmr",
-    "hmr": "vite --port 5173",
+    "hmr": "vite --host 127.0.0.1 --strictPort --port ${LLM_SPACE_DESKTOP_HMR_PORT:-5173}",
     "build:canary": "vite build && electrobun build --env=canary"
   },
   "dependencies": {

--- a/apps/desktop/src/bun/app/dev-server-url.test.ts
+++ b/apps/desktop/src/bun/app/dev-server-url.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+import { getDevServerUrl } from "./dev-server-url";
+
+describe("getDevServerUrl", () => {
+  test("matches the Vite HMR loopback host", () => {
+    expect(getDevServerUrl(undefined)).toBe("http://127.0.0.1:5173");
+    expect(getDevServerUrl("5180")).toBe("http://127.0.0.1:5180");
+  });
+});

--- a/apps/desktop/src/bun/app/dev-server-url.ts
+++ b/apps/desktop/src/bun/app/dev-server-url.ts
@@ -1,0 +1,16 @@
+const DEFAULT_DEV_SERVER_PORT = 5173;
+const DEV_SERVER_HOST = "127.0.0.1";
+
+export function getDevServerUrl(portValue: string | undefined): string {
+  return `http://${DEV_SERVER_HOST}:${_getDevServerPort(portValue)}`;
+}
+
+function _getDevServerPort(value: string | undefined): number {
+  if (!value) {
+    return DEFAULT_DEV_SERVER_PORT;
+  }
+  const port = Number(value);
+  return Number.isInteger(port) && port > 0 && port <= 65535
+    ? port
+    : DEFAULT_DEV_SERVER_PORT;
+}

--- a/apps/desktop/src/bun/app/window.ts
+++ b/apps/desktop/src/bun/app/window.ts
@@ -12,8 +12,17 @@ import { mainWindowRPC } from "../rpc";
 import { registerMenuActions } from "./menu";
 import { attachWindowStates } from "./window-state";
 
-const DEV_SERVER_PORT = 5173;
+const DEV_SERVER_PORT = _getDevServerPort();
 const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}`;
+
+function _getDevServerPort(): number {
+  const value = process.env.LLM_SPACE_DESKTOP_HMR_PORT;
+  if (!value) {
+    return 5173;
+  }
+  const port = Number(value);
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : 5173;
+}
 
 // Check if Vite dev server is running for HMR
 async function getMainViewUrl(): Promise<string> {

--- a/apps/desktop/src/bun/app/window.ts
+++ b/apps/desktop/src/bun/app/window.ts
@@ -9,20 +9,11 @@ import { BrowserWindow, Updater } from "electrobun/bun";
 
 import { mainWindowRPC } from "../rpc";
 
+import { getDevServerUrl } from "./dev-server-url";
 import { registerMenuActions } from "./menu";
 import { attachWindowStates } from "./window-state";
 
-const DEV_SERVER_PORT = _getDevServerPort();
-const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}`;
-
-function _getDevServerPort(): number {
-  const value = process.env.LLM_SPACE_DESKTOP_HMR_PORT;
-  if (!value) {
-    return 5173;
-  }
-  const port = Number(value);
-  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : 5173;
-}
+const DEV_SERVER_URL = getDevServerUrl(process.env.LLM_SPACE_DESKTOP_HMR_PORT);
 
 // Check if Vite dev server is running for HMR
 async function getMainViewUrl(): Promise<string> {

--- a/apps/desktop/src/bun/mcp/mcp-manager.test.ts
+++ b/apps/desktop/src/bun/mcp/mcp-manager.test.ts
@@ -1,0 +1,27 @@
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+describe("mcpManager", () => {
+  test("recovers from a corrupt MCP settings file", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "llm-space-mcp-"));
+    const settingsDir = path.join(root, "settings");
+    await mkdir(settingsDir, { recursive: true });
+    await writeFile(path.join(settingsDir, "mcp.json"), "{bad json", "utf8");
+    process.env.LLM_SPACE_ROOT = root;
+
+    const { mcpManager } = await import("./mcp-manager");
+
+    expect(mcpManager.listServers()).toEqual([]);
+    expect(
+      JSON.parse(await readFile(path.join(settingsDir, "mcp.json"), "utf8"))
+    ).toEqual({ servers: [] });
+
+    const files = await readdir(settingsDir);
+    expect(files.some((file) => file.startsWith("mcp.json.invalid-"))).toBe(
+      true
+    );
+  });
+});

--- a/apps/desktop/src/bun/mcp/mcp-manager.ts
+++ b/apps/desktop/src/bun/mcp/mcp-manager.ts
@@ -1,8 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import { uuid } from "@llm-space/core";
-import { getSettingsDir } from "@llm-space/core/server";
+import {
+  getSettingsDir,
+  readJsonFileWithRecoverySync,
+} from "@llm-space/core/server";
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
@@ -709,7 +712,9 @@ export class McpManager {
   private _loadConfig(): McpServersConfig {
     try {
       const parsed = serversConfigSchema.parse(
-        JSON.parse(readFileSync(this._configPath, "utf8"))
+        readJsonFileWithRecoverySync<unknown>(this._configPath, {
+          servers: [],
+        })
       );
       return {
         servers: parsed.servers.map((server) => ({
@@ -731,14 +736,6 @@ export class McpManager {
         throw error;
       }
       const empty: McpServersConfig = { servers: [] };
-      if (!existsSync(this._configPath)) {
-        mkdirSync(getSettingsDir(), { recursive: true });
-        writeFileSync(
-          this._configPath,
-          `${JSON.stringify(empty, null, 2)}\n`,
-          "utf8"
-        );
-      }
       return empty;
     }
   }

--- a/apps/desktop/src/bun/models/model-manager.ts
+++ b/apps/desktop/src/bun/models/model-manager.ts
@@ -11,7 +11,10 @@ import {
   type Provider,
 } from "@earendil-works/pi-ai";
 import { ModelProviderGroup, type ModelConfig } from "@llm-space/core";
-import { getSettingsDir } from "@llm-space/core/server";
+import {
+  getSettingsDir,
+  readJsonFileWithRecoverySync,
+} from "@llm-space/core/server";
 
 import {
   BUILTIN_PROVIDER_META,
@@ -572,27 +575,14 @@ export class ModelManager {
    * config on disk so the app has something to edit, and report no providers.
    */
   private _loadConfig(): ModelsConfig {
-    try {
-      const parsed = JSON.parse(
-        readFileSync(this._configPath, "utf8")
-      ) as ModelsConfig;
-      return {
-        providers: Array.isArray(parsed.providers) ? parsed.providers : [],
-        defaultModel: parsed.defaultModel,
-      };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
-      const empty: ModelsConfig = { providers: [] };
-      mkdirSync(getSettingsDir(), { recursive: true });
-      writeFileSync(
-        this._configPath,
-        `${JSON.stringify(empty, null, 2)}\n`,
-        "utf8"
-      );
-      return empty;
-    }
+    const parsed = readJsonFileWithRecoverySync<ModelsConfig>(
+      this._configPath,
+      { providers: [] }
+    );
+    return {
+      providers: Array.isArray(parsed.providers) ? parsed.providers : [],
+      defaultModel: parsed.defaultModel,
+    };
   }
 
   private async _detectProviders() {

--- a/apps/desktop/src/bun/search/search-settings-manager.ts
+++ b/apps/desktop/src/bun/search/search-settings-manager.ts
@@ -1,7 +1,10 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
-import { getSettingsDir } from "@llm-space/core/server";
+import {
+  getSettingsDir,
+  readJsonFileWithRecoverySync,
+} from "@llm-space/core/server";
 
 import {
   DEFAULT_SEARCH_SETTINGS,
@@ -51,24 +54,11 @@ class SearchSettingsManager {
    * files stay valid. Seeds the default config on disk when the file is absent.
    */
   private _loadConfig(): SearchSettings {
-    try {
-      const parsed = JSON.parse(
-        readFileSync(this._configPath, "utf8")
-      ) as Partial<SearchSettings>;
-      return this._normalize(parsed);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
-      const defaults = { ...DEFAULT_SEARCH_SETTINGS };
-      mkdirSync(getSettingsDir(), { recursive: true });
-      writeFileSync(
-        this._configPath,
-        `${JSON.stringify(defaults, null, 2)}\n`,
-        "utf8"
-      );
-      return defaults;
-    }
+    const parsed = readJsonFileWithRecoverySync<Partial<SearchSettings>>(
+      this._configPath,
+      { ...DEFAULT_SEARCH_SETTINGS }
+    );
+    return this._normalize(parsed);
   }
 
   private _normalize(input: Partial<SearchSettings>): SearchSettings {

--- a/apps/desktop/src/bun/skills/skills-manager.test.ts
+++ b/apps/desktop/src/bun/skills/skills-manager.test.ts
@@ -1,0 +1,27 @@
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+describe("skillsManager", () => {
+  test("recovers from a corrupt skills settings file", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "llm-space-skills-"));
+    const settingsDir = path.join(root, "settings");
+    await mkdir(settingsDir, { recursive: true });
+    await writeFile(path.join(settingsDir, "skills.json"), "{bad json", "utf8");
+    process.env.LLM_SPACE_ROOT = root;
+
+    const { skillsManager } = await import("./skills-manager");
+
+    expect(skillsManager.getConfig().discoveryPaths.length).toBeGreaterThan(0);
+    expect(JSON.parse(await readFile(path.join(settingsDir, "skills.json"), "utf8"))).toEqual(
+      skillsManager.getConfig()
+    );
+
+    const files = await readdir(settingsDir);
+    expect(files.some((file) => file.startsWith("skills.json.invalid-"))).toBe(
+      true
+    );
+  });
+});

--- a/apps/desktop/src/bun/skills/skills-manager.ts
+++ b/apps/desktop/src/bun/skills/skills-manager.ts
@@ -7,7 +7,10 @@ import {
 import os from "node:os";
 import path from "node:path";
 
-import { getSettingsDir } from "@llm-space/core/server";
+import {
+  getSettingsDir,
+  readJsonFileWithRecoverySync,
+} from "@llm-space/core/server";
 import matter from "gray-matter";
 import { isValidSkillName, validateSkillFrontmatter } from "skills-handler";
 
@@ -258,24 +261,11 @@ class SkillsManager {
    * missing files stay valid. Seeds the default config on disk when absent.
    */
   private _loadConfig(): SkillsSettings {
-    try {
-      const parsed = JSON.parse(
-        readFileSync(this._configPath, "utf8")
-      ) as Partial<SkillsSettings>;
-      return this._normalize(parsed);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
-      const defaults = this._defaultSettings();
-      mkdirSync(getSettingsDir(), { recursive: true });
-      writeFileSync(
-        this._configPath,
-        `${JSON.stringify(defaults, null, 2)}\n`,
-        "utf8"
-      );
-      return defaults;
-    }
+    const parsed = readJsonFileWithRecoverySync<Partial<SkillsSettings>>(
+      this._configPath,
+      this._defaultSettings()
+    );
+    return this._normalize(parsed);
   }
 
   private _normalize(input: Partial<SkillsSettings>): SkillsSettings {

--- a/apps/desktop/src/components/thread-playground/message/message-list-view.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-view.tsx
@@ -13,7 +13,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
 } from "react";
 
 import { cn } from "@/lib/utils";
@@ -179,7 +178,7 @@ function DroppableMessageList({
                 // to size the placeholder and compute drag displacement — a
                 // `gap` is invisible to it and offsets every item mid-drag.
                 className="mb-3.5"
-                style={style as CSSProperties}
+                style={style}
               >
                 <MessageListItem
                   message={message}

--- a/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
@@ -26,7 +26,7 @@ import { Input } from "../../ui/input";
 import { useThreadStoreActions } from "../stores";
 
 import { ToolCallInputView } from "./tool-call-input-view";
-import { getToolCallOutputText, getToolCallStatus } from "./tool-call-status";
+import { getToolCallOutputText } from "./tool-call-status";
 import { useToolCallRunner } from "./use-tool-call-runner";
 
 function _ToolCallListItem({
@@ -49,7 +49,6 @@ function _ToolCallListItem({
   const [calling, setCalling] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const outputText = useMemo(() => getToolCallOutputText(toolCall), [toolCall]);
-  const toolCallStatus = useMemo(() => getToolCallStatus(toolCall), [toolCall]);
   const isError = toolCall.output?.isError ?? false;
   const handleOutputChange = useCallback(
     (value: string) => {

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "llm-space",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.2",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "@earendil-works/pi-agent-core": "catalog:",
+        "@earendil-works/pi-ai": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:",
         "typebox": "catalog:",
       },
       "devDependencies": {
@@ -108,8 +108,8 @@
   "catalog": {
     "@earendil-works/pi-agent-core": "^0.80.3",
     "@earendil-works/pi-ai": "^0.80.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "typebox": "^1.2.8",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "llm-space",
   "private": true,
+  "type": "module",
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "catalog": {
     "@earendil-works/pi-ai": "^0.80.3",
     "@earendil-works/pi-agent-core": "^0.80.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "typebox": "^1.2.8"
   },
   "devDependencies": {
@@ -43,10 +43,10 @@
   },
   "packageManager": "bun",
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.80.3",
-    "@earendil-works/pi-ai": "^0.80.2",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "@earendil-works/pi-agent-core": "catalog:",
+    "@earendil-works/pi-ai": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "typebox": "catalog:"
   }
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent/stream";
 export * from "./paths";
+export * from "./settings-json";
 export * from "./window-state";
 export * from "./storage";

--- a/packages/core/src/server/settings-json.test.ts
+++ b/packages/core/src/server/settings-json.test.ts
@@ -1,0 +1,27 @@
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { readJsonFileWithRecovery } from "./settings-json";
+
+describe("readJsonFileWithRecovery", () => {
+  test("backs up invalid JSON and rewrites defaults", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "llm-space-settings-"));
+    const filePath = path.join(dir, "models.json");
+    await writeFile(filePath, "{not json", "utf8");
+
+    const result = await readJsonFileWithRecovery(filePath, { providers: [] });
+
+    expect(result).toEqual({ providers: [] });
+    expect(JSON.parse(await readFile(filePath, "utf8"))).toEqual({
+      providers: [],
+    });
+
+    const files = await readdir(dir);
+    const backup = files.find((file) => file.startsWith("models.json.invalid-"));
+    expect(backup).toBeDefined();
+    expect(await readFile(path.join(dir, backup!), "utf8")).toBe("{not json");
+  });
+});

--- a/packages/core/src/server/settings-json.ts
+++ b/packages/core/src/server/settings-json.ts
@@ -1,0 +1,82 @@
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+  type PathLike,
+} from "node:fs";
+import * as fs from "node:fs/promises";
+import path from "node:path";
+
+export async function readJsonFileWithRecovery<T>(
+  filePath: string,
+  fallback: T
+): Promise<T> {
+  try {
+    const text = await fs.readFile(filePath, "utf8");
+    return JSON.parse(text) as T;
+  } catch (error) {
+    if (_isMissingFile(error)) {
+      await _writeJsonFile(filePath, fallback);
+      return fallback;
+    }
+    if (error instanceof SyntaxError) {
+      await _backupInvalidFile(filePath);
+      await _writeJsonFile(filePath, fallback);
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+export function readJsonFileWithRecoverySync<T>(
+  filePath: string,
+  fallback: T
+): T {
+  try {
+    const text = readFileSync(filePath, "utf8");
+    return JSON.parse(text) as T;
+  } catch (error) {
+    if (_isMissingFile(error)) {
+      _writeJsonFileSync(filePath, fallback);
+      return fallback;
+    }
+    if (error instanceof SyntaxError) {
+      _backupInvalidFileSync(filePath);
+      _writeJsonFileSync(filePath, fallback);
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+async function _writeJsonFile<T>(filePath: string, data: T): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function _writeJsonFileSync<T>(filePath: string, data: T): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function _backupInvalidFile(filePath: string): Promise<void> {
+  await fs.rename(filePath, _invalidBackupPath(filePath));
+}
+
+function _backupInvalidFileSync(filePath: string): void {
+  renameSync(filePath, _invalidBackupPath(filePath));
+}
+
+function _invalidBackupPath(filePath: string): PathLike {
+  return `${filePath}.invalid-${Date.now()}`;
+}
+
+function _isMissingFile(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}

--- a/packages/core/src/server/storage/local/file-system.test.ts
+++ b/packages/core/src/server/storage/local/file-system.test.ts
@@ -1,0 +1,27 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { LocalFileSystem } from "./file-system";
+
+describe("LocalFileSystem", () => {
+  test("reports corrupt thread JSON with the thread path", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "llm-space-workspace-"));
+    await writeFile(path.join(root, "broken.json"), "{bad json", "utf8");
+    const fs = new LocalFileSystem(root);
+
+    let error: unknown;
+    try {
+      await fs.read("broken.json");
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Thread file "broken.json" contains invalid JSON.'
+    );
+  });
+});

--- a/packages/core/src/server/storage/local/file-system.ts
+++ b/packages/core/src/server/storage/local/file-system.ts
@@ -82,7 +82,16 @@ export class LocalFileSystem implements FileSystem, ThreadStorage {
 
   async read(p: string): Promise<Thread> {
     const text = await fs.readFile(this._resolve(p), "utf8");
-    return normalizeThread(JSON.parse(text) as Thread);
+    try {
+      return normalizeThread(JSON.parse(text) as Thread);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(`Thread file "${p}" contains invalid JSON.`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
   }
 
   async write(p: string, thread: Thread): Promise<void> {

--- a/packages/core/src/server/window-state/index.ts
+++ b/packages/core/src/server/window-state/index.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 
 import { getSettingsDir, getWindowStatePath } from "../paths";
+import { readJsonFileWithRecovery } from "../settings-json";
 
 export interface WindowFrame {
   x: number;
@@ -56,15 +57,7 @@ export function getWindowZoom(state: WindowState): number | undefined {
 }
 
 export async function loadWindowState(): Promise<WindowState> {
-  try {
-    const text = await fs.readFile(getWindowStatePath(), "utf8");
-    return JSON.parse(text) as WindowState;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return {};
-    }
-    throw error;
-  }
+  return readJsonFileWithRecovery(getWindowStatePath(), {});
 }
 
 async function writeWindowState(next: WindowState): Promise<void> {


### PR DESCRIPTION
## Summary
- Recover corrupted local settings JSON by backing up invalid files and rewriting defaults
- Harden model/search/skills/MCP/window settings loading paths
- Improve corrupt thread JSON errors and clean up lint/package drift

## Example failure case
A real failure this prevents: while the app is saving `settings/models.json` after a provider/API-key edit, the process or machine is interrupted and the file is left half-written, for example ending at `{"providers":[{"id":"openai",`. On the next launch, plain `JSON.parse()` would throw and model settings could fail to load or block startup.

With this change, the invalid file is preserved as `models.json.invalid-<timestamp>`, a default config is rewritten, and the app can continue opening instead of crashing. The same recovery behavior applies to local settings such as `mcp.json`, `skills.json`, `search.json`, and `window.json`.

## Validation
- bun run lint:check
- bun test packages/core/src/server/storage/local/file-system.test.ts apps/desktop/src/bun/mcp/mcp-manager.test.ts apps/desktop/src/bun/skills/skills-manager.test.ts packages/core/src/server/settings-json.test.ts
- bunx --bun tsc --noEmit -p packages/core/tsconfig.json
- bunx --bun tsc --noEmit -p apps/desktop/tsconfig.json
