### PR TITLE
[react-doctor] Fix label-has-associated-control in mcp-page

### DIFF
--- a/apps/desktop/src/components/settings/mcp-page.tsx
+++ b/apps/desktop/src/components/settings/mcp-page.tsx
@@ -867,7 +867,7 @@ function ToolSummaryRow({ tool }: { tool: McpToolSummary }) {
 function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">{label}</label>
+      <span className="text-sm font-medium">{label}</span>
       {children}
     </div>
   );
@@ -895,7 +895,7 @@ function KeyValueRows({
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium">{label}</label>
+      <span className="text-sm font-medium">{label}</span>
       {rows.map((row, index) => (
         <div key={index} className="flex items-center gap-2">
           <Input


### PR DESCRIPTION
## Issue
`label-has-associated-control` (a11y, warning) at `apps/desktop/src/components/settings/mcp-page.tsx` — the `Field` and `KeyValueRows` wrapper components each rendered a `<label className="text-sm font-medium">{label}</label>` caption with no `htmlFor` that did not wrap its control. Screen readers announce a `<label>` tied to no input — redundant and misleading.

## Fix
Every control rendered inside these wrappers already provides its own `aria-label`:
- `Field` children: MCP server name, transport, command, args, working directory, URL (all 6 usages verified).
- `KeyValueRows` inputs: `"<label> <n> name"` / `"<label> <n> value"`.

So the `<label>` was a redundant visual caption. Converted both to `<span>` (same `className`, same layout) — zero visual/behavior change, accessible names preserved. Matches the existing `<span className="text-sm font-medium">Tools</span>` caption already in this file, continuing #30.

## Verification (react-doctor 0.7.4)
- **Worktree (frozen install off `origin/main` eda3046):** `apps/desktop` typechecks with no new errors; re-scan `label-has-associated-control` **10 → 6** (both mcp-page sites gone, double-counted across the 2 tsconfig projects), total **701 → 697**, zero new diagnostics, score held **53**.
- **Owner-checkout cross-check:** applied the same diff read-only in the live checkout, `apps/desktop` `tsc --noEmit` **delta = 0** vs clean, then reverted (tree clean).

Health score **53** unchanged; progress metric total diagnostics **701 → 697**.