### PR TITLE
perf(streaming): cut per-flush cost of rendering streamed replies

### DIFF
--- a/apps/desktop/src/components/code-editor/editor.tsx
+++ b/apps/desktop/src/components/code-editor/editor.tsx
@@ -1,5 +1,6 @@
 import { type Extension } from "@codemirror/state";
 import CodeMirror, {
+  ExternalChange,
   type BasicSetupOptions,
   type ReactCodeMirrorRef,
 } from "@uiw/react-codemirror";
@@ -56,6 +57,12 @@ export interface CodeEditorProps {
    */
   plain?: boolean;
   language?: "markdown" | "json";
+  /**
+   * The value is a live streaming preview: syntax highlighting is skipped
+   * (restored by whatever renders the settled value — the streamed message
+   * commits into a fresh editor) and content sniffing is pinned so mid-stream
+   * chunks can't reconfigure the editor.
+   */
   streaming?: boolean;
   value: string;
   readonly?: boolean;
@@ -102,6 +109,9 @@ function _CodeEditor(
 
   const detectLanguage = useCallback(
     (text: string): "markdown" | "json" => {
+      // While streaming, the extensions memo overrides the language to "none";
+      // this branch only pins the detection *state* so a JSON-looking chunk
+      // can't flip `detectedLanguage` (and reconfigure the editor) mid-stream.
       if (streaming) {
         return "markdown";
       }
@@ -140,10 +150,31 @@ function _CodeEditor(
   );
 
   useEffect(() => {
-    if (!isFocusedRef.current || readonly) {
-      setDraftValue(value, true);
-      committedRef.current = value;
+    if (isFocusedRef.current && !readonly) {
+      return;
     }
+    // Once the view exists, dispatch external values directly instead of via
+    // the `value` prop — react-codemirror applies prop updates as a full-
+    // document replace (reparse + native selection resync), which saturates
+    // the main thread on streamed replies growing every frame. `ExternalChange`
+    // stops react-codemirror from echoing the change back through `onChange`,
+    // and the untouched `syncedValue` now only seeds the initial document.
+    const view = cmRef.current?.view;
+    if (!view) {
+      setDraftValue(value, true);
+    } else if (value !== draftRef.current) {
+      const previous = draftRef.current;
+      const docLength = view.state.doc.length;
+      view.dispatch({
+        changes:
+          docLength === previous.length && value.startsWith(previous)
+            ? { from: docLength, insert: value.slice(previous.length) }
+            : { from: 0, to: docLength, insert: value },
+        annotations: ExternalChange.of(true),
+      });
+      setDraftValue(value);
+    }
+    committedRef.current = value;
   }, [value, readonly, setDraftValue]);
 
   const commit = useCallback(() => {
@@ -231,9 +262,17 @@ function _CodeEditor(
     [commit, onKeyDown]
   );
 
+  // While streaming, skip the language extension entirely: highlighting a
+  // growing document re-parses the trailing block on every appended chunk
+  // (O(paragraph) per frame — a major source of long frames), for colors the
+  // reader barely sees mid-stream. Same editor, same layout; the committed
+  // message (or the first post-stream update) brings the highlighting back.
   const extensions = useMemo(
-    () => [...createExtensions(detectedLanguage), ...(extraExtensions ?? [])],
-    [detectedLanguage, extraExtensions]
+    () => [
+      ...createExtensions(streaming ? "none" : detectedLanguage),
+      ...(extraExtensions ?? []),
+    ],
+    [detectedLanguage, extraExtensions, streaming]
   );
   return (
     <div

--- a/apps/desktop/src/components/code-editor/extensions.ts
+++ b/apps/desktop/src/components/code-editor/extensions.ts
@@ -4,9 +4,11 @@ import { languages } from "@codemirror/language-data";
 import { type Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 
-export function createExtensions(language: "markdown" | "json") {
+export function createExtensions(language: "markdown" | "json" | "none") {
   const extensions: Extension[] = [EditorView.lineWrapping];
   switch (language) {
+    case "none":
+      break;
     case "json":
       extensions.push(json());
       break;

--- a/apps/desktop/src/components/thread-playground/stores/thread-store.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-store.ts
@@ -35,6 +35,9 @@ import { createStore, useStore, type StoreApi } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { useShallow } from "zustand/shallow";
 
+import { createFrameThrottle } from "@/lib/frame-throttle";
+
+import { PREVIEW_THROTTLE_MS } from "../streaming-preview";
 import { aggregateMessageUsage } from "../token-usage";
 import {
   createMessagePromptVariablePlaceKey,
@@ -941,38 +944,18 @@ export function createThreadStore(
           // A failed run is never recorded in the run history.
           let failed = false;
 
-          // Coalesce live-preview updates to at most one per animation frame.
-          // A fast stream delivers a burst of events that the transport drains
-          // synchronously; calling set() on every one fires a synchronous
-          // useSyncExternalStore re-render per event within a single microtask
-          // chain, which never crosses the task boundary React uses to reset
-          // its nested-update counter — tripping "Maximum update depth
-          // exceeded". Batching by frame also lets the UI paint between chunks.
-          const canRaf = typeof requestAnimationFrame === "function";
-          let previewFrame: number | null = null;
-          const flushPreview = () => {
-            previewFrame = null;
-            if (!isActiveRun()) {
-              return;
-            }
-            set({ streamingMessage });
-          };
-          const schedulePreview = () => {
-            if (!isActiveRun()) {
-              return;
-            }
-            if (!canRaf) {
+          // Throttle live-preview updates (frame-aligned, at most one per
+          // PREVIEW_THROTTLE_MS) — see createFrameThrottle for why per-event
+          // set() calls are unsafe and re-rendering the growing document per
+          // frame is too expensive.
+          const {
+            schedule: schedulePreview,
+            cancel: cancelPreview,
+          } = createFrameThrottle(() => {
+            if (isActiveRun()) {
               set({ streamingMessage });
-              return;
             }
-            previewFrame ??= requestAnimationFrame(flushPreview);
-          };
-          const cancelPreview = () => {
-            if (previewFrame !== null) {
-              cancelAnimationFrame(previewFrame);
-              previewFrame = null;
-            }
-          };
+          }, PREVIEW_THROTTLE_MS);
 
           const finalizeActiveRun = () => {
             if (!isActiveRun()) {

--- a/apps/desktop/src/components/thread-playground/streaming-preview.ts
+++ b/apps/desktop/src/components/thread-playground/streaming-preview.ts
@@ -1,0 +1,8 @@
+/**
+ * How often streaming previews repaint. Each update makes the streaming
+ * editor re-render and re-lay-out the growing document — the dominant
+ * per-update cost (especially on the WebKit renderer, which also pays a
+ * multi-frame compositor round trip per DOM commit) — so previews flush at
+ * this cadence instead of every animation frame.
+ */
+export const PREVIEW_THROTTLE_MS = 100;

--- a/apps/desktop/src/components/thread-playground/use-stream-text.ts
+++ b/apps/desktop/src/components/thread-playground/use-stream-text.ts
@@ -11,8 +11,11 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { createRpcTransport } from "@/client/rpc-transport";
+import { createFrameThrottle } from "@/lib/frame-throttle";
 
 import { useDefaultTextGenerationModel } from "../model-provider";
+
+import { PREVIEW_THROTTLE_MS } from "./streaming-preview";
 
 // One transport for the app: stream agent runs over Electrobun RPC to the bun
 // process. It multiplexes concurrent runs by internal `streamId`, so a single
@@ -109,32 +112,20 @@ export function useStreamText({
     setError(null);
     setStreaming(true);
 
-    // Coalesce text updates to at most one per animation frame: the transport
-    // drains a burst of events synchronously, and calling set() per event trips
-    // React's "Maximum update depth exceeded" (see thread-store.ts run()).
-    const canRaf = typeof requestAnimationFrame === "function";
-    let previewFrame: number | null = null;
-    let pendingText = "";
-    const flushPreview = () => {
-      previewFrame = null;
+    let streamingMessage: AssistantMessage | null = null;
+    let content: ReducedMessageContent[] = [];
+    const lastText = () => {
+      const parts = streamingMessage?.content;
+      return parts?.[parts.length - 1]?.text ?? "";
+    };
+
+    // Throttle text updates (frame-aligned, at most one per
+    // PREVIEW_THROTTLE_MS) — see createFrameThrottle.
+    const preview = createFrameThrottle(() => {
       if (controllerRef.current === controller) {
-        setText(pendingText);
+        setText(lastText());
       }
-    };
-    const schedulePreview = (next: string) => {
-      pendingText = next;
-      if (!canRaf) {
-        flushPreview();
-        return;
-      }
-      previewFrame ??= requestAnimationFrame(flushPreview);
-    };
-    const cancelPreview = () => {
-      if (previewFrame !== null && canRaf) {
-        cancelAnimationFrame(previewFrame);
-        previewFrame = null;
-      }
-    };
+    }, PREVIEW_THROTTLE_MS);
 
     const context = {
       systemPrompt,
@@ -160,8 +151,6 @@ export function useStreamText({
       },
     };
 
-    let streamingMessage: AssistantMessage | null = null;
-    let content: ReducedMessageContent[] = [];
     try {
       const response = streamThread(
         { context, model: runModel },
@@ -174,24 +163,20 @@ export function useStreamText({
         }
         streamingMessage = reduced.message;
         content = reduced.content;
-        schedulePreview(
-          streamingMessage.content[streamingMessage.content.length - 1]
-            ?.text ?? ""
-        );
+        preview.schedule();
       }
     } catch (e) {
       if (!controller.signal.aborted) {
-        cancelPreview();
+        preview.cancel();
         if (controllerRef.current === controller) {
           setError(e instanceof Error ? e.message : String(e));
         }
       }
     } finally {
-      cancelPreview();
+      preview.cancel();
       if (controllerRef.current === controller) {
         // Emit the final text directly so a dropped frame can't leave it stale.
-        const finalContent = streamingMessage?.content;
-        setText(finalContent?.[finalContent.length - 1]?.text ?? "");
+        setText(lastText());
         setStreaming(false);
         controllerRef.current = null;
       }

--- a/apps/desktop/src/lib/frame-throttle.ts
+++ b/apps/desktop/src/lib/frame-throttle.ts
@@ -1,0 +1,51 @@
+/**
+ * Run `flush` at most once per `minIntervalMs`, aligned to an animation frame.
+ * `schedule()` coalesces bursts: one flush per interval, on the first frame
+ * after the interval elapses. The frame alignment matters beyond pacing — a
+ * fast stream drains a burst of events synchronously, and flushing state per
+ * event inside one microtask chain never crosses the task boundary React uses
+ * to reset its nested-update counter, tripping "Maximum update depth
+ * exceeded".
+ */
+export function createFrameThrottle(
+  flush: () => void,
+  minIntervalMs: number
+): { schedule: () => void; cancel: () => void } {
+  let frame: number | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastFlushAt = 0;
+
+  const runFlush = () => {
+    frame = null;
+    lastFlushAt = performance.now();
+    flush();
+  };
+
+  const schedule = () => {
+    if (frame !== null || timer !== null) {
+      return;
+    }
+    const wait = minIntervalMs - (performance.now() - lastFlushAt);
+    if (wait <= 0) {
+      frame = requestAnimationFrame(runFlush);
+    } else {
+      timer = setTimeout(() => {
+        timer = null;
+        frame = requestAnimationFrame(runFlush);
+      }, wait);
+    }
+  };
+
+  const cancel = () => {
+    if (frame !== null) {
+      cancelAnimationFrame(frame);
+      frame = null;
+    }
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  return { schedule, cancel };
+}

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -5,12 +5,17 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
+  /* Compositor-only (`transform`): scaling beats animating `width`, which
+     relayouts the skeleton line every frame. The origin lives in the
+     keyframes so consumers can't forget it. */
   @keyframes skeleton-extending {
     0% {
-      width: 0%;
+      transform: scaleX(0);
+      transform-origin: left;
     }
     100% {
-      width: 90%;
+      transform: scaleX(1);
+      transform-origin: left;
     }
   }
   --animate-skeleton-extending: skeleton-extending 2s ease-in-out infinite;


### PR DESCRIPTION
## Problem

Streaming a long reply saturated the renderer main thread and dropped frame rates hard — ~30fps on CEF with a 4.5× stretched stream duration, and ~15fps on the native WebKit renderer.

## Root causes (all profiled, not guessed)

1. **react-codemirror applies every external `value` as a full-document replace.** The replace triggers a reparse plus a native selection resync whose cost grows with the reply — 66% of CPU in a profiled run (`readSelectionRange` alone was 51%), turning an 8s stream into 37s of wall time on CEF.
2. **Streaming highlight re-parses the trailing markdown block on every appended chunk** — O(paragraph) per frame.
3. **WKWebView pays a multi-frame compositor round trip per DOM commit, regardless of commit size.** Measured on real replies: per-flush JS + style/layout totals ~3ms, yet each flush frame costs 33–50ms. Flush *frequency* is therefore the only lever that matters there — unthrottled rAF flushes floor WebKit at ~15fps.
4. The streaming skeleton animated `width`, relayouting every frame.

## Changes

- `CodeEditor` dispatches external values directly into the CodeMirror view: appends just the tail when the new value provably extends the document, full-replaces on any divergence (self-healing). The `value` prop now only seeds the initial document; `ExternalChange` keeps react-codemirror's listener from echoing the change back.
- While `streaming`, the language extension is skipped ("none"); the committed message mounts a fresh editor with full highlighting, so the swap point is the existing commit lifecycle.
- Streaming previews flush at most once per 100ms, frame-aligned, via a new shared `createFrameThrottle` — replacing two hand-rolled rAF coalescers in `thread-store.ts` and `use-stream-text.ts`. The cadence knob lives in `thread-playground/streaming-preview.ts`.
- `skeleton-extending` keyframes animate `transform: scaleX` (origin baked into the keyframes) instead of `width`.

## Measurements

Mock 78KB / 1500-chunk stream, CEF, dev build:

| | before | after |
|---|---|---|
| run wall time | 36.8s | 7.1s |
| avg / p90 frame | 33ms / 50ms | 17ms / 17ms |
| frames >50ms | 105 | 4 |
| full-doc replace subtree | 24.9s | 0ms |
| streaming markdown parse | 3.7s | 0ms |

On WKWebView with real replies, streaming now holds ~50fps (10 flushes/s × one ~2–3 vsync compositor commit each — the residual is engine pipeline cost, not app work; verified by direct measurement of dispatch, React commit, and forced style/layout, all ≤3ms combined).

## Ruled out along the way (measured, for posterity)

RPC transport encryption/decoding, CodeMirror viewport virtualization, Radix ScrollArea `display: table`, `box-shadow` repaints, ShineBorder's gradient animation, and long-unbroken-line layout (the last one is real but only triggered by pathological single-line content, not typical replies).