### PR TITLE
[react-doctor] Fix label-has-associated-control in models-page

### DIFF
--- a/apps/desktop/src/components/settings/models-page.tsx
+++ b/apps/desktop/src/components/settings/models-page.tsx
@@ -615,7 +615,7 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
           {!isBuiltin && (
             <>
               <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium">Name</label>
+                <span className="text-sm font-medium">Name</span>
                 <Input
                   defaultValue={provider.name}
                   placeholder="Custom provider"
@@ -625,7 +625,7 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
               </div>
 
               <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium">API type</label>
+                <span className="text-sm font-medium">API type</span>
                 <Select
                   value={apiValue}
                   onValueChange={(value) =>
@@ -652,7 +652,7 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
 
           {!isBuiltin && (
             <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">Icon</label>
+              <span className="text-sm font-medium">Icon</span>
               <div className="flex items-center gap-2">
                 <ProviderAvatar
                   id={provider.id}
@@ -707,7 +707,7 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
           {isBuiltin ? (
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-between">
-                <label className="text-sm font-medium">Custom base URL</label>
+                <span className="text-sm font-medium">Custom base URL</span>
                 <Switch
                   aria-label={
                     baseUrlEnabled
@@ -735,7 +735,7 @@ function ProviderEditor({ provider }: { provider: ModelProviderGroup | null }) {
             </div>
           ) : (
             <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">Base URL</label>
+              <span className="text-sm font-medium">Base URL</span>
               <Input
                 required
                 defaultValue={provider.baseUrl ?? ""}
@@ -906,7 +906,7 @@ function ProviderHeadersEditor({ provider }: { provider: ModelProviderGroup }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">Custom headers</label>
+      <span className="text-sm font-medium">Custom headers</span>
       {rows.map((row, index) => (
         <div key={index} className="flex items-center gap-2">
           <Input


### PR DESCRIPTION
## Issue

react-doctor `label-has-associated-control` (Accessibility) — 6 sites in
`apps/desktop/src/components/settings/models-page.tsx`
(lines 618, 628, 655, 710, 738, 909).

Each `<label className="text-sm font-medium">…</label>` is a purely visual
caption: it has **no `htmlFor`** and does **not** wrap its control (the input is
a sibling, sometimes with an intervening wrapper). Because the control in every
case already carries its own `aria-label`, the `<label>` element is redundant as
a form label and, per the diagnostic, misleading — screen readers announce a
label tied to no input.

## Fix

Convert the six visual captions from `<label>` to `<span>`, preserving the exact
`className` (`text-sm font-medium`) and text. `<span>` and `<label>` are both
inline by default and layout is fully driven by the class, so there is **zero
visual or behavioral change** (an unassociated `<label>` already does nothing on
click). Every field keeps its accessible name via the existing input `aria-label`.

Uniform treatment across all 6 sites (which mix plain `<Input>`, Radix `<Select>`,
and Radix `<Switch>` controls) — no per-control `htmlFor`/`id` plumbing needed.

## Verification (two-env)

- **Worktree** (frozen install off `origin/main` 407da70): `apps/desktop`
  `tsc --noEmit` clean; re-scan `label-has-associated-control` **22 → 10** (all 6
  raw models-page sites gone, double-counted across the two tsconfig projects),
  total **711 → 699**, **zero new diagnostics**, score held **52**.
- **Owner cross-check**: applied read-only in the live checkout — `tsc` delta = **0**
  vs clean baseline (only pre-existing `clip-filepaths` / unused-var noise), then
  reverted; tree clean.

**Before/after health score: 52 → 52** (score is pinned by unrelated warning
volume; genuine diagnostics drop by the 6 fixed sites).
