### PR TITLE
[react-doctor] Fix label-has-associated-control in api-key-field

### DIFF
--- a/apps/desktop/src/components/settings/api-key-field.tsx
+++ b/apps/desktop/src/components/settings/api-key-field.tsx
@@ -32,7 +32,7 @@ export function ApiKeyField({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <label className="text-sm font-medium">{label}</label>
+        <span className="text-sm font-medium">{label}</span>
         {getKeyUrl ? (
           <Link
             href={getKeyUrl}


### PR DESCRIPTION
## Issue
`react-doctor` **label-has-associated-control** (warning, a11y) in `apps/desktop/src/components/settings/api-key-field.tsx:35`.

The `ApiKeyField` caption renders `<label className="text-sm font-medium">{label}</label>` with **no `htmlFor`** and it does not wrap its control. Screen readers announce a `<label>` tied to no input, which is misleading.

## Fix
The `Input` in this component already carries its own accessible name — `aria-label={ariaLabel ?? label}` (line 50). So the `<label>` element is a redundant, screen-reader-misleading caption. Converted it to a `<span>` with the same className — **zero visual/behavior change**, the accessible name is preserved on the Input.

Continues the same safe pattern shipped in PR #30 (models-page) and PR #32 (mcp-page).

## Verification (react-doctor 0.7.4)
- **Worktree** (frozen install off `origin/main` `2183236`): `apps/desktop` `tsc --noEmit` — no new errors (only the pre-existing out-of-scope `prompts.ts:94` unused const). Re-scan: `label-has-associated-control` **6 → 4** (the double-counted api-key-field site gone), total **715 → 713**, zero new diagnostics, score held **54**.
- **Owner-checkout cross-check**: applied read-only, `tsc` delta = **0** (only pre-existing owner-only noise: `prompts.ts:94` + `message-list-view.tsx:214` Radix `CSSProperties`/`DraggableStyle` skew — both unrelated to the touched file), reverted, tree clean.

## Before / after score
Health score **54 → 54** (single warning fix; genuine diagnostics 715 → 713).
