### PR TITLE
feat(core): extract headless thread semantics into `@llm-space/core/thread`

### DIFF
--- a/.agents/kaizen-loop/CAPABILITY_MAP.md
+++ b/.agents/kaizen-loop/CAPABILITY_MAP.md
@@ -1,7 +1,7 @@
 # LLM Space Capability Map
 
-- Last updated: 2026-07-11
-- Map status: refreshed after DI/plugin-readiness V1. The Bun process now has one explicit composition root, deterministic bundled-module lifecycle, and one frozen built-in-tool contribution seam; public or dynamically loaded plugins remain absent.
+- Last updated: 2026-07-12
+- Map status: refreshed after Headless Thread Semantics V1. A dedicated browser-safe `@llm-space/core/thread` entrypoint now owns prompt materialization, usage arithmetic, and persisted run/evaluation lifecycle rules; desktop retains UI/session and host-specific adapters. Public or dynamically loaded plugins remain absent.
 - Evidence rule: entries marked `confirmed` cite current rendered-product or current-code evidence. Entries marked `stale` rely on previous logs or code paths not fully re-inspected in this loop. Entries marked `unknown` need a future product-surface check before they can drive a recommendation.
 
 ## First-Run Model Setup
@@ -47,7 +47,7 @@
   - Variable Panel V2 screenshot `audits/2026-07-08-191806-variable-panel-v2/06-v2-custom-scenario.png` shows custom variable `customer_profile` under active scenario `scenario_2` with a multiline value.
   - Isolated runtime file `workspace/untitled-3.json` persisted `context.variables.available_skills` with `skillNames`, `format`, and `indent`, plus `context.variableVariants` with `baseline` and `scenario_2` value sets.
   - Live CEF resolver checks rendered `{{available_skills}}`, `{{customer_profile}}`, and `{{system_date}}`, and rejected legacy `{{llm_space.current_date format="default"}}`, empty skill selections, and empty custom values with actionable errors.
-  - `apps/desktop/src/components/thread-playground/prompt-variables.ts` formats date and skill variables, loads enabled skills through existing skill settings, and resolves placeholders.
+  - `packages/core/src/thread/prompt-variables.ts` owns date/skill formatting and placeholder semantics; desktop injects enabled local skills through `variable/prompt-variable-skills.ts`.
   - `apps/desktop/src/components/thread-playground/stores/thread-store.ts` now renders variables before `streamThread()` while run snapshots keep the rendered prompt and the live editor keeps the template.
   - Current screenshot `02-starter-thread-current.png` shows `Start from Example` now opens a prompt-example chooser rather than directly creating a single starter thread.
   - Current screenshot `03-example-thread-opened.png` shows a `general-agent` prompt example opened with a populated system prompt, fallback model, and an empty user message.
@@ -127,6 +127,24 @@
 - Boundary: one thread can run against its selected or fallback model, stream assistant/tool output, abort, and persist completed state.
 - Explicit non-goals: batch runs, scheduled runs, provider health validation.
 - Visible gaps: live-provider continuation after a real paid/provider tool-call turn still needs a bounded smoke check; the global run control remains generic while the message-level continuation flow is specialized.
+
+## Headless Thread Execution And Evaluation
+
+- Status: shipped V1
+- Freshness: confirmed
+- Last checked: 2026-07-12
+- Evidence:
+  - `packages/core/src/types/threads/thread.ts` owns the durable schemas for prompt variables, variable snapshots, run snapshots, evaluation rubrics, scores, and evaluations.
+  - `packages/core/src/client/` owns transport-independent streaming, event reduction, conversion, and run eligibility; `packages/core/src/parsers/` owns native/foreign thread parsing and normalization.
+  - `packages/core/src/thread/` now owns prompt-variable rendering/snapshot semantics, usage validation/arithmetic/fallback, run-history normalization/recording, and rubric/evaluation persistence rules behind `@llm-space/core/thread`.
+  - Desktop imports durable variable behavior directly from core. `variable/prompt-variable-skills.ts` owns enabled local skill discovery, `prompt-variable-options.ts` owns UI labels, and `prompt-variable-display.ts` owns CodeMirror completion/hover presentation; the former mirror façade was deleted. Desktop undo/redo and image-memory policy remain in `stores/thread-history.ts`.
+  - `apps/desktop/src/bun/traces/trace-manager.ts` now uses the core usage aggregators instead of a private duplicate implementation.
+  - The public-entrypoint headless workflow test materializes prompt variables, records two runs with usage, and persists a structured evaluation without desktop imports; frozen prompt bytes and the missing-skill error contract have focused coverage.
+  - All 54 Bun tests, core TypeScript, lint with its one pre-existing warning, and the Vite production build passed on 2026-07-12. Focused tests cover usage compatibility, run caps/fallback IDs, injected-ID collisions, variable normalization, multi-place snapshots, and template-preserving snapshot application. Desktop TypeScript retains the same pre-existing unused `HELLO_WORLD_BUILT_IN_TOOLS` diagnostic.
+  - Real Electrobun CEF loaded the existing configured `GPT-5.3 Codex Spark`, materialized a current-date/skills template, and entered the real run path without prompt/RPC/render errors. The provider then failed with `Unable to connect`, so no completed run was available for live persistence inspection; the temporary test thread was removed.
+- Boundary: a core-only consumer can materialize a variableized Thread with injected skills/time, apply canonical usage semantics, record and normalize bounded runs, and create/update valid rubrics and evaluations. Desktop supplies local skill discovery and owns UI/session behavior.
+- Explicit non-goals: React/Zustand state, CodeMirror completion UI, Electrobun RPC and commands, native menus/windows/updates, desktop analytics, and dynamic third-party plugins do not belong to this capability.
+- Visible gaps: core still contains desktop-specific window-state persistence; the new public entrypoint has no real second product consumer beyond desktop and its headless integration test; a successful live-provider run/reload smoke remains pending because the configured provider was unreachable in this loop.
 
 ## Token Usage Visibility
 

--- a/apps/desktop/src/bun/traces/trace-manager.ts
+++ b/apps/desktop/src/bun/traces/trace-manager.ts
@@ -14,6 +14,10 @@ import {
   type ToolCall,
 } from "@llm-space/core";
 import { getLlmSpaceHomePath } from "@llm-space/core/server";
+import {
+  aggregateMessageUsage,
+  aggregateModelUsage,
+} from "@llm-space/core/thread";
 
 import type {
   TraceConnectedProjectInput,
@@ -1148,7 +1152,7 @@ function _createWorkbench(
       messages,
     },
   };
-  const usage = _aggregateMessageUsage(messages);
+  const usage = aggregateMessageUsage(messages) ?? undefined;
   thread.runHistory = [
     {
       id: `imported-${_shortHash(trace.source.traceId)}`,
@@ -1311,49 +1315,13 @@ function _usageFromRow(row: LangfuseObservation): ModelUsage | null {
 function _aggregateRowsUsage(
   rows: LangfuseObservation[]
 ): ModelUsage | undefined {
-  return _aggregateUsages(
-    rows.flatMap((row) => {
-      const usage = _usageFromRow(row);
-      return usage ? [usage] : [];
-    })
-  );
-}
-
-function _aggregateMessageUsage(messages: Message[]): ModelUsage | undefined {
-  return _aggregateUsages(
-    messages.flatMap((message) =>
-      message.role === "assistant" && message.usage ? [message.usage] : []
-    )
-  );
-}
-
-function _aggregateUsages(usages: ModelUsage[]): ModelUsage | undefined {
-  if (usages.length === 0) {
-    return undefined;
-  }
-  return usages.reduce<ModelUsage>(
-    (total, usage) => ({
-      input: total.input + usage.input,
-      output: total.output + usage.output,
-      cacheRead: total.cacheRead + usage.cacheRead,
-      cacheWrite: total.cacheWrite + usage.cacheWrite,
-      totalTokens: total.totalTokens + usage.totalTokens,
-      cost: {
-        input: total.cost.input + usage.cost.input,
-        output: total.cost.output + usage.cost.output,
-        cacheRead: total.cost.cacheRead + usage.cost.cacheRead,
-        cacheWrite: total.cost.cacheWrite + usage.cost.cacheWrite,
-        total: total.cost.total + usage.cost.total,
-      },
-    }),
-    {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    }
+  return (
+    aggregateModelUsage(
+      rows.flatMap((row) => {
+        const usage = _usageFromRow(row);
+        return usage ? [usage] : [];
+      })
+    ) ?? undefined
   );
 }
 

--- a/apps/desktop/src/components/thread-playground/evaluation-rubric-editor.tsx
+++ b/apps/desktop/src/components/thread-playground/evaluation-rubric-editor.tsx
@@ -1,5 +1,15 @@
 import { uuid } from "@llm-space/core";
 import {
+  MAX_CRITERION_DESCRIPTION_LENGTH,
+  MAX_CRITERION_NAME_LENGTH,
+  MAX_RUBRIC_CRITERIA,
+  MAX_RUBRIC_NAME_LENGTH,
+  MIN_RUBRIC_CRITERIA,
+  type EvaluationCriterion,
+  type EvaluationRubricInput,
+  type EvaluationRubricRecord,
+} from "@llm-space/core/thread";
+import {
   ArrowDownIcon,
   ArrowLeftIcon,
   ArrowUpIcon,
@@ -14,17 +24,6 @@ import { Tooltip } from "../tooltip";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
-
-import {
-  MAX_CRITERION_DESCRIPTION_LENGTH,
-  MAX_CRITERION_NAME_LENGTH,
-  MAX_RUBRIC_CRITERIA,
-  MAX_RUBRIC_NAME_LENGTH,
-  MIN_RUBRIC_CRITERIA,
-  type EvaluationCriterion,
-  type EvaluationRubricInput,
-  type EvaluationRubricRecord,
-} from "./stores";
 
 function _emptyCriterion(): EvaluationCriterion {
   return { id: uuid(), name: "" };

--- a/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
@@ -7,6 +7,7 @@ import {
   type ThreadContext,
   type ToolCall,
 } from "@llm-space/core";
+import { createMessagePromptVariablePlaceKey } from "@llm-space/core/thread";
 import { PlusIcon } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -23,7 +24,6 @@ import { Marker, MarkerContent } from "../../ui/marker";
 import { ShineBorder } from "../../ui/shine-border";
 import { Skeleton } from "../../ui/skeleton";
 import { useThreadStore, useThreadStoreActions } from "../stores";
-import { createMessagePromptVariablePlaceKey } from "../variable/prompt-variables";
 import { usePromptVariableExtensionForContext } from "../variable/use-prompt-variable-extension";
 
 import { ImageContentList } from "./image-content-view";

--- a/apps/desktop/src/components/thread-playground/message/token-usage-summary.tsx
+++ b/apps/desktop/src/components/thread-playground/message/token-usage-summary.tsx
@@ -1,4 +1,5 @@
 import type { ModelUsage } from "@llm-space/core";
+import { hasModelUsage } from "@llm-space/core/thread";
 import { GaugeIcon } from "lucide-react";
 import { memo, useMemo } from "react";
 
@@ -8,7 +9,6 @@ import { Tooltip } from "../../tooltip";
 import {
   formatCompactUsage,
   formatUsageSummary,
-  hasModelUsage,
   usageBreakdownRows,
 } from "../token-usage";
 

--- a/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/tool-call-list-item.tsx
@@ -4,6 +4,7 @@ import {
   type ToolCall,
   type ToolCallInput,
 } from "@llm-space/core";
+import { createToolResultPromptVariablePlaceKey } from "@llm-space/core/thread";
 import {
   AlertCircleIcon,
   CheckIcon,
@@ -26,7 +27,6 @@ import { CodeEditor, type CodeEditorProps } from "../../code-editor";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
 import { useThreadStoreActions } from "../stores";
-import { createToolResultPromptVariablePlaceKey } from "../variable/prompt-variables";
 import { usePromptVariableExtensionForContext } from "../variable/use-prompt-variable-extension";
 
 import { ToolCallInputView } from "./tool-call-input-view";

--- a/apps/desktop/src/components/thread-playground/prompt/system-prompt-editor.tsx
+++ b/apps/desktop/src/components/thread-playground/prompt/system-prompt-editor.tsx
@@ -1,4 +1,5 @@
 import { uuid, type Message } from "@llm-space/core";
+import { SYSTEM_PROMPT_PLACE_KEY } from "@llm-space/core/thread";
 import { memo, useCallback, useEffect } from "react";
 
 import { cn } from "@/lib/utils";
@@ -10,7 +11,6 @@ import { ExamplesMenu } from "../examples-menu";
 import { GeneratePopoverButton } from "../generate-popover-button";
 import { useThreadStore, useThreadStoreActions } from "../stores";
 import { useStreamText } from "../use-stream-text";
-import { SYSTEM_PROMPT_PLACE_KEY } from "../variable/prompt-variables";
 import { usePromptVariableExtension } from "../variable/use-prompt-variable-extension";
 
 interface SystemPromptEditorProps {

--- a/apps/desktop/src/components/thread-playground/run-evaluation-dialog.tsx
+++ b/apps/desktop/src/components/thread-playground/run-evaluation-dialog.tsx
@@ -1,3 +1,12 @@
+import {
+  snapshotEvaluationRubric,
+  type EvaluationRecord,
+  type EvaluationRubricInput,
+  type EvaluationRubricRecord,
+  type EvaluationRubricSnapshot,
+  type EvaluationRunScores,
+  type RunSnapshot,
+} from "@llm-space/core/thread";
 import { ArrowLeftIcon, CheckIcon, EyeIcon, SaveIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -34,15 +43,6 @@ import {
   summarizeRun,
 } from "./run-history-utils";
 import { RunTraceView } from "./run-trace-view";
-import {
-  snapshotEvaluationRubric,
-  type EvaluationRecord,
-  type EvaluationRubricInput,
-  type EvaluationRubricRecord,
-  type EvaluationRubricSnapshot,
-  type EvaluationRunScores,
-  type RunSnapshot,
-} from "./stores";
 
 const VERDICT_OPTIONS: {
   value: EvaluationRecord["verdict"];

--- a/apps/desktop/src/components/thread-playground/run-evaluation-scorecard.tsx
+++ b/apps/desktop/src/components/thread-playground/run-evaluation-scorecard.tsx
@@ -1,3 +1,9 @@
+import {
+  MAX_EVALUATION_RUBRICS,
+  snapshotEvaluationRubric,
+  type EvaluationRubricRecord,
+  type EvaluationRubricSnapshot,
+} from "@llm-space/core/thread";
 import { Edit3Icon, PlusIcon } from "lucide-react";
 import { useMemo, type KeyboardEvent } from "react";
 
@@ -17,12 +23,6 @@ import {
   completeRunScores,
   type EvaluationScoreDraft,
 } from "./run-evaluation-utils";
-import {
-  snapshotEvaluationRubric,
-  MAX_EVALUATION_RUBRICS,
-  type EvaluationRubricRecord,
-  type EvaluationRubricSnapshot,
-} from "./stores";
 
 const NO_RUBRIC = "none";
 const SAVED_RUBRIC = "saved";

--- a/apps/desktop/src/components/thread-playground/run-evaluation-utils.test.ts
+++ b/apps/desktop/src/components/thread-playground/run-evaluation-utils.test.ts
@@ -1,3 +1,8 @@
+import type {
+  EvaluationRecord,
+  EvaluationRubricRecord,
+  EvaluationRubricSnapshot,
+} from "@llm-space/core/thread";
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -10,12 +15,6 @@ import {
   requiresScoreRemovalConfirmation,
   scoreDraftForRubricChange,
 } from "./run-evaluation-utils";
-import type {
-  EvaluationRecord,
-  EvaluationRubricRecord,
-  EvaluationRubricSnapshot,
-} from "./stores";
-
 const RUBRIC: EvaluationRubricSnapshot = {
   id: "rubric-1",
   name: "Answer quality",

--- a/apps/desktop/src/components/thread-playground/run-evaluation-utils.ts
+++ b/apps/desktop/src/components/thread-playground/run-evaluation-utils.ts
@@ -3,7 +3,7 @@ import type {
   EvaluationRubricRecord,
   EvaluationRubricSnapshot,
   EvaluationRunScores,
-} from "./stores";
+} from "@llm-space/core/thread";
 
 export type EvaluationScoreDraft = Record<string, Record<string, number>>;
 

--- a/apps/desktop/src/components/thread-playground/run-history-list-view.tsx
+++ b/apps/desktop/src/components/thread-playground/run-history-list-view.tsx
@@ -1,4 +1,8 @@
 import {
+  type EvaluationRecord,
+  type RunSnapshot,
+} from "@llm-space/core/thread";
+import {
   ArrowLeftIcon,
   CheckIcon,
   ChevronLeftIcon,
@@ -42,7 +46,6 @@ import {
 } from "./run-history-utils";
 import { RunTraceView } from "./run-trace-view";
 import { useThreadStore, useThreadStoreActions } from "./stores";
-import type { EvaluationRecord, RunSnapshot } from "./stores";
 
 const VERDICT_LABELS: Record<EvaluationRecord["verdict"], string> = {
   leftBetter: "Run A Better",

--- a/apps/desktop/src/components/thread-playground/run-trace-view.tsx
+++ b/apps/desktop/src/components/thread-playground/run-trace-view.tsx
@@ -1,3 +1,4 @@
+import { usageForRun, type RunSnapshot } from "@llm-space/core/thread";
 import { memo } from "react";
 import { format } from "timeago.js";
 
@@ -10,8 +11,6 @@ import {
   runModelLabel,
   summarizeRun,
 } from "./run-history-utils";
-import type { RunSnapshot } from "./stores";
-import { usageForRun } from "./token-usage";
 
 function _RunTraceView({
   className,

--- a/apps/desktop/src/components/thread-playground/stores/thread-history.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-history.ts
@@ -1,60 +1,11 @@
-import type {
-  ModelUsage,
-  Thread,
-  ThreadEvaluationCriterion,
-  ThreadEvaluation,
-  ThreadEvaluationRubric,
-  ThreadEvaluationRubricSnapshot,
-  ThreadEvaluationRunScores,
-  ThreadRunSnapshot,
-  ThreadSnapshot,
-} from "@llm-space/core";
-import { uuid } from "@llm-space/core";
-
-import { emptyModelUsage, isModelUsage } from "../token-usage";
+import type { Thread } from "@llm-space/core";
 
 /** Maximum number of snapshots retained, including the current state. */
 export const MAX_HISTORY = 100;
 
-/**
- * Soft ceiling on the extra image payload that undo history may pin in memory:
- * base64 bytes of `image_data` that are no longer in the current thread but are
- * still referenced by an older snapshot. When exceeded, the oldest steps are
- * dropped until the retained payload is back under budget. Text-only editing
- * never approaches this — only heavy add/remove of large images does.
- *
- * Measured on base64 string length, which slightly over-estimates the decoded
- * image size (~1.33x), so the real retained bytes stay under this number.
- */
+/** Soft ceiling on image payload retained only by desktop undo history. */
 export const MAX_HISTORY_IMAGE_BYTES = 64 * 1024 * 1024;
 
-/** Maximum number of run snapshots retained in `runHistory`. */
-export const MAX_RUN_HISTORY = 20;
-
-/** Maximum number of manual evaluation records retained per thread. */
-export const MAX_EVALUATIONS = 50;
-
-/** Maximum number of reusable evaluation rubrics retained per thread. */
-export const MAX_EVALUATION_RUBRICS = 20;
-
-/** Minimum and maximum ordered criteria in one V1 rubric. */
-export const MIN_RUBRIC_CRITERIA = 2;
-export const MAX_RUBRIC_CRITERIA = 6;
-
-export const MAX_RUBRIC_NAME_LENGTH = 80;
-export const MAX_CRITERION_NAME_LENGTH = 80;
-export const MAX_CRITERION_DESCRIPTION_LENGTH = 240;
-
-/**
- * Undo/redo history for a thread, kept separate from the thread object itself.
- *
- * `snapshots` holds successive thread *references* (not deep copies). Because the
- * store mutates the thread immutably (copy-on-write), unchanged substructure —
- * including base64 image content — is shared across snapshots, so the history
- * stays memory-cheap. Undo/redo is an O(1) pointer move.
- *
- * Invariant: `snapshots[index]` is always the current `state.thread`.
- */
 export interface ChangeHistory {
   snapshots: Thread[];
   index: number;
@@ -77,14 +28,9 @@ export function canRedo(history: ChangeHistory): boolean {
   return history.index < history.snapshots.length - 1;
 }
 
-/** The `image_data` content objects in a thread's user messages. */
 function _imageContents(thread: Thread): { data: string }[] {
   const result: { data: string }[] = [];
-  const messages = thread.context?.messages;
-  if (!messages) {
-    return result;
-  }
-  for (const message of messages) {
+  for (const message of thread.context?.messages ?? []) {
     if (message.role !== "user") {
       continue;
     }
@@ -97,23 +43,16 @@ function _imageContents(thread: Thread): { data: string }[] {
   return result;
 }
 
-/**
- * Approximate base64 bytes of image payloads referenced by an older snapshot but
- * no longer present in the current (newest) one — the extra memory the history
- * pins beyond what the live thread already holds. Images shared with the current
- * thread, or shared across snapshots, are counted at most once (by reference).
- */
 function _retainedImageBytes(snapshots: Thread[]): number {
   const current = snapshots[snapshots.length - 1];
   if (current === undefined) {
     return 0;
   }
   const live = new Set<unknown>(_imageContents(current));
-
   const counted = new Set<unknown>();
   let bytes = 0;
-  for (let i = 0; i < snapshots.length - 1; i++) {
-    const snapshot = snapshots[i];
+  for (let index = 0; index < snapshots.length - 1; index++) {
+    const snapshot = snapshots[index];
     if (snapshot === undefined) {
       continue;
     }
@@ -127,12 +66,6 @@ function _retainedImageBytes(snapshots: Thread[]): number {
   return bytes;
 }
 
-/**
- * Record a new thread snapshot at the history tip, discarding any redo entries.
- * Trims the oldest steps to stay within {@link MAX_HISTORY} steps and, when
- * images are involved, within {@link MAX_HISTORY_IMAGE_BYTES} of pinned image
- * memory. No-ops when the thread is unchanged (same reference).
- */
 export function recordSnapshot(
   history: ChangeHistory,
   next: Thread
@@ -142,12 +75,9 @@ export function recordSnapshot(
   }
   const snapshots = history.snapshots.slice(0, history.index + 1);
   snapshots.push(next);
-  // Cap by number of steps.
   if (snapshots.length > MAX_HISTORY) {
     snapshots.splice(0, snapshots.length - MAX_HISTORY);
   }
-  // Cap the extra image memory pinned by history. Only runs while over budget
-  // (i.e. heavy image churn); always keeps the current state + one undo step.
   while (
     snapshots.length > 2 &&
     _retainedImageBytes(snapshots) > MAX_HISTORY_IMAGE_BYTES
@@ -157,628 +87,15 @@ export function recordSnapshot(
   return { snapshots, index: snapshots.length - 1 };
 }
 
-export type RunSnapshot = ThreadRunSnapshot & { id: string };
-export type EvaluationRecord = ThreadEvaluation;
-export type EvaluationCriterion = ThreadEvaluationCriterion;
-export type EvaluationRubricRecord = ThreadEvaluationRubric;
-export type EvaluationRubricSnapshot = ThreadEvaluationRubricSnapshot;
-export type EvaluationRunScores = ThreadEvaluationRunScores;
-
-export interface EvaluationRubricInput {
-  id?: string;
-  name: string;
-  criteria: EvaluationCriterion[];
-}
-
-function _asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function _trimmed(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed || null;
-}
-
-function _trimBounded(value: unknown, maxLength: number): string | null {
-  return _trimmed(value)?.slice(0, maxLength) ?? null;
-}
-
-/**
- * Create a de-nested thread snapshot for durable run history. The returned
- * object intentionally drops `runHistory`, otherwise each completed run would
- * persist the entire previous timeline inside the new entry.
- */
-export function snapshotThread(thread: Thread): ThreadSnapshot {
-  const snapshot: ThreadSnapshot = {};
-  if (thread.title !== undefined) {
-    snapshot.title = thread.title;
-  }
-  if (thread.model !== undefined) {
-    snapshot.model = thread.model;
-  }
-  if (thread.context !== undefined) {
-    snapshot.context = thread.context;
-  }
-  return snapshot;
-}
-
-/** Build a deterministic ID for old timestamp-only runs. */
-function _fallbackRunId(run: ThreadRunSnapshot, index: number): string {
-  return `run-${Math.trunc(run.timestamp)}-${index}`;
-}
-
-/**
- * Normalize persisted run history read from a thread file, trimming malformed
- * timestamps and enforcing the same recent-run cap used for newly recorded runs.
- */
-export function normalizeRunHistory(
-  runHistory: Thread["runHistory"]
-): RunSnapshot[] {
-  if (!Array.isArray(runHistory)) {
-    return [];
-  }
-  const normalized = runHistory.flatMap((run, index): RunSnapshot[] => {
-    if (!Number.isFinite(run.timestamp)) {
-      return [];
-    }
-    const id =
-      typeof run.id === "string" && run.id.trim()
-        ? run.id
-        : _fallbackRunId(run, index);
-    const usage =
-      Object.prototype.hasOwnProperty.call(run, "usage") &&
-      isModelUsage(run.usage)
-        ? run.usage
-        : undefined;
-    return [
-      {
-        id,
-        timestamp: run.timestamp,
-        thread: snapshotThread(run.thread),
-        ...(usage ? { usage } : {}),
-      },
-    ];
-  });
-  const lastIndexById = new Map(
-    normalized.map((run, index) => [run.id, index] as const)
-  );
-  const deduped = normalized.filter(
-    (run, index) => lastIndexById.get(run.id) === index
-  );
-  return deduped.length > MAX_RUN_HISTORY
-    ? deduped.slice(deduped.length - MAX_RUN_HISTORY)
-    : deduped;
-}
-
-function _normalizeCriterion(
-  value: unknown,
-  seenIds: Set<string>,
-  seenNames: Set<string>
-): EvaluationCriterion | null {
-  const criterion = _asRecord(value);
-  if (!criterion) {
-    return null;
-  }
-  const id = _trimmed(criterion.id);
-  const name = _trimBounded(criterion.name, MAX_CRITERION_NAME_LENGTH);
-  const normalizedName = name?.toLowerCase();
-  if (
-    !id ||
-    !name ||
-    !normalizedName ||
-    seenIds.has(id) ||
-    seenNames.has(normalizedName)
-  ) {
-    return null;
-  }
-  seenIds.add(id);
-  seenNames.add(normalizedName);
-  const description = _trimBounded(
-    criterion.description,
-    MAX_CRITERION_DESCRIPTION_LENGTH
-  );
-  return { id, name, ...(description ? { description } : {}) };
-}
-
-function _normalizeCriteria(value: unknown): EvaluationCriterion[] | null {
-  if (!Array.isArray(value)) {
-    return null;
-  }
-  const seenIds = new Set<string>();
-  const seenNames = new Set<string>();
-  const criteria = value
-    .flatMap((criterion): EvaluationCriterion[] => {
-      const normalized = _normalizeCriterion(criterion, seenIds, seenNames);
-      return normalized ? [normalized] : [];
-    })
-    .slice(0, MAX_RUBRIC_CRITERIA);
-  return criteria.length >= MIN_RUBRIC_CRITERIA ? criteria : null;
-}
-
-function _normalizeRubricSnapshot(
-  value: unknown
-): EvaluationRubricSnapshot | null {
-  const rubric = _asRecord(value);
-  if (!rubric) {
-    return null;
-  }
-  const id = _trimmed(rubric.id);
-  const name = _trimBounded(rubric.name, MAX_RUBRIC_NAME_LENGTH);
-  const criteria = _normalizeCriteria(rubric.criteria);
-  if (
-    !id ||
-    !name ||
-    !criteria ||
-    !Number.isSafeInteger(rubric.revision) ||
-    (rubric.revision as number) < 1
-  ) {
-    return null;
-  }
-  return {
-    id,
-    name,
-    criteria,
-    revision: rubric.revision as number,
-  };
-}
-
-function _normalizeEvaluationRubric(
-  value: unknown
-): EvaluationRubricRecord | null {
-  const rubric = _asRecord(value);
-  const snapshot = _normalizeRubricSnapshot(value);
-  if (
-    !rubric ||
-    !snapshot ||
-    !Number.isFinite(rubric.createdAt) ||
-    !Number.isFinite(rubric.updatedAt)
-  ) {
-    return null;
-  }
-  return {
-    ...snapshot,
-    createdAt: rubric.createdAt as number,
-    updatedAt: rubric.updatedAt as number,
-  };
-}
-
-/** Normalize bounded thread-owned rubric definitions read from disk. */
-export function normalizeEvaluationRubrics(
-  rubrics: Thread["evaluationRubrics"]
-): EvaluationRubricRecord[] {
-  if (!Array.isArray(rubrics)) {
-    return [];
-  }
-  const normalized: EvaluationRubricRecord[] = [];
-  const indexById = new Map<string, number>();
-  for (const value of rubrics as unknown[]) {
-    const rubric = _normalizeEvaluationRubric(value);
-    if (!rubric) {
-      continue;
-    }
-    const existingIndex = indexById.get(rubric.id);
-    if (existingIndex === undefined) {
-      indexById.set(rubric.id, normalized.length);
-      normalized.push(rubric);
-    } else {
-      normalized[existingIndex] = rubric;
-    }
-  }
-  return normalized.length > MAX_EVALUATION_RUBRICS
-    ? normalized.slice(normalized.length - MAX_EVALUATION_RUBRICS)
-    : normalized;
-}
-
-/** Copy the durable structure of a definition into an evaluation record. */
-export function snapshotEvaluationRubric(
-  rubric: EvaluationRubricRecord
-): EvaluationRubricSnapshot {
-  return {
-    id: rubric.id,
-    name: rubric.name,
-    revision: rubric.revision,
-    criteria: rubric.criteria.map((criterion) => ({ ...criterion })),
-  };
-}
-
-function _sameCriteria(
-  left: EvaluationCriterion[],
-  right: EvaluationCriterion[]
-): boolean {
-  return (
-    left.length === right.length &&
-    left.every((criterion, index) => {
-      const other = right[index];
-      return (
-        criterion.id === other?.id &&
-        criterion.name === other.name &&
-        criterion.description === other.description
-      );
-    })
-  );
-}
-
-/** Create or update one reusable rubric definition. */
-export function upsertEvaluationRubric(
-  rubrics: EvaluationRubricRecord[],
-  input: EvaluationRubricInput,
-  timestamp: number = Date.now()
-): {
-  rubric: EvaluationRubricRecord;
-  rubrics: EvaluationRubricRecord[];
-} | null {
-  const normalized = normalizeEvaluationRubrics(rubrics);
-  const name = _trimBounded(input.name, MAX_RUBRIC_NAME_LENGTH);
-  const criteria = _normalizeCriteria(input.criteria);
-  if (
-    !name ||
-    criteria?.length !== input.criteria.length ||
-    !Number.isFinite(timestamp)
-  ) {
-    return null;
-  }
-  const existingIndex = input.id
-    ? normalized.findIndex((rubric) => rubric.id === input.id)
-    : -1;
-  if (input.id && existingIndex === -1) {
-    return null;
-  }
-  if (!input.id && normalized.length >= MAX_EVALUATION_RUBRICS) {
-    return null;
-  }
-  const existing = existingIndex === -1 ? undefined : normalized[existingIndex];
-  if (existing?.revision === Number.MAX_SAFE_INTEGER) {
-    return null;
-  }
-  if (existing?.name === name && _sameCriteria(existing.criteria, criteria)) {
-    return { rubric: existing, rubrics: normalized };
-  }
-  const rubric: EvaluationRubricRecord = {
-    id: existing?.id ?? uuid(),
-    name,
-    criteria,
-    revision: (existing?.revision ?? 0) + 1,
-    createdAt: existing?.createdAt ?? timestamp,
-    updatedAt: timestamp,
-  };
-  const next =
-    existingIndex === -1
-      ? [...normalized, rubric]
-      : normalized.map((value, index) =>
-          index === existingIndex ? rubric : value
-        );
-  return { rubric, rubrics: next };
-}
-
-function _normalizeRunScores(
-  value: unknown,
-  rubric: EvaluationRubricSnapshot,
-  leftRunId: string,
-  rightRunId: string
-): EvaluationRunScores[] | null {
-  if (!Array.isArray(value) || value.length !== 2) {
-    return null;
-  }
-  const allowedRunIds = new Set([leftRunId, rightRunId]);
-  const scoreByRunId = new Map<string, Map<string, number>>();
-  for (const rawRunScores of value) {
-    const runScores = _asRecord(rawRunScores);
-    const runId = _trimmed(runScores?.runId);
-    if (
-      !runScores ||
-      !runId ||
-      !allowedRunIds.has(runId) ||
-      scoreByRunId.has(runId) ||
-      !Array.isArray(runScores.scores) ||
-      runScores.scores.length !== rubric.criteria.length
-    ) {
-      return null;
-    }
-    const scores = new Map<string, number>();
-    for (const rawScore of runScores.scores) {
-      const score = _asRecord(rawScore);
-      const criterionId = _trimmed(score?.criterionId);
-      if (
-        !score ||
-        !criterionId ||
-        scores.has(criterionId) ||
-        !Number.isInteger(score.score) ||
-        (score.score as number) < 1 ||
-        (score.score as number) > 5
-      ) {
-        return null;
-      }
-      scores.set(criterionId, score.score as number);
-    }
-    scoreByRunId.set(runId, scores);
-  }
-  const criterionIds = new Set(
-    rubric.criteria.map((criterion) => criterion.id)
-  );
-  if (
-    scoreByRunId.size !== 2 ||
-    [...scoreByRunId.values()].some(
-      (scores) =>
-        scores.size !== criterionIds.size ||
-        [...scores.keys()].some((criterionId) => !criterionIds.has(criterionId))
-    )
-  ) {
-    return null;
-  }
-  return [leftRunId, rightRunId].map((runId) => {
-    const scores = scoreByRunId.get(runId)!;
-    return {
-      runId,
-      scores: rubric.criteria.map((criterion) => ({
-        criterionId: criterion.id,
-        score: scores.get(criterion.id)!,
-      })),
-    };
-  });
-}
-
-/** Check whether a value is a supported persisted evaluation verdict. */
-function _isEvaluationVerdict(
-  value: unknown
-): value is EvaluationRecord["verdict"] {
-  return (
-    value === "leftBetter" ||
-    value === "rightBetter" ||
-    value === "tie" ||
-    value === "pass" ||
-    value === "fail"
-  );
-}
-
-/**
- * Normalize persisted evaluations and drop records whose compared runs no
- * longer exist in the bounded run history.
- */
-export function normalizeEvaluations(
-  evaluations: Thread["evaluations"],
-  runHistory: RunSnapshot[]
-): EvaluationRecord[] {
-  if (!Array.isArray(evaluations)) {
-    return [];
-  }
-  const runIds = new Set(runHistory.map((run) => run.id));
-  const normalized = (evaluations as unknown[]).flatMap(
-    (value, index): EvaluationRecord[] => {
-      const evaluation = _asRecord(value);
-      if (
-        !evaluation ||
-        typeof evaluation.leftRunId !== "string" ||
-        typeof evaluation.rightRunId !== "string" ||
-        evaluation.leftRunId === evaluation.rightRunId ||
-        !_isEvaluationVerdict(evaluation.verdict) ||
-        !Number.isFinite(evaluation.createdAt) ||
-        !Number.isFinite(evaluation.updatedAt) ||
-        !runIds.has(evaluation.leftRunId) ||
-        !runIds.has(evaluation.rightRunId)
-      ) {
-        return [];
-      }
-      const id =
-        typeof evaluation.id === "string" && evaluation.id.trim()
-          ? evaluation.id
-          : `evaluation-${evaluation.leftRunId}-${evaluation.rightRunId}-${index}`;
-      const hasStructuredPayload =
-        Object.prototype.hasOwnProperty.call(evaluation, "rubric") ||
-        Object.prototype.hasOwnProperty.call(evaluation, "runScores");
-      const rubric = hasStructuredPayload
-        ? _normalizeRubricSnapshot(evaluation.rubric)
-        : null;
-      const runScores = rubric
-        ? _normalizeRunScores(
-            evaluation.runScores,
-            rubric,
-            evaluation.leftRunId,
-            evaluation.rightRunId
-          )
-        : null;
-      const base = {
-        id,
-        leftRunId: evaluation.leftRunId,
-        rightRunId: evaluation.rightRunId,
-        verdict: evaluation.verdict,
-        note:
-          typeof evaluation.note === "string" && evaluation.note.trim()
-            ? evaluation.note.trim()
-            : undefined,
-        createdAt: evaluation.createdAt as number,
-        updatedAt: evaluation.updatedAt as number,
-      };
-      return rubric && runScores ? [{ ...base, rubric, runScores }] : [base];
-    }
-  );
-  const seenIds = new Set<string>();
-  const seenPairs = new Set<string>();
-  const deduped: EvaluationRecord[] = [];
-  for (let index = normalized.length - 1; index >= 0; index--) {
-    const evaluation = normalized[index];
-    const pairKey = JSON.stringify(
-      [evaluation.leftRunId, evaluation.rightRunId].sort()
-    );
-    if (seenIds.has(evaluation.id) || seenPairs.has(pairKey)) {
-      continue;
-    }
-    seenIds.add(evaluation.id);
-    seenPairs.add(pairKey);
-    deduped.push(evaluation);
-  }
-  deduped.reverse();
-  return deduped.length > MAX_EVALUATIONS
-    ? deduped.slice(deduped.length - MAX_EVALUATIONS)
-    : deduped;
-}
-
-/**
- * Attach durable run/evaluation records to a thread while omitting empty fields.
- * This keeps old thread files tidy until the user creates these records.
- */
-export function withRunMetadata(
-  thread: Thread,
-  {
-    runHistory,
-    evaluations = normalizeEvaluations(
-      thread.evaluations,
-      normalizeRunHistory(runHistory)
-    ),
-    evaluationRubrics = normalizeEvaluationRubrics(thread.evaluationRubrics),
-  }: {
-    runHistory: RunSnapshot[];
-    evaluations?: EvaluationRecord[];
-    evaluationRubrics?: EvaluationRubricRecord[];
-  }
-): Thread {
-  const normalized = normalizeRunHistory(runHistory);
-  const normalizedEvaluations = normalizeEvaluations(evaluations, normalized);
-  const normalizedRubrics = normalizeEvaluationRubrics(evaluationRubrics);
-  const next: Thread = snapshotThread(thread);
-  if (normalized.length > 0) {
-    next.runHistory = normalized;
-  }
-  if (normalizedEvaluations.length > 0) {
-    next.evaluations = normalizedEvaluations;
-  }
-  if (normalizedRubrics.length > 0) {
-    next.evaluationRubrics = normalizedRubrics;
-  }
-  return next;
-}
-
-/**
- * Append a snapshot of a completed run, keeping only the most recent
- * {@link MAX_RUN_HISTORY}. The thread is stored by reference and shares unchanged
- * substructure with the live thread, so this stays cheap.
- */
-export function recordRun(
-  runHistory: RunSnapshot[],
-  thread: Thread,
-  timestamp: number,
-  options: { id?: string; usage?: ModelUsage | null } = {}
-): RunSnapshot[] {
-  const usage = options.usage ?? emptyModelUsage();
-  const next = [
-    ...normalizeRunHistory(runHistory),
-    {
-      id: options.id ?? uuid(),
-      thread: snapshotThread(thread),
-      timestamp,
-      usage,
-    },
-  ];
-  return next.length > MAX_RUN_HISTORY
-    ? next.slice(next.length - MAX_RUN_HISTORY)
-    : next;
-}
-
-/** Check whether two left/right run IDs describe the same comparison pair. */
-function _isSameRunPair(
-  leftRunId: string,
-  rightRunId: string,
-  otherLeftRunId: string,
-  otherRightRunId: string
-): boolean {
-  return (
-    (leftRunId === otherLeftRunId && rightRunId === otherRightRunId) ||
-    (leftRunId === otherRightRunId && rightRunId === otherLeftRunId)
-  );
-}
-
-/**
- * Create or update an evaluation for a run pair. The persisted left/right
- * orientation follows the latest save, but matching is order-insensitive so a
- * reversed A/B selection updates the existing comparison instead of duplicating it.
- */
-export function upsertEvaluation(
-  evaluations: EvaluationRecord[],
-  runHistory: RunSnapshot[],
-  input: {
-    leftRunId: string;
-    rightRunId: string;
-    verdict: EvaluationRecord["verdict"];
-    note?: string;
-    rubric?: EvaluationRubricSnapshot;
-    runScores?: EvaluationRunScores[];
-  },
-  timestamp: number = Date.now()
-): EvaluationRecord[] | null {
-  const normalizedRunHistory = normalizeRunHistory(runHistory);
-  const normalized = normalizeEvaluations(evaluations, normalizedRunHistory);
-  const runIds = new Set(normalizedRunHistory.map((run) => run.id));
-  if (
-    input.leftRunId === input.rightRunId ||
-    !runIds.has(input.leftRunId) ||
-    !runIds.has(input.rightRunId)
-  ) {
-    return null;
-  }
-  const hasStructuredPayload =
-    input.rubric !== undefined || input.runScores !== undefined;
-  const rubric = hasStructuredPayload
-    ? _normalizeRubricSnapshot(input.rubric)
-    : null;
-  const runScores = rubric
-    ? _normalizeRunScores(
-        input.runScores,
-        rubric,
-        input.leftRunId,
-        input.rightRunId
-      )
-    : null;
-  if (hasStructuredPayload && (!rubric || !runScores)) {
-    return null;
-  }
-  const existingIndex = normalized.findIndex((evaluation) =>
-    _isSameRunPair(
-      evaluation.leftRunId,
-      evaluation.rightRunId,
-      input.leftRunId,
-      input.rightRunId
-    )
-  );
-  const existing = existingIndex === -1 ? undefined : normalized[existingIndex];
-  const baseEvaluation = {
-    id: existing?.id ?? uuid(),
-    leftRunId: input.leftRunId,
-    rightRunId: input.rightRunId,
-    verdict: input.verdict,
-    note: input.note?.trim() || undefined,
-    createdAt: existing?.createdAt ?? timestamp,
-    updatedAt: timestamp,
-  };
-  const nextEvaluation: EvaluationRecord =
-    rubric && runScores
-      ? { ...baseEvaluation, rubric, runScores }
-      : baseEvaluation;
-
-  const next =
-    existingIndex === -1
-      ? [...normalized, nextEvaluation]
-      : normalized.map((evaluation, index) =>
-          index === existingIndex ? nextEvaluation : evaluation
-        );
-  return next.length > MAX_EVALUATIONS
-    ? next.slice(next.length - MAX_EVALUATIONS)
-    : next;
-}
-
 export function undo(history: ChangeHistory): UndoRedoResult | null {
   if (!canUndo(history)) {
     return null;
   }
   const index = history.index - 1;
   const thread = history.snapshots[index];
-  if (thread === undefined) {
-    return null;
-  }
-  return { history: { ...history, index }, thread };
+  return thread === undefined
+    ? null
+    : { history: { ...history, index }, thread };
 }
 
 export function redo(history: ChangeHistory): UndoRedoResult | null {
@@ -787,8 +104,7 @@ export function redo(history: ChangeHistory): UndoRedoResult | null {
   }
   const index = history.index + 1;
   const thread = history.snapshots[index];
-  if (thread === undefined) {
-    return null;
-  }
-  return { history: { ...history, index }, thread };
+  return thread === undefined
+    ? null
+    : { history: { ...history, index }, thread };
 }

--- a/apps/desktop/src/components/thread-playground/stores/thread-store.ts
+++ b/apps/desktop/src/components/thread-playground/stores/thread-store.ts
@@ -28,6 +28,33 @@ import {
   type ToolCall,
   type UserMessage,
 } from "@llm-space/core";
+import {
+  aggregateMessageUsage,
+  createMessagePromptVariablePlaceKey,
+  createToolResultPromptVariablePlaceKey,
+  DEFAULT_VARIABLE_VARIANT_NAME,
+  ensureThreadVariableState,
+  normalizeEvaluationRubrics,
+  normalizeEvaluations,
+  normalizePromptVariableState,
+  normalizeRunHistory,
+  PromptVariableError,
+  recordRun,
+  removePromptVariableSnapshotPlaces,
+  renderThreadPromptVariables,
+  replaceThreadPromptVariableReferences,
+  SYSTEM_PROMPT_PLACE_KEY,
+  upsertEvaluation,
+  upsertEvaluationRubric,
+  withPromptVariableSnapshot,
+  withRunMetadata,
+  type EvaluationRecord,
+  type EvaluationRubricInput,
+  type EvaluationRubricRecord,
+  type EvaluationRubricSnapshot,
+  type EvaluationRunScores,
+  type RunSnapshot,
+} from "@llm-space/core/thread";
 import { createContext, useContext } from "react";
 import { toast } from "sonner";
 import { Compile } from "typebox/compile";
@@ -38,39 +65,14 @@ import { useShallow } from "zustand/shallow";
 import { createFrameThrottle } from "@/lib/frame-throttle";
 
 import { PREVIEW_THROTTLE_MS } from "../streaming-preview";
-import { aggregateMessageUsage } from "../token-usage";
-import {
-  createMessagePromptVariablePlaceKey,
-  createToolResultPromptVariablePlaceKey,
-  DEFAULT_VARIABLE_VARIANT_NAME,
-  ensureThreadVariableState,
-  normalizePromptVariableState,
-  PromptVariableError,
-  removePromptVariableSnapshotPlaces,
-  replaceThreadPromptVariableReferences,
-  renderThreadPromptVariables,
-  SYSTEM_PROMPT_PLACE_KEY,
-} from "../variable/prompt-variables";
+import { listEnabledPromptVariableSkills } from "../variable/prompt-variable-skills";
 
 import {
   createInitialHistory,
-  normalizeEvaluationRubrics,
-  normalizeEvaluations,
-  normalizeRunHistory,
-  recordRun,
   recordSnapshot,
   redo as redoHistory,
   undo as undoHistory,
-  upsertEvaluation,
-  upsertEvaluationRubric,
-  withRunMetadata,
   type ChangeHistory,
-  type EvaluationRecord,
-  type EvaluationRubricInput,
-  type EvaluationRubricRecord,
-  type EvaluationRubricSnapshot,
-  type EvaluationRunScores,
-  type RunSnapshot,
 } from "./thread-history";
 
 const toolValidator = Compile(ToolSchema);
@@ -233,19 +235,6 @@ export function createThreadStore(
 
       const patchContext = (partial: Partial<Thread["context"]>) => {
         patchThread({ context: { ...get().thread.context, ...partial } });
-      };
-
-      const threadWithPromptSnapshot = (
-        thread: Thread,
-        snapshot: ThreadContext["snapshot"]
-      ): Thread => {
-        const context: ThreadContext = { ...(thread.context ?? {}) };
-        if (snapshot === undefined) {
-          delete context.snapshot;
-        } else {
-          context.snapshot = snapshot;
-        }
-        return { ...thread, context };
       };
 
       const getVariableState = () =>
@@ -891,6 +880,7 @@ export function createThreadStore(
           try {
             const rendered = await renderThreadPromptVariables({
               context: { ...get().thread.context, messages },
+              loadSkills: listEnabledPromptVariableSkills,
             });
             preparedContext = rendered.context;
             promptSnapshot = rendered.snapshot;
@@ -977,7 +967,7 @@ export function createThreadStore(
             // thread is unchanged.
             const finalThread = get().thread;
             if (sawEvent && !failed) {
-              const threadWithSnapshot = threadWithPromptSnapshot(
+              const threadWithSnapshot = withPromptVariableSnapshot(
                 finalThread,
                 promptSnapshot
               );
@@ -1048,6 +1038,7 @@ export function createThreadStore(
                         messages,
                         snapshot: promptSnapshot,
                       },
+                      loadSkills: listEnabledPromptVariableSkills,
                     })
                   ).context;
               preparedContext = null;

--- a/apps/desktop/src/components/thread-playground/token-usage.ts
+++ b/apps/desktop/src/components/thread-playground/token-usage.ts
@@ -1,9 +1,4 @@
-import type {
-  Message,
-  ModelUsage,
-  ModelUsageCost,
-  ThreadSnapshot,
-} from "@llm-space/core";
+import type { ModelUsage, ModelUsageCost } from "@llm-space/core";
 
 const INTEGER_FORMATTER = new Intl.NumberFormat("en", {
   maximumFractionDigits: 0,
@@ -17,122 +12,6 @@ const COMPACT_FORMATTER = new Intl.NumberFormat("en", {
 export interface UsageBreakdownRow {
   label: string;
   value: string;
-}
-
-/** Empty usage marker for new runs whose provider omitted usage. */
-export function emptyModelUsage(): ModelUsage {
-  return {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 0,
-    cost: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      total: 0,
-    },
-  };
-}
-
-/**
- * Runtime guard for persisted usage.
- *
- * Thread JSON can outlive this build, so UI helpers should reject malformed
- * usage records before reading nested cost fields.
- */
-export function isModelUsage(usage: unknown): usage is ModelUsage {
-  if (!usage || typeof usage !== "object") {
-    return false;
-  }
-  const candidate = usage as Partial<ModelUsage>;
-  return (
-    _isUsageNumber(candidate.input) &&
-    _isUsageNumber(candidate.output) &&
-    _isUsageNumber(candidate.cacheRead) &&
-    _isUsageNumber(candidate.cacheWrite) &&
-    _isUsageNumber(candidate.totalTokens) &&
-    (candidate.reasoning === undefined ||
-      _isUsageNumber(candidate.reasoning)) &&
-    _isModelUsageCost(candidate.cost)
-  );
-}
-
-/** True when an assistant message has provider-reported usage worth showing. */
-export function hasModelUsage(
-  usage: ModelUsage | null | undefined
-): usage is ModelUsage {
-  if (!isModelUsage(usage)) {
-    return false;
-  }
-  return (
-    usage.totalTokens > 0 ||
-    usage.input > 0 ||
-    usage.output > 0 ||
-    usage.cacheRead > 0 ||
-    usage.cacheWrite > 0 ||
-    (usage.reasoning ?? 0) > 0 ||
-    _hasCost(usage.cost)
-  );
-}
-
-/** Sum provider usage across every assistant/model step in a thread snapshot. */
-export function aggregateThreadUsage(
-  thread: ThreadSnapshot
-): ModelUsage | null {
-  return aggregateMessageUsage(thread.context?.messages ?? []);
-}
-
-/**
- * Usage displayed for a saved run. New snapshots store the run's own delta; old
- * snapshots fall back to summing their whole thread so older files still show a
- * best-effort value instead of going blank.
- */
-export function usageForRun(run: {
-  thread: ThreadSnapshot;
-  usage?: ModelUsage | null;
-}): ModelUsage | null {
-  // Presence matters: new run snapshots store an empty usage marker when the
-  // provider omitted usage, while old snapshots have no `usage` field at all.
-  // Only old snapshots should fall back to cumulative thread aggregation.
-  if (Object.prototype.hasOwnProperty.call(run, "usage")) {
-    return hasModelUsage(run.usage) ? run.usage : null;
-  }
-  return aggregateThreadUsage(run.thread);
-}
-
-/** Sum provider usage across assistant messages, skipping unavailable usage. */
-export function aggregateMessageUsage(messages: Message[]): ModelUsage | null {
-  let total: ModelUsage | null = null;
-  for (const message of messages) {
-    if (message.role !== "assistant" || !hasModelUsage(message.usage)) {
-      continue;
-    }
-    total = total ? addModelUsage(total, message.usage) : message.usage;
-  }
-  return total;
-}
-
-/** Add two provider usage records without changing either input object. */
-export function addModelUsage(a: ModelUsage, b: ModelUsage): ModelUsage {
-  const reasoning = _optionalSum(a.reasoning, b.reasoning);
-  return {
-    input: a.input + b.input,
-    output: a.output + b.output,
-    cacheRead: a.cacheRead + b.cacheRead,
-    cacheWrite: a.cacheWrite + b.cacheWrite,
-    ...(reasoning === undefined ? {} : { reasoning }),
-    totalTokens: _totalTokens(a) + _totalTokens(b),
-    cost: {
-      input: a.cost.input + b.cost.input,
-      output: a.cost.output + b.cost.output,
-      cacheRead: a.cost.cacheRead + b.cost.cacheRead,
-      cacheWrite: a.cost.cacheWrite + b.cost.cacheWrite,
-      total: a.cost.total + b.cost.total,
-    },
-  };
 }
 
 /** Short label for dense rows such as Run history. */
@@ -253,46 +132,10 @@ function _reasoningSummaryParts(
   return reasoning > 0 ? [`${formatter(reasoning)} reasoning`] : [];
 }
 
-function _optionalSum(
-  a: number | undefined,
-  b: number | undefined
-): number | undefined {
-  const total = (a ?? 0) + (b ?? 0);
-  return a === undefined && b === undefined ? undefined : total;
-}
-
-function _hasCost(cost: ModelUsageCost): boolean {
-  return (
-    cost.input > 0 ||
-    cost.output > 0 ||
-    cost.cacheRead > 0 ||
-    cost.cacheWrite > 0 ||
-    cost.total > 0
-  );
-}
-
 function _costBreakdownRows(cost: ModelUsageCost): UsageBreakdownRow[] {
   const total = formatCost(cost.total);
   if (!total) {
     return [];
   }
   return [{ label: "Cost", value: total }];
-}
-
-function _isUsageNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0;
-}
-
-function _isModelUsageCost(cost: unknown): cost is ModelUsageCost {
-  if (!cost || typeof cost !== "object") {
-    return false;
-  }
-  const candidate = cost as Partial<ModelUsageCost>;
-  return (
-    _isUsageNumber(candidate.input) &&
-    _isUsageNumber(candidate.output) &&
-    _isUsageNumber(candidate.cacheRead) &&
-    _isUsageNumber(candidate.cacheWrite) &&
-    _isUsageNumber(candidate.total)
-  );
 }

--- a/apps/desktop/src/components/thread-playground/variable/prompt-variable-display.ts
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variable-display.ts
@@ -1,0 +1,119 @@
+import type { ThreadContext, ThreadSkillsVariable } from "@llm-space/core";
+import {
+  DEFAULT_VARIABLE_VARIANT_NAME,
+  formatCurrentDateVariable,
+  formatSkillsVariable,
+  normalizePromptVariableState,
+  VARIABLE_NAME_RE,
+  type PromptSkill,
+} from "@llm-space/core/thread";
+
+export interface PromptVariableCompletion {
+  name: string;
+  hint: string;
+}
+
+export type VariableResolution =
+  | { status: "ok"; value: string }
+  | { status: "empty"; name: string }
+  | { status: "unknown"; name: string }
+  | { status: "invalid"; name: string };
+
+export function resolvePromptVariableValueSync(
+  name: string,
+  context: ThreadContext | undefined
+):
+  | VariableResolution
+  | { status: "needsSkills"; variable: ThreadSkillsVariable } {
+  if (!VARIABLE_NAME_RE.test(name)) {
+    return { status: "invalid", name };
+  }
+  const state = normalizePromptVariableState(context);
+  const builtIn = state.variables[name];
+  if (builtIn?.type === "currentDate") {
+    return { status: "ok", value: formatCurrentDateVariable(builtIn.format) };
+  }
+  if (builtIn?.type === "skills") {
+    return { status: "needsSkills", variable: builtIn };
+  }
+  const customValues =
+    state.variableVariants.variants[DEFAULT_VARIABLE_VARIANT_NAME] ?? {};
+  if (!(name in customValues)) {
+    return { status: "unknown", name };
+  }
+  const raw = customValues[name];
+  return raw?.trim() ? { status: "ok", value: raw } : { status: "empty", name };
+}
+
+export async function resolvePromptVariableValue(
+  name: string,
+  context: ThreadContext | undefined,
+  loadSkills: () => Promise<PromptSkill[]>
+): Promise<VariableResolution> {
+  const fast = resolvePromptVariableValueSync(name, context);
+  if (fast.status !== "needsSkills") {
+    return fast;
+  }
+  try {
+    const all = await loadSkills();
+    const byName = new Map(all.map((skill) => [skill.name, skill]));
+    const selected =
+      fast.variable.skillNames.length === 0
+        ? all
+        : fast.variable.skillNames.flatMap((skillName) => {
+            const skill = byName.get(skillName);
+            return skill ? [skill] : [];
+          });
+    const value = formatSkillsVariable(selected, fast.variable);
+    return value.trim() ? { status: "ok", value } : { status: "empty", name };
+  } catch {
+    return { status: "unknown", name };
+  }
+}
+
+export function resolvePromptVariableValueForPlace(
+  name: string,
+  context: ThreadContext | undefined,
+  placeKey: string | undefined,
+  loadSkills: () => Promise<PromptSkill[]>
+): Promise<VariableResolution> {
+  if (!VARIABLE_NAME_RE.test(name)) {
+    return Promise.resolve({ status: "invalid", name });
+  }
+  const frozen =
+    placeKey === undefined
+      ? undefined
+      : context?.snapshot?.variables?.[placeKey]?.[name];
+  if (frozen !== undefined) {
+    return Promise.resolve({ status: "ok", value: frozen });
+  }
+  return resolvePromptVariableValue(name, context, loadSkills);
+}
+
+export function listPromptVariableCompletions(
+  context: ThreadContext | undefined
+): PromptVariableCompletion[] {
+  const state = normalizePromptVariableState(context);
+  const items: PromptVariableCompletion[] = [];
+  for (const [name, variable] of Object.entries(state.variables)) {
+    const hint =
+      variable.type === "currentDate"
+        ? formatCurrentDateVariable(variable.format)
+        : variable.skillNames.length === 0
+          ? "All enabled skills"
+          : `${variable.skillNames.length} selected skill${
+              variable.skillNames.length === 1 ? "" : "s"
+            }`;
+    items.push({ name, hint });
+  }
+  const customValues =
+    state.variableVariants.variants[DEFAULT_VARIABLE_VARIANT_NAME] ?? {};
+  for (const [name, value] of Object.entries(customValues)) {
+    items.push({ name, hint: value.trim() ? _singleLine(value) : "(empty)" });
+  }
+  return items.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function _singleLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}

--- a/apps/desktop/src/components/thread-playground/variable/prompt-variable-extension.ts
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variable-extension.ts
@@ -20,7 +20,7 @@ import {
 import type {
   PromptVariableCompletion,
   VariableResolution,
-} from "./prompt-variables";
+} from "./prompt-variable-display";
 
 /**
  * Resolves a `{{name}}` to its display value. May return synchronously (date /

--- a/apps/desktop/src/components/thread-playground/variable/prompt-variable-options.ts
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variable-options.ts
@@ -1,0 +1,24 @@
+import type {
+  PromptDateVariableFormat,
+  PromptSkillsVariableFormat,
+} from "@llm-space/core/thread";
+
+interface PromptVariableFormatOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export const PROMPT_DATE_FORMATS: readonly PromptVariableFormatOption<PromptDateVariableFormat>[] =
+  [
+    { value: "readable-date", label: "Readable date" },
+    { value: "iso-date", label: "ISO date" },
+    { value: "local-date-time", label: "Local date and time" },
+  ];
+
+export const PROMPT_SKILLS_FORMATS: readonly PromptVariableFormatOption<PromptSkillsVariableFormat>[] =
+  [
+    { value: "xml", label: "XML" },
+    { value: "markdown-list", label: "Markdown list" },
+  ];
+
+export const PROMPT_SKILLS_INDENTS = [0, 2, 4] as const;

--- a/apps/desktop/src/components/thread-playground/variable/prompt-variable-skills.ts
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variable-skills.ts
@@ -1,0 +1,19 @@
+import { getSkillsSettings, listSkills } from "@/client/skills";
+import type { SkillInfo } from "@/shared/skills";
+
+/** Return enabled local skills in stable name order for core prompt rendering. */
+export async function listEnabledPromptVariableSkills(): Promise<SkillInfo[]> {
+  const { discoveryPaths } = await getSkillsSettings();
+  const perPath = await Promise.all(
+    discoveryPaths.map((entry) =>
+      listSkills(entry.path).catch((): SkillInfo[] => [])
+    )
+  );
+  const byName = new Map<string, SkillInfo>();
+  for (const skill of perPath.flat()) {
+    if (skill.enabled && !byName.has(skill.name)) {
+      byName.set(skill.name, skill);
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/desktop/src/components/thread-playground/variable/prompt-variables-list-view.tsx
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variables-list-view.tsx
@@ -5,6 +5,10 @@ import type {
   ThreadVariable,
 } from "@llm-space/core";
 import {
+  DEFAULT_VARIABLE_VARIANT_NAME,
+  normalizePromptVariableState,
+} from "@llm-space/core/thread";
+import {
   BracesIcon,
   CalendarDaysIcon,
   CopyIcon,
@@ -22,11 +26,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "../../ui/button";
 import { useThreadStore } from "../stores";
 
-import {
-  DEFAULT_VARIABLE_VARIANT_NAME,
-  normalizePromptVariableState,
-  PROMPT_DATE_FORMATS,
-} from "./prompt-variables";
+import { PROMPT_DATE_FORMATS } from "./prompt-variable-options";
 import { PromptVariablesDialog } from "./prompt-variables-dialog";
 import type { PromptVariableSelection } from "./prompt-variables-panel";
 

--- a/apps/desktop/src/components/thread-playground/variable/prompt-variables-panel.tsx
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variables-panel.tsx
@@ -6,6 +6,13 @@ import type {
   ThreadVariable,
 } from "@llm-space/core";
 import {
+  DEFAULT_VARIABLE_VARIANT_NAME,
+  formatCurrentDateVariable,
+  formatSkillsVariable,
+  normalizePromptVariableState,
+  VARIABLE_NAME_RE,
+} from "@llm-space/core/thread";
+import {
   BracesIcon,
   CalendarDaysIcon,
   ListFilterIcon,
@@ -42,16 +49,11 @@ import { Textarea } from "../../ui/textarea";
 import { useThreadStore, useThreadStoreActions } from "../stores";
 
 import {
-  DEFAULT_VARIABLE_VARIANT_NAME,
-  formatCurrentDateVariable,
-  formatSkillsVariable,
-  listEnabledPromptVariableSkills,
-  normalizePromptVariableState,
   PROMPT_DATE_FORMATS,
   PROMPT_SKILLS_FORMATS,
   PROMPT_SKILLS_INDENTS,
-  VARIABLE_NAME_RE,
-} from "./prompt-variables";
+} from "./prompt-variable-options";
+import { listEnabledPromptVariableSkills } from "./prompt-variable-skills";
 import { SkillSelectionDialog } from "./skill-selection-dialog";
 
 interface PromptVariablesPanelProps {

--- a/apps/desktop/src/components/thread-playground/variable/use-prompt-variable-extension.ts
+++ b/apps/desktop/src/components/thread-playground/variable/use-prompt-variable-extension.ts
@@ -7,12 +7,12 @@ import type { SkillInfo } from "@/shared/skills";
 
 import { ThreadStoreContext, type ThreadStore } from "../stores";
 
-import { createPromptVariableExtension } from "./prompt-variable-extension";
 import {
-  listEnabledPromptVariableSkills,
   listPromptVariableCompletions,
   resolvePromptVariableValueForPlace,
-} from "./prompt-variables";
+} from "./prompt-variable-display";
+import { createPromptVariableExtension } from "./prompt-variable-extension";
+import { listEnabledPromptVariableSkills } from "./prompt-variable-skills";
 
 // Skills settings are global (not per-thread), so the resolved list is cached
 // module-wide with a short TTL and in-flight de-dupe. Repeated hovers over a

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts",
     "./client": "./src/client/index.ts",
     "./server": "./src/server/index.ts",
+    "./thread": "./src/thread/index.ts",
     "./types": "./src/types/index.ts",
     "./package.json": "./package.json"
   },

--- a/packages/core/src/thread/history.test.ts
+++ b/packages/core/src/thread/history.test.ts
@@ -1,10 +1,13 @@
-import type { Thread } from "@llm-space/core";
 import { describe, expect, test } from "bun:test";
 
+import type { Thread } from "../types";
+
 import {
+  MAX_RUN_HISTORY,
   normalizeEvaluationRubrics,
   normalizeEvaluations,
   normalizeRunHistory,
+  recordRun,
   snapshotEvaluationRubric,
   upsertEvaluation,
   upsertEvaluationRubric,
@@ -12,7 +15,7 @@ import {
   type EvaluationRecord,
   type EvaluationRubricRecord,
   type RunSnapshot,
-} from "./thread-history";
+} from "./history";
 
 const RUNS: RunSnapshot[] = [
   { id: "run-a", thread: {}, timestamp: 1 },
@@ -158,6 +161,49 @@ describe("evaluation rubrics", () => {
       })
     ).toBeNull();
   });
+
+  test("rejects an injected id already owned by another rubric", () => {
+    const existing = { ..._createRubric(), id: "rubric-existing" };
+    expect(
+      upsertEvaluationRubric(
+        [existing],
+        { name: "New rubric", criteria: CRITERIA },
+        20,
+        { id: existing.id }
+      )
+    ).toBeNull();
+  });
+});
+
+describe("run history persistence", () => {
+  test("backfills stable ids and retains only the newest runs", () => {
+    const raw = Array.from({ length: MAX_RUN_HISTORY + 2 }, (_, index) => ({
+      thread: { title: `Run ${index}` },
+      timestamp: index + 0.9,
+    }));
+    const normalized = normalizeRunHistory(raw);
+
+    expect(normalized).toHaveLength(MAX_RUN_HISTORY);
+    expect(normalized[0]?.id).toBe("run-2-2");
+    expect(normalized.at(-1)?.id).toBe(
+      `run-${MAX_RUN_HISTORY + 1}-${MAX_RUN_HISTORY + 1}`
+    );
+  });
+
+  test("does not append beyond the run cap", () => {
+    const runs = Array.from({ length: MAX_RUN_HISTORY }, (_, index) => ({
+      id: `run-${index}`,
+      thread: {},
+      timestamp: index,
+    }));
+    const next = recordRun(runs, { title: "Latest" }, 100, {
+      id: "run-latest",
+    });
+
+    expect(next).toHaveLength(MAX_RUN_HISTORY);
+    expect(next[0]?.id).toBe("run-1");
+    expect(next.at(-1)?.id).toBe("run-latest");
+  });
 });
 
 describe("structured evaluation persistence", () => {
@@ -243,6 +289,24 @@ describe("structured evaluation persistence", () => {
       createdAt: original.createdAt,
       updatedAt: 30,
     });
+  });
+
+  test("rejects an injected id already owned by another evaluation", () => {
+    const existing = _legacyEvaluation();
+    const runs = [...RUNS, { id: "run-c", thread: {}, timestamp: 3 }];
+    expect(
+      upsertEvaluation(
+        [existing],
+        runs,
+        {
+          id: existing.id,
+          leftRunId: "run-a",
+          rightRunId: "run-c",
+          verdict: "tie",
+        },
+        40
+      )
+    ).toBeNull();
   });
 
   test("keeps the last valid duplicate run ID and unordered evaluation pair", () => {

--- a/packages/core/src/thread/history.ts
+++ b/packages/core/src/thread/history.ts
@@ -1,0 +1,665 @@
+import type {
+  ModelUsage,
+  Thread,
+  ThreadEvaluationCriterion,
+  ThreadEvaluation,
+  ThreadEvaluationRubric,
+  ThreadEvaluationRubricSnapshot,
+  ThreadEvaluationRunScores,
+  ThreadRunSnapshot,
+  ThreadSnapshot,
+} from "../types";
+import { uuid } from "../utils";
+
+import { emptyModelUsage, isModelUsage } from "./usage";
+
+/** Maximum number of run snapshots retained in `runHistory`. */
+export const MAX_RUN_HISTORY = 20;
+
+/** Maximum number of manual evaluation records retained per thread. */
+export const MAX_EVALUATIONS = 50;
+
+/** Maximum number of reusable evaluation rubrics retained per thread. */
+export const MAX_EVALUATION_RUBRICS = 20;
+
+/** Minimum and maximum ordered criteria in one V1 rubric. */
+export const MIN_RUBRIC_CRITERIA = 2;
+export const MAX_RUBRIC_CRITERIA = 6;
+
+export const MAX_RUBRIC_NAME_LENGTH = 80;
+export const MAX_CRITERION_NAME_LENGTH = 80;
+export const MAX_CRITERION_DESCRIPTION_LENGTH = 240;
+
+export type RunSnapshot = ThreadRunSnapshot & { id: string };
+export type EvaluationRecord = ThreadEvaluation;
+export type EvaluationCriterion = ThreadEvaluationCriterion;
+export type EvaluationRubricRecord = ThreadEvaluationRubric;
+export type EvaluationRubricSnapshot = ThreadEvaluationRubricSnapshot;
+export type EvaluationRunScores = ThreadEvaluationRunScores;
+
+export interface EvaluationRubricInput {
+  id?: string;
+  name: string;
+  criteria: EvaluationCriterion[];
+}
+
+function _asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function _trimmed(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function _trimBounded(value: unknown, maxLength: number): string | null {
+  return _trimmed(value)?.slice(0, maxLength) ?? null;
+}
+
+/**
+ * Create a de-nested thread snapshot for durable run history. The returned
+ * object intentionally drops `runHistory`, otherwise each completed run would
+ * persist the entire previous timeline inside the new entry.
+ */
+export function snapshotThread(thread: Thread): ThreadSnapshot {
+  const snapshot: ThreadSnapshot = {};
+  if (thread.title !== undefined) {
+    snapshot.title = thread.title;
+  }
+  if (thread.model !== undefined) {
+    snapshot.model = thread.model;
+  }
+  if (thread.context !== undefined) {
+    snapshot.context = thread.context;
+  }
+  return snapshot;
+}
+
+/** Build a deterministic ID for old timestamp-only runs. */
+function _fallbackRunId(run: ThreadRunSnapshot, index: number): string {
+  return `run-${Math.trunc(run.timestamp)}-${index}`;
+}
+
+/**
+ * Normalize persisted run history read from a thread file, trimming malformed
+ * timestamps and enforcing the same recent-run cap used for newly recorded runs.
+ */
+export function normalizeRunHistory(
+  runHistory: Thread["runHistory"]
+): RunSnapshot[] {
+  if (!Array.isArray(runHistory)) {
+    return [];
+  }
+  const normalized = runHistory.flatMap((run, index): RunSnapshot[] => {
+    if (!Number.isFinite(run.timestamp)) {
+      return [];
+    }
+    const id =
+      typeof run.id === "string" && run.id.trim()
+        ? run.id
+        : _fallbackRunId(run, index);
+    const usage =
+      Object.prototype.hasOwnProperty.call(run, "usage") &&
+      isModelUsage(run.usage)
+        ? run.usage
+        : undefined;
+    return [
+      {
+        id,
+        timestamp: run.timestamp,
+        thread: snapshotThread(run.thread),
+        ...(usage ? { usage } : {}),
+      },
+    ];
+  });
+  const lastIndexById = new Map(
+    normalized.map((run, index) => [run.id, index] as const)
+  );
+  const deduped = normalized.filter(
+    (run, index) => lastIndexById.get(run.id) === index
+  );
+  return deduped.length > MAX_RUN_HISTORY
+    ? deduped.slice(deduped.length - MAX_RUN_HISTORY)
+    : deduped;
+}
+
+function _normalizeCriterion(
+  value: unknown,
+  seenIds: Set<string>,
+  seenNames: Set<string>
+): EvaluationCriterion | null {
+  const criterion = _asRecord(value);
+  if (!criterion) {
+    return null;
+  }
+  const id = _trimmed(criterion.id);
+  const name = _trimBounded(criterion.name, MAX_CRITERION_NAME_LENGTH);
+  const normalizedName = name?.toLowerCase();
+  if (
+    !id ||
+    !name ||
+    !normalizedName ||
+    seenIds.has(id) ||
+    seenNames.has(normalizedName)
+  ) {
+    return null;
+  }
+  seenIds.add(id);
+  seenNames.add(normalizedName);
+  const description = _trimBounded(
+    criterion.description,
+    MAX_CRITERION_DESCRIPTION_LENGTH
+  );
+  return { id, name, ...(description ? { description } : {}) };
+}
+
+function _normalizeCriteria(value: unknown): EvaluationCriterion[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+  const criteria = value
+    .flatMap((criterion): EvaluationCriterion[] => {
+      const normalized = _normalizeCriterion(criterion, seenIds, seenNames);
+      return normalized ? [normalized] : [];
+    })
+    .slice(0, MAX_RUBRIC_CRITERIA);
+  return criteria.length >= MIN_RUBRIC_CRITERIA ? criteria : null;
+}
+
+function _normalizeRubricSnapshot(
+  value: unknown
+): EvaluationRubricSnapshot | null {
+  const rubric = _asRecord(value);
+  if (!rubric) {
+    return null;
+  }
+  const id = _trimmed(rubric.id);
+  const name = _trimBounded(rubric.name, MAX_RUBRIC_NAME_LENGTH);
+  const criteria = _normalizeCriteria(rubric.criteria);
+  if (
+    !id ||
+    !name ||
+    !criteria ||
+    !Number.isSafeInteger(rubric.revision) ||
+    (rubric.revision as number) < 1
+  ) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    criteria,
+    revision: rubric.revision as number,
+  };
+}
+
+function _normalizeEvaluationRubric(
+  value: unknown
+): EvaluationRubricRecord | null {
+  const rubric = _asRecord(value);
+  const snapshot = _normalizeRubricSnapshot(value);
+  if (
+    !rubric ||
+    !snapshot ||
+    !Number.isFinite(rubric.createdAt) ||
+    !Number.isFinite(rubric.updatedAt)
+  ) {
+    return null;
+  }
+  return {
+    ...snapshot,
+    createdAt: rubric.createdAt as number,
+    updatedAt: rubric.updatedAt as number,
+  };
+}
+
+/** Normalize bounded thread-owned rubric definitions read from disk. */
+export function normalizeEvaluationRubrics(
+  rubrics: Thread["evaluationRubrics"]
+): EvaluationRubricRecord[] {
+  if (!Array.isArray(rubrics)) {
+    return [];
+  }
+  const normalized: EvaluationRubricRecord[] = [];
+  const indexById = new Map<string, number>();
+  for (const value of rubrics as unknown[]) {
+    const rubric = _normalizeEvaluationRubric(value);
+    if (!rubric) {
+      continue;
+    }
+    const existingIndex = indexById.get(rubric.id);
+    if (existingIndex === undefined) {
+      indexById.set(rubric.id, normalized.length);
+      normalized.push(rubric);
+    } else {
+      normalized[existingIndex] = rubric;
+    }
+  }
+  return normalized.length > MAX_EVALUATION_RUBRICS
+    ? normalized.slice(normalized.length - MAX_EVALUATION_RUBRICS)
+    : normalized;
+}
+
+/** Copy the durable structure of a definition into an evaluation record. */
+export function snapshotEvaluationRubric(
+  rubric: EvaluationRubricRecord
+): EvaluationRubricSnapshot {
+  return {
+    id: rubric.id,
+    name: rubric.name,
+    revision: rubric.revision,
+    criteria: rubric.criteria.map((criterion) => ({ ...criterion })),
+  };
+}
+
+function _sameCriteria(
+  left: EvaluationCriterion[],
+  right: EvaluationCriterion[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((criterion, index) => {
+      const other = right[index];
+      return (
+        criterion.id === other?.id &&
+        criterion.name === other.name &&
+        criterion.description === other.description
+      );
+    })
+  );
+}
+
+/** Create or update one reusable rubric definition. */
+export function upsertEvaluationRubric(
+  rubrics: EvaluationRubricRecord[],
+  input: EvaluationRubricInput,
+  timestamp: number = Date.now(),
+  options: { id?: string } = {}
+): {
+  rubric: EvaluationRubricRecord;
+  rubrics: EvaluationRubricRecord[];
+} | null {
+  const normalized = normalizeEvaluationRubrics(rubrics);
+  const name = _trimBounded(input.name, MAX_RUBRIC_NAME_LENGTH);
+  const criteria = _normalizeCriteria(input.criteria);
+  const requestedId =
+    options.id === undefined ? undefined : _trimmed(options.id);
+  if (
+    !name ||
+    criteria?.length !== input.criteria.length ||
+    !Number.isFinite(timestamp) ||
+    (options.id !== undefined && !requestedId)
+  ) {
+    return null;
+  }
+  const existingIndex = input.id
+    ? normalized.findIndex((rubric) => rubric.id === input.id)
+    : -1;
+  if (input.id && existingIndex === -1) {
+    return null;
+  }
+  if (!input.id && normalized.length >= MAX_EVALUATION_RUBRICS) {
+    return null;
+  }
+  const existing = existingIndex === -1 ? undefined : normalized[existingIndex];
+  if (
+    !existing &&
+    requestedId &&
+    normalized.some((rubric) => rubric.id === requestedId)
+  ) {
+    return null;
+  }
+  if (existing?.revision === Number.MAX_SAFE_INTEGER) {
+    return null;
+  }
+  if (existing?.name === name && _sameCriteria(existing.criteria, criteria)) {
+    return { rubric: existing, rubrics: normalized };
+  }
+  const rubric: EvaluationRubricRecord = {
+    id: existing?.id ?? requestedId ?? uuid(),
+    name,
+    criteria,
+    revision: (existing?.revision ?? 0) + 1,
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+  };
+  const next =
+    existingIndex === -1
+      ? [...normalized, rubric]
+      : normalized.map((value, index) =>
+          index === existingIndex ? rubric : value
+        );
+  return { rubric, rubrics: next };
+}
+
+function _normalizeRunScores(
+  value: unknown,
+  rubric: EvaluationRubricSnapshot,
+  leftRunId: string,
+  rightRunId: string
+): EvaluationRunScores[] | null {
+  if (!Array.isArray(value) || value.length !== 2) {
+    return null;
+  }
+  const allowedRunIds = new Set([leftRunId, rightRunId]);
+  const scoreByRunId = new Map<string, Map<string, number>>();
+  for (const rawRunScores of value) {
+    const runScores = _asRecord(rawRunScores);
+    const runId = _trimmed(runScores?.runId);
+    if (
+      !runScores ||
+      !runId ||
+      !allowedRunIds.has(runId) ||
+      scoreByRunId.has(runId) ||
+      !Array.isArray(runScores.scores) ||
+      runScores.scores.length !== rubric.criteria.length
+    ) {
+      return null;
+    }
+    const scores = new Map<string, number>();
+    for (const rawScore of runScores.scores) {
+      const score = _asRecord(rawScore);
+      const criterionId = _trimmed(score?.criterionId);
+      if (
+        !score ||
+        !criterionId ||
+        scores.has(criterionId) ||
+        !Number.isInteger(score.score) ||
+        (score.score as number) < 1 ||
+        (score.score as number) > 5
+      ) {
+        return null;
+      }
+      scores.set(criterionId, score.score as number);
+    }
+    scoreByRunId.set(runId, scores);
+  }
+  const criterionIds = new Set(
+    rubric.criteria.map((criterion) => criterion.id)
+  );
+  if (
+    scoreByRunId.size !== 2 ||
+    [...scoreByRunId.values()].some(
+      (scores) =>
+        scores.size !== criterionIds.size ||
+        [...scores.keys()].some((criterionId) => !criterionIds.has(criterionId))
+    )
+  ) {
+    return null;
+  }
+  return [leftRunId, rightRunId].map((runId) => {
+    const scores = scoreByRunId.get(runId)!;
+    return {
+      runId,
+      scores: rubric.criteria.map((criterion) => ({
+        criterionId: criterion.id,
+        score: scores.get(criterion.id)!,
+      })),
+    };
+  });
+}
+
+/** Check whether a value is a supported persisted evaluation verdict. */
+function _isEvaluationVerdict(
+  value: unknown
+): value is EvaluationRecord["verdict"] {
+  return (
+    value === "leftBetter" ||
+    value === "rightBetter" ||
+    value === "tie" ||
+    value === "pass" ||
+    value === "fail"
+  );
+}
+
+/**
+ * Normalize persisted evaluations and drop records whose compared runs no
+ * longer exist in the bounded run history.
+ */
+export function normalizeEvaluations(
+  evaluations: Thread["evaluations"],
+  runHistory: RunSnapshot[]
+): EvaluationRecord[] {
+  if (!Array.isArray(evaluations)) {
+    return [];
+  }
+  const runIds = new Set(runHistory.map((run) => run.id));
+  const normalized = (evaluations as unknown[]).flatMap(
+    (value, index): EvaluationRecord[] => {
+      const evaluation = _asRecord(value);
+      if (
+        !evaluation ||
+        typeof evaluation.leftRunId !== "string" ||
+        typeof evaluation.rightRunId !== "string" ||
+        evaluation.leftRunId === evaluation.rightRunId ||
+        !_isEvaluationVerdict(evaluation.verdict) ||
+        !Number.isFinite(evaluation.createdAt) ||
+        !Number.isFinite(evaluation.updatedAt) ||
+        !runIds.has(evaluation.leftRunId) ||
+        !runIds.has(evaluation.rightRunId)
+      ) {
+        return [];
+      }
+      const id =
+        typeof evaluation.id === "string" && evaluation.id.trim()
+          ? evaluation.id
+          : `evaluation-${evaluation.leftRunId}-${evaluation.rightRunId}-${index}`;
+      const hasStructuredPayload =
+        Object.prototype.hasOwnProperty.call(evaluation, "rubric") ||
+        Object.prototype.hasOwnProperty.call(evaluation, "runScores");
+      const rubric = hasStructuredPayload
+        ? _normalizeRubricSnapshot(evaluation.rubric)
+        : null;
+      const runScores = rubric
+        ? _normalizeRunScores(
+            evaluation.runScores,
+            rubric,
+            evaluation.leftRunId,
+            evaluation.rightRunId
+          )
+        : null;
+      const base = {
+        id,
+        leftRunId: evaluation.leftRunId,
+        rightRunId: evaluation.rightRunId,
+        verdict: evaluation.verdict,
+        note:
+          typeof evaluation.note === "string" && evaluation.note.trim()
+            ? evaluation.note.trim()
+            : undefined,
+        createdAt: evaluation.createdAt as number,
+        updatedAt: evaluation.updatedAt as number,
+      };
+      return rubric && runScores ? [{ ...base, rubric, runScores }] : [base];
+    }
+  );
+  const seenIds = new Set<string>();
+  const seenPairs = new Set<string>();
+  const deduped: EvaluationRecord[] = [];
+  for (let index = normalized.length - 1; index >= 0; index--) {
+    const evaluation = normalized[index]!;
+    const pairKey = JSON.stringify(
+      [evaluation.leftRunId, evaluation.rightRunId].sort()
+    );
+    if (seenIds.has(evaluation.id) || seenPairs.has(pairKey)) {
+      continue;
+    }
+    seenIds.add(evaluation.id);
+    seenPairs.add(pairKey);
+    deduped.push(evaluation);
+  }
+  deduped.reverse();
+  return deduped.length > MAX_EVALUATIONS
+    ? deduped.slice(deduped.length - MAX_EVALUATIONS)
+    : deduped;
+}
+
+/**
+ * Attach durable run/evaluation records to a thread while omitting empty fields.
+ * This keeps old thread files tidy until the user creates these records.
+ */
+export function withRunMetadata(
+  thread: Thread,
+  {
+    runHistory,
+    evaluations = normalizeEvaluations(
+      thread.evaluations,
+      normalizeRunHistory(runHistory)
+    ),
+    evaluationRubrics = normalizeEvaluationRubrics(thread.evaluationRubrics),
+  }: {
+    runHistory: RunSnapshot[];
+    evaluations?: EvaluationRecord[];
+    evaluationRubrics?: EvaluationRubricRecord[];
+  }
+): Thread {
+  const normalized = normalizeRunHistory(runHistory);
+  const normalizedEvaluations = normalizeEvaluations(evaluations, normalized);
+  const normalizedRubrics = normalizeEvaluationRubrics(evaluationRubrics);
+  const next: Thread = snapshotThread(thread);
+  if (normalized.length > 0) {
+    next.runHistory = normalized;
+  }
+  if (normalizedEvaluations.length > 0) {
+    next.evaluations = normalizedEvaluations;
+  }
+  if (normalizedRubrics.length > 0) {
+    next.evaluationRubrics = normalizedRubrics;
+  }
+  return next;
+}
+
+/**
+ * Append a snapshot of a completed run, keeping only the most recent
+ * {@link MAX_RUN_HISTORY}. The thread is stored by reference and shares unchanged
+ * substructure with the live thread, so this stays cheap.
+ */
+export function recordRun(
+  runHistory: RunSnapshot[],
+  thread: Thread,
+  timestamp: number = Date.now(),
+  options: { id?: string; usage?: ModelUsage | null } = {}
+): RunSnapshot[] {
+  const usage = options.usage ?? emptyModelUsage();
+  const next = [
+    ...normalizeRunHistory(runHistory),
+    {
+      id: options.id ?? uuid(),
+      thread: snapshotThread(thread),
+      timestamp,
+      usage,
+    },
+  ];
+  return next.length > MAX_RUN_HISTORY
+    ? next.slice(next.length - MAX_RUN_HISTORY)
+    : next;
+}
+
+/** Check whether two left/right run IDs describe the same comparison pair. */
+function _isSameRunPair(
+  leftRunId: string,
+  rightRunId: string,
+  otherLeftRunId: string,
+  otherRightRunId: string
+): boolean {
+  return (
+    (leftRunId === otherLeftRunId && rightRunId === otherRightRunId) ||
+    (leftRunId === otherRightRunId && rightRunId === otherLeftRunId)
+  );
+}
+
+/**
+ * Create or update an evaluation for a run pair. The persisted left/right
+ * orientation follows the latest save, but matching is order-insensitive so a
+ * reversed A/B selection updates the existing comparison instead of duplicating it.
+ */
+export function upsertEvaluation(
+  evaluations: EvaluationRecord[],
+  runHistory: RunSnapshot[],
+  input: {
+    id?: string;
+    leftRunId: string;
+    rightRunId: string;
+    verdict: EvaluationRecord["verdict"];
+    note?: string;
+    rubric?: EvaluationRubricSnapshot;
+    runScores?: EvaluationRunScores[];
+  },
+  timestamp: number = Date.now()
+): EvaluationRecord[] | null {
+  const normalizedRunHistory = normalizeRunHistory(runHistory);
+  const normalized = normalizeEvaluations(evaluations, normalizedRunHistory);
+  const requestedId = input.id === undefined ? undefined : _trimmed(input.id);
+  const runIds = new Set(normalizedRunHistory.map((run) => run.id));
+  if (
+    (input.id !== undefined && !requestedId) ||
+    input.leftRunId === input.rightRunId ||
+    !runIds.has(input.leftRunId) ||
+    !runIds.has(input.rightRunId)
+  ) {
+    return null;
+  }
+  const hasStructuredPayload =
+    input.rubric !== undefined || input.runScores !== undefined;
+  const rubric = hasStructuredPayload
+    ? _normalizeRubricSnapshot(input.rubric)
+    : null;
+  const runScores = rubric
+    ? _normalizeRunScores(
+        input.runScores,
+        rubric,
+        input.leftRunId,
+        input.rightRunId
+      )
+    : null;
+  if (hasStructuredPayload && (!rubric || !runScores)) {
+    return null;
+  }
+  const existingIndex = normalized.findIndex((evaluation) =>
+    _isSameRunPair(
+      evaluation.leftRunId,
+      evaluation.rightRunId,
+      input.leftRunId,
+      input.rightRunId
+    )
+  );
+  const existing = existingIndex === -1 ? undefined : normalized[existingIndex];
+  if (
+    requestedId &&
+    (existing
+      ? requestedId !== existing.id
+      : normalized.some((evaluation) => evaluation.id === requestedId))
+  ) {
+    return null;
+  }
+  const baseEvaluation = {
+    id: existing?.id ?? requestedId ?? uuid(),
+    leftRunId: input.leftRunId,
+    rightRunId: input.rightRunId,
+    verdict: input.verdict,
+    note: input.note?.trim() || undefined,
+    createdAt: existing?.createdAt ?? timestamp,
+    updatedAt: timestamp,
+  };
+  const nextEvaluation: EvaluationRecord =
+    rubric && runScores
+      ? { ...baseEvaluation, rubric, runScores }
+      : baseEvaluation;
+
+  const next =
+    existingIndex === -1
+      ? [...normalized, nextEvaluation]
+      : normalized.map((evaluation, index) =>
+          index === existingIndex ? nextEvaluation : evaluation
+        );
+  return next.length > MAX_EVALUATIONS
+    ? next.slice(next.length - MAX_EVALUATIONS)
+    : next;
+}

--- a/packages/core/src/thread/index.ts
+++ b/packages/core/src/thread/index.ts
@@ -1,0 +1,3 @@
+export * from "./history";
+export * from "./prompt-variables";
+export * from "./usage";

--- a/packages/core/src/thread/prompt-variables.ts
+++ b/packages/core/src/thread/prompt-variables.ts
@@ -13,18 +13,21 @@ import type {
   ThreadVariable,
   ThreadVariableVariants,
   ThreadVariables,
-} from "@llm-space/core";
+} from "../types";
 
-import { getSkillsSettings, listSkills } from "@/client/skills";
-import type { SkillInfo } from "@/shared/skills";
+export interface PromptSkill {
+  name: string;
+  description: string;
+  path: string;
+}
+
+export interface PromptVariableRenderOptions {
+  loadSkills?: () => Promise<PromptSkill[]>;
+  now?: () => Date;
+}
 
 export type PromptDateVariableFormat = ThreadCurrentDateVariableFormat;
 export type PromptSkillsVariableFormat = ThreadSkillsVariableFormat;
-
-export interface PromptVariableFormatOption<T extends string> {
-  value: T;
-  label: string;
-}
 
 export interface PromptVariableState {
   variables: ThreadVariables;
@@ -49,20 +52,6 @@ export interface RenderedThreadPromptVariables {
   variables: RenderedPromptVariable[];
 }
 
-/** A selectable variable for `{{`-triggered autocompletion. */
-export interface PromptVariableCompletion {
-  name: string;
-  /** One-line value preview for the dropdown (skills show a short summary). */
-  hint: string;
-}
-
-/** Outcome of resolving a single `{{name}}` placeholder for hover display. */
-export type VariableResolution =
-  | { status: "ok"; value: string }
-  | { status: "empty"; name: string } // defined but blank/whitespace value
-  | { status: "unknown"; name: string } // neither built-in nor a custom key
-  | { status: "invalid"; name: string }; // name fails VARIABLE_NAME_RE
-
 export class PromptVariableError extends Error {
   constructor(message: string) {
     super(message);
@@ -72,21 +61,6 @@ export class PromptVariableError extends Error {
 
 export const VARIABLE_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9_]*";
 export const VARIABLE_NAME_RE = new RegExp(`^${VARIABLE_NAME_PATTERN}$`);
-
-export const PROMPT_DATE_FORMATS: readonly PromptVariableFormatOption<PromptDateVariableFormat>[] =
-  [
-    { value: "readable-date", label: "Readable date" },
-    { value: "iso-date", label: "ISO date" },
-    { value: "local-date-time", label: "Local date and time" },
-  ];
-
-export const PROMPT_SKILLS_FORMATS: readonly PromptVariableFormatOption<PromptSkillsVariableFormat>[] =
-  [
-    { value: "xml", label: "XML" },
-    { value: "markdown-list", label: "Markdown list" },
-  ];
-
-export const PROMPT_SKILLS_INDENTS = [0, 2, 4] as const;
 
 const DEFAULT_CURRENT_DATE_NAME = "current_date";
 const DEFAULT_SKILLS_NAME = "available_skills";
@@ -190,6 +164,20 @@ export function removePromptVariableSnapshotPlaces(
   return changed ? _buildSnapshot(snapshot, variables) : snapshot;
 }
 
+/** Attach frozen runtime values while preserving the editable thread templates. */
+export function withPromptVariableSnapshot(
+  thread: Thread,
+  snapshot: ThreadContextSnapshot | undefined
+): Thread {
+  const context: ThreadContext = { ...(thread.context ?? {}) };
+  if (snapshot === undefined) {
+    delete context.snapshot;
+  } else {
+    context.snapshot = snapshot;
+  }
+  return { ...thread, context };
+}
+
 /** Return the default built-in variable definitions for a thread. */
 export function createDefaultThreadVariables(): ThreadVariables {
   return {
@@ -266,7 +254,7 @@ export function formatCurrentDateVariable(
 
 /** Format a group of selected skills without inlining their full instructions. */
 export function formatSkillsVariable(
-  skills: SkillInfo[],
+  skills: PromptSkill[],
   variable: ThreadSkillsVariable
 ): string {
   const value =
@@ -277,41 +265,25 @@ export function formatSkillsVariable(
 }
 
 /**
- * List enabled skills across all configured discovery folders, de-duped by
- * name. Reuses the Settings skill model so prompt variables cannot see hidden
- * skills the runtime `skill()` tool would reject.
- */
-export async function listEnabledPromptVariableSkills(): Promise<SkillInfo[]> {
-  const { discoveryPaths } = await getSkillsSettings();
-  const perPath = await Promise.all(
-    discoveryPaths.map((entry) =>
-      listSkills(entry.path).catch((): SkillInfo[] => [])
-    )
-  );
-  const byName = new Map<string, SkillInfo>();
-  for (const skill of perPath.flat()) {
-    if (skill.enabled && !byName.has(skill.name)) {
-      byName.set(skill.name, skill);
-    }
-  }
-  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
-}
-
-/**
  * Resolve supported prompt variables into the concrete system prompt sent to
  * the model. The caller keeps the stored thread template untouched.
  */
 export async function renderSystemPromptVariables({
   systemPrompt,
   context,
+  loadSkills,
+  now,
 }: {
   systemPrompt: string;
   context?: ThreadContext;
-}): Promise<RenderedSystemPrompt> {
+} & PromptVariableRenderOptions): Promise<RenderedSystemPrompt> {
   const state = normalizePromptVariableState(context);
   _assertValidVariableState(state);
 
-  const renderState = _createPromptVariableRenderState(state);
+  const renderState = _createPromptVariableRenderState(state, {
+    loadSkills,
+    now,
+  });
   const rendered: RenderedPromptVariable[] = [];
   const snapshotVariables: SnapshotVariables = {};
   const output = await _renderTextPromptVariables({
@@ -332,13 +304,18 @@ export async function renderSystemPromptVariables({
  */
 export async function renderThreadPromptVariables({
   context,
+  loadSkills,
+  now,
 }: {
   context: ThreadContext;
-}): Promise<RenderedThreadPromptVariables> {
+} & PromptVariableRenderOptions): Promise<RenderedThreadPromptVariables> {
   const state = normalizePromptVariableState(context);
   _assertValidVariableState(state);
 
-  const renderState = _createPromptVariableRenderState(state);
+  const renderState = _createPromptVariableRenderState(state, {
+    loadSkills,
+    now,
+  });
   const rendered: RenderedPromptVariable[] = [];
   const snapshotVariables = _normalizeSnapshotVariables(
     context.snapshot?.variables
@@ -380,129 +357,13 @@ export async function renderThreadPromptVariables({
   };
 }
 
-/**
- * Resolve one variable by name WITHOUT any async work. Handles currentDate and
- * custom-string variables directly; returns `needsSkills` when the name is a
- * skills built-in so the caller can await the async path only when required.
- * Keeps the common hover (date / custom) fully synchronous.
- */
-export function resolvePromptVariableValueSync(
-  name: string,
-  context: ThreadContext | undefined
-):
-  | VariableResolution
-  | { status: "needsSkills"; variable: ThreadSkillsVariable } {
-  if (!VARIABLE_NAME_RE.test(name)) {
-    return { status: "invalid", name };
-  }
-  const state = normalizePromptVariableState(context);
-  const builtIn = state.variables[name];
-  if (builtIn?.type === "currentDate") {
-    return { status: "ok", value: formatCurrentDateVariable(builtIn.format) };
-  }
-  if (builtIn?.type === "skills") {
-    return { status: "needsSkills", variable: builtIn };
-  }
-  const customValues =
-    state.variableVariants.variants[DEFAULT_VARIABLE_VARIANT_NAME] ?? {};
-  if (!(name in customValues)) {
-    return { status: "unknown", name };
-  }
-  const raw = customValues[name];
-  return raw?.trim() ? { status: "ok", value: raw } : { status: "empty", name };
-}
-
-/**
- * Resolve one variable by name for hover display. Never throws. Mirrors the
- * three branches of the runtime resolver but is lenient (drops missing skills,
- * degrades load failures to `unknown`) since this is display-only. `loadSkills`
- * is injected so callers can share a cached skills list across many hovers.
- */
-export async function resolvePromptVariableValue(
-  name: string,
-  context: ThreadContext | undefined,
-  loadSkills: () => Promise<SkillInfo[]> = listEnabledPromptVariableSkills
-): Promise<VariableResolution> {
-  const fast = resolvePromptVariableValueSync(name, context);
-  if (fast.status !== "needsSkills") {
-    return fast;
-  }
-  try {
-    const all = await loadSkills();
-    const byName = new Map(all.map((skill) => [skill.name, skill]));
-    // An empty selection means "all enabled skills".
-    const selected =
-      fast.variable.skillNames.length === 0
-        ? all
-        : fast.variable.skillNames.flatMap((skillName) => {
-            const skill = byName.get(skillName);
-            return skill ? [skill] : [];
-          });
-    const value = formatSkillsVariable(selected, fast.variable);
-    return value.trim() ? { status: "ok", value } : { status: "empty", name };
-  } catch {
-    return { status: "unknown", name };
-  }
-}
-
-/**
- * Resolve a variable for display at a specific prompt place. Frozen snapshot
- * values take precedence; missing values fall back to the live variable config.
- */
-export async function resolvePromptVariableValueForPlace(
-  name: string,
-  context: ThreadContext | undefined,
-  placeKey: string | undefined,
-  loadSkills: () => Promise<SkillInfo[]> = listEnabledPromptVariableSkills
-): Promise<VariableResolution> {
-  if (!VARIABLE_NAME_RE.test(name)) {
-    return { status: "invalid", name };
-  }
-  const frozen =
-    placeKey === undefined
-      ? undefined
-      : context?.snapshot?.variables?.[placeKey]?.[name];
-  if (frozen !== undefined) {
-    return { status: "ok", value: frozen };
-  }
-  return resolvePromptVariableValue(name, context, loadSkills);
-}
-
-/**
- * List every variable available for `{{`-triggered autocompletion (built-ins +
- * custom), each with a one-line, synchronous value preview. Skills show a short
- * summary rather than their full resolved list (which would require async IO).
- */
-export function listPromptVariableCompletions(
-  context: ThreadContext | undefined
-): PromptVariableCompletion[] {
-  const state = normalizePromptVariableState(context);
-  const items: PromptVariableCompletion[] = [];
-  for (const [name, variable] of Object.entries(state.variables)) {
-    const hint =
-      variable.type === "currentDate"
-        ? formatCurrentDateVariable(variable.format)
-        : variable.skillNames.length === 0
-          ? "All enabled skills"
-          : `${variable.skillNames.length} selected skill${
-              variable.skillNames.length === 1 ? "" : "s"
-            }`;
-    items.push({ name, hint });
-  }
-  const customValues =
-    state.variableVariants.variants[DEFAULT_VARIABLE_VARIANT_NAME] ?? {};
-  for (const [name, value] of Object.entries(customValues)) {
-    items.push({ name, hint: value.trim() ? _singleLine(value) : "(empty)" });
-  }
-  return items.sort((a, b) => a.name.localeCompare(b.name));
-}
-
 type SnapshotVariables = Record<string, Record<string, string>>;
 
 interface PromptVariableRenderState {
   state: PromptVariableState;
-  skills: Map<string, SkillInfo>;
+  skills: Map<string, PromptSkill>;
   loadSkills: () => Promise<void>;
+  now: () => Date;
 }
 
 interface RenderTextPromptVariablesInput {
@@ -634,19 +495,22 @@ function _renamePromptVariableSnapshotReference(
 }
 
 function _createPromptVariableRenderState(
-  state: PromptVariableState
+  state: PromptVariableState,
+  options: PromptVariableRenderOptions
 ): PromptVariableRenderState {
-  const skills = new Map<string, SkillInfo>();
+  const skills = new Map<string, PromptSkill>();
   let loadedSkills: Promise<void> | null = null;
   const loadSkills = async () => {
-    loadedSkills ??= listEnabledPromptVariableSkills().then((items) => {
-      for (const item of items) {
-        skills.set(item.name, item);
+    loadedSkills ??= (options.loadSkills?.() ?? Promise.resolve([])).then(
+      (items) => {
+        for (const item of items) {
+          skills.set(item.name, item);
+        }
       }
-    });
+    );
     await loadedSkills;
   };
-  return { state, skills, loadSkills };
+  return { state, skills, loadSkills, now: options.now ?? (() => new Date()) };
 }
 
 async function _renderMessagesPromptVariables({
@@ -780,17 +644,22 @@ async function _renderTextPromptVariables({
       continue;
     }
     const placeholder = match[0];
-    const name = match[1].trim();
+    const name = match[1]?.trim();
+    if (!name) {
+      continue;
+    }
     // Arbitrary "{{...}}" text can appear in message and tool-result content
     // (e.g. a web-search response). Leave any placeholder whose name isn't a
     // valid variable reference untouched rather than failing the whole run.
     if (!VARIABLE_NAME_RE.test(name)) {
       continue;
     }
-    let value: string | undefined = placeValues[name] ?? frozenPlaceValues[name];
+    let value: string | undefined =
+      placeValues[name] ?? frozenPlaceValues[name];
     if (value === undefined) {
       value = await _renderVariableValue(name, renderState.state, {
         loadSkills: renderState.loadSkills,
+        now: renderState.now,
         skills: renderState.skills,
       });
       // Unknown variable name — keep the original placeholder text as-is.
@@ -972,16 +841,18 @@ async function _renderVariableValue(
   state: PromptVariableState,
   {
     loadSkills,
+    now,
     skills,
   }: {
     loadSkills: () => Promise<void>;
-    skills: Map<string, SkillInfo>;
+    now: () => Date;
+    skills: Map<string, PromptSkill>;
   }
 ): Promise<string | undefined> {
   const builtIn = state.variables[name];
   if (builtIn) {
     if (builtIn.type === "currentDate") {
-      return formatCurrentDateVariable(builtIn.format);
+      return formatCurrentDateVariable(builtIn.format, now());
     }
     await loadSkills();
     // An empty selection means "all enabled skills" — the default that keeps
@@ -1020,7 +891,7 @@ function _assertVariableName(name: string, message: string): void {
   }
 }
 
-function _formatSkillsXml(skills: SkillInfo[]): string {
+function _formatSkillsXml(skills: PromptSkill[]): string {
   return [
     "<available-skills>",
     ...skills.flatMap((skill) => [
@@ -1032,7 +903,7 @@ function _formatSkillsXml(skills: SkillInfo[]): string {
   ].join("\n");
 }
 
-function _formatSkillsMarkdownList(skills: SkillInfo[]): string {
+function _formatSkillsMarkdownList(skills: PromptSkill[]): string {
   return skills
     .map(
       (skill) =>

--- a/packages/core/src/thread/thread-workflow.test.ts
+++ b/packages/core/src/thread/thread-workflow.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ModelUsage, Thread } from "@llm-space/core";
+import {
+  aggregateMessageUsage,
+  normalizePromptVariableState,
+  recordRun,
+  renderThreadPromptVariables,
+  snapshotEvaluationRubric,
+  upsertEvaluation,
+  upsertEvaluationRubric,
+  withPromptVariableSnapshot,
+} from "@llm-space/core/thread";
+
+const USAGE: ModelUsage = {
+  input: 10,
+  output: 5,
+  cacheRead: 2,
+  cacheWrite: 0,
+  totalTokens: 17,
+  cost: {
+    input: 0.01,
+    output: 0.02,
+    cacheRead: 0.001,
+    cacheWrite: 0,
+    total: 0.031,
+  },
+};
+
+describe("public headless thread workflow", () => {
+  test("materializes, records, and evaluates without desktop imports", async () => {
+    const template: Thread = {
+      title: "Headless workflow",
+      context: {
+        systemPrompt: "Today: {{current_date}}\n{{available_skills}}",
+        variables: {
+          current_date: { type: "currentDate", format: "iso-date" },
+          available_skills: {
+            type: "skills",
+            skillNames: ["deep-research"],
+            format: "markdown-list",
+            indent: 0,
+          },
+        },
+        variableVariants: {
+          active: "default",
+          variants: { default: { customer: "Acme" } },
+        },
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            content: [{ type: "text", text: "Research {{customer}}" }],
+          },
+        ],
+      },
+    };
+
+    const rendered = await renderThreadPromptVariables({
+      context: template.context!,
+      now: () => new Date(2026, 6, 12, 9, 30),
+      loadSkills: () =>
+        Promise.resolve([
+          {
+            name: "deep-research",
+            description: "Research deeply",
+            path: "/skills/deep-research",
+          },
+        ]),
+    });
+
+    expect(rendered.context.systemPrompt).toBe(
+      "Today: 2026-07-12\n- **deep-research**: Research deeply"
+    );
+    expect(rendered.context.messages?.[0]?.content[0]).toEqual({
+      type: "text",
+      text: "Research Acme",
+    });
+    expect(rendered.snapshot?.variables).toEqual({
+      systemPrompt: {
+        current_date: "2026-07-12",
+        available_skills: "- **deep-research**: Research deeply",
+      },
+      "message:user-1:text": { customer: "Acme" },
+    });
+
+    const completedThread = withPromptVariableSnapshot(
+      {
+        ...template,
+        context: {
+          ...template.context,
+          messages: [
+            ...(template.context?.messages ?? []),
+            {
+              id: "assistant-1",
+              role: "assistant",
+              content: [{ type: "text", text: "Result A" }],
+              usage: USAGE,
+            },
+          ],
+        },
+      },
+      rendered.snapshot
+    );
+    const usage = aggregateMessageUsage(
+      completedThread.context?.messages ?? []
+    );
+    expect(usage).toEqual(USAGE);
+
+    const firstRun = recordRun([], completedThread, 1000, {
+      id: "run-a",
+      usage,
+    });
+    const runs = recordRun(firstRun, completedThread, 2000, {
+      id: "run-b",
+      usage,
+    });
+    const rubricResult = upsertEvaluationRubric(
+      [],
+      {
+        name: "Quality",
+        criteria: [
+          { id: "accuracy", name: "Accuracy" },
+          { id: "clarity", name: "Clarity" },
+        ],
+      },
+      3000,
+      { id: "rubric-1" }
+    );
+    expect(rubricResult).not.toBeNull();
+    const rubric = snapshotEvaluationRubric(rubricResult!.rubric);
+    const evaluations = upsertEvaluation(
+      [],
+      runs,
+      {
+        id: "evaluation-1",
+        leftRunId: "run-a",
+        rightRunId: "run-b",
+        verdict: "rightBetter",
+        rubric,
+        runScores: [
+          {
+            runId: "run-a",
+            scores: [
+              { criterionId: "accuracy", score: 3 },
+              { criterionId: "clarity", score: 4 },
+            ],
+          },
+          {
+            runId: "run-b",
+            scores: [
+              { criterionId: "accuracy", score: 5 },
+              { criterionId: "clarity", score: 5 },
+            ],
+          },
+        ],
+      },
+      4000
+    );
+
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations?.[0]).toMatchObject({
+      id: "evaluation-1",
+      leftRunId: "run-a",
+      rightRunId: "run-b",
+      verdict: "rightBetter",
+      rubric: { id: "rubric-1", revision: 1 },
+    });
+    expect(runs[0]?.thread.context?.systemPrompt).toBe(
+      "Today: {{current_date}}\n{{available_skills}}"
+    );
+    expect(runs[0]?.thread.context?.snapshot).toEqual(rendered.snapshot);
+  });
+
+  test("keeps frozen prompt bytes across later runs", async () => {
+    const context: NonNullable<Thread["context"]> = {
+      systemPrompt: "Date: {{current_date}}",
+      variables: {
+        current_date: { type: "currentDate", format: "iso-date" },
+      },
+    };
+    const first = await renderThreadPromptVariables({
+      context,
+      now: () => new Date(2026, 6, 12, 9, 30),
+    });
+    const second = await renderThreadPromptVariables({
+      context: { ...context, snapshot: first.snapshot },
+      now: () => new Date(2027, 0, 1, 9, 30),
+    });
+
+    expect(first.context.systemPrompt).toBe("Date: 2026-07-12");
+    expect(second.context.systemPrompt).toBe("Date: 2026-07-12");
+  });
+
+  test("normalizes legacy variable configuration", () => {
+    const state = normalizePromptVariableState({
+      variables: {
+        date: { type: "currentDate", format: "legacy" },
+        skills: {
+          type: "skills",
+          skillNames: ["one", 2, "two"],
+          format: "legacy",
+          indent: 3,
+        },
+      },
+      variableVariants: {
+        active: "scenario",
+        variants: { scenario: { customer: "Acme", invalid: 42 } },
+      },
+    } as unknown as NonNullable<Thread["context"]>);
+
+    expect(state).toEqual({
+      variables: {
+        date: { type: "currentDate", format: "readable-date" },
+        skills: {
+          type: "skills",
+          skillNames: ["one", "two"],
+          format: "xml",
+          indent: 0,
+        },
+      },
+      variableVariants: {
+        active: "default",
+        variants: { default: { customer: "Acme" } },
+      },
+    });
+  });
+
+  test("captures independent values for every prompt place", async () => {
+    const rendered = await renderThreadPromptVariables({
+      context: {
+        systemPrompt: "System {{value}}",
+        variableVariants: {
+          active: "default",
+          variants: { default: { value: "frozen" } },
+        },
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            content: [{ type: "text", text: "User {{value}}" }],
+          },
+          {
+            id: "assistant-1",
+            role: "assistant",
+            content: [],
+            toolCalls: [
+              {
+                id: "tool-1",
+                input: { name: "lookup", arguments: {} },
+                output: {
+                  content: [{ type: "text", text: "Tool {{value}}" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(rendered.snapshot?.variables).toEqual({
+      systemPrompt: { value: "frozen" },
+      "message:user-1:text": { value: "frozen" },
+      "toolResult:assistant-1:tool-1:text": { value: "frozen" },
+    });
+  });
+
+  test("preserves the missing-skill error contract", async () => {
+    const render = renderThreadPromptVariables({
+      context: {
+        systemPrompt: "{{available_skills}}",
+        variables: {
+          available_skills: {
+            type: "skills",
+            skillNames: ["missing-skill"],
+            format: "xml",
+            indent: 0,
+          },
+        },
+      },
+      loadSkills: () => Promise.resolve([]),
+    });
+
+    const error = await render.then(
+      () => null,
+      (reason: unknown) => reason
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      'Skill "missing-skill" in variable "available_skills" is not enabled or cannot be found.'
+    );
+  });
+});

--- a/packages/core/src/thread/usage.test.ts
+++ b/packages/core/src/thread/usage.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ModelUsage, ThreadSnapshot } from "../types";
+
+import {
+  addModelUsage,
+  emptyModelUsage,
+  isModelUsage,
+  usageForRun,
+} from "./usage";
+
+const BASE_USAGE: ModelUsage = {
+  input: 10,
+  output: 5,
+  cacheRead: 2,
+  cacheWrite: 1,
+  totalTokens: 18,
+  cost: {
+    input: 0.1,
+    output: 0.2,
+    cacheRead: 0.01,
+    cacheWrite: 0.02,
+    total: 0.33,
+  },
+};
+
+describe("model usage compatibility", () => {
+  test("rejects malformed persisted usage", () => {
+    expect(isModelUsage(BASE_USAGE)).toBe(true);
+    expect(isModelUsage({ ...BASE_USAGE, input: -1 })).toBe(false);
+    expect(isModelUsage({ ...BASE_USAGE, cost: { total: 1 } })).toBe(false);
+    expect(isModelUsage({ ...BASE_USAGE, reasoning: Number.NaN })).toBe(false);
+  });
+
+  test("adds provider usage without mutating either input", () => {
+    const left = structuredClone(BASE_USAGE);
+    const right: ModelUsage = {
+      ...BASE_USAGE,
+      input: 1,
+      output: 2,
+      reasoning: 3,
+      totalTokens: 0,
+    };
+    const total = addModelUsage(left, right);
+
+    expect(total).toMatchObject({
+      input: 11,
+      output: 7,
+      cacheRead: 4,
+      cacheWrite: 2,
+      reasoning: 3,
+      totalTokens: 24,
+      cost: { total: 0.66 },
+    });
+    expect(left).toEqual(BASE_USAGE);
+  });
+
+  test("falls back only for legacy runs without a usage field", () => {
+    const thread: ThreadSnapshot = {
+      context: {
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            content: [{ type: "text", text: "Done" }],
+            usage: BASE_USAGE,
+          },
+        ],
+      },
+    };
+
+    expect(usageForRun({ thread })).toEqual(BASE_USAGE);
+    expect(usageForRun({ thread, usage: emptyModelUsage() })).toBeNull();
+  });
+});

--- a/packages/core/src/thread/usage.ts
+++ b/packages/core/src/thread/usage.ts
@@ -1,0 +1,163 @@
+import type {
+  Message,
+  ModelUsage,
+  ModelUsageCost,
+  ThreadSnapshot,
+} from "../types";
+
+/** Empty usage marker for new runs whose provider omitted usage. */
+export function emptyModelUsage(): ModelUsage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+/** Runtime guard for usage read from durable thread files. */
+export function isModelUsage(usage: unknown): usage is ModelUsage {
+  if (!usage || typeof usage !== "object") {
+    return false;
+  }
+  const candidate = usage as Partial<ModelUsage>;
+  return (
+    _isUsageNumber(candidate.input) &&
+    _isUsageNumber(candidate.output) &&
+    _isUsageNumber(candidate.cacheRead) &&
+    _isUsageNumber(candidate.cacheWrite) &&
+    _isUsageNumber(candidate.totalTokens) &&
+    (candidate.reasoning === undefined ||
+      _isUsageNumber(candidate.reasoning)) &&
+    _isModelUsageCost(candidate.cost)
+  );
+}
+
+/** True when provider-reported usage contains a value worth retaining. */
+export function hasModelUsage(
+  usage: ModelUsage | null | undefined
+): usage is ModelUsage {
+  if (!isModelUsage(usage)) {
+    return false;
+  }
+  return (
+    usage.totalTokens > 0 ||
+    usage.input > 0 ||
+    usage.output > 0 ||
+    usage.cacheRead > 0 ||
+    usage.cacheWrite > 0 ||
+    (usage.reasoning ?? 0) > 0 ||
+    _hasCost(usage.cost)
+  );
+}
+
+export function aggregateThreadUsage(
+  thread: ThreadSnapshot
+): ModelUsage | null {
+  return aggregateMessageUsage(thread.context?.messages ?? []);
+}
+
+/** Preserve the legacy fallback for snapshots saved before per-run usage. */
+export function usageForRun(run: {
+  thread: ThreadSnapshot;
+  usage?: ModelUsage | null;
+}): ModelUsage | null {
+  if (Object.prototype.hasOwnProperty.call(run, "usage")) {
+    return hasModelUsage(run.usage) ? run.usage : null;
+  }
+  return aggregateThreadUsage(run.thread);
+}
+
+export function aggregateMessageUsage(messages: Message[]): ModelUsage | null {
+  let total: ModelUsage | null = null;
+  for (const message of messages) {
+    if (message.role !== "assistant" || !hasModelUsage(message.usage)) {
+      continue;
+    }
+    total = total ? addModelUsage(total, message.usage) : message.usage;
+  }
+  return total;
+}
+
+export function aggregateModelUsage(
+  usages: readonly ModelUsage[]
+): ModelUsage | null {
+  let total: ModelUsage | null = null;
+  for (const usage of usages) {
+    if (!isModelUsage(usage)) {
+      continue;
+    }
+    total = total ? addModelUsage(total, usage) : usage;
+  }
+  return total;
+}
+
+export function addModelUsage(a: ModelUsage, b: ModelUsage): ModelUsage {
+  const reasoning = _optionalSum(a.reasoning, b.reasoning);
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheWrite: a.cacheWrite + b.cacheWrite,
+    ...(reasoning === undefined ? {} : { reasoning }),
+    totalTokens: _totalTokens(a) + _totalTokens(b),
+    cost: {
+      input: a.cost.input + b.cost.input,
+      output: a.cost.output + b.cost.output,
+      cacheRead: a.cost.cacheRead + b.cost.cacheRead,
+      cacheWrite: a.cost.cacheWrite + b.cost.cacheWrite,
+      total: a.cost.total + b.cost.total,
+    },
+  };
+}
+
+function _totalTokens(usage: ModelUsage): number {
+  return (
+    usage.totalTokens ||
+    usage.input + usage.output + usage.cacheRead + usage.cacheWrite
+  );
+}
+
+function _optionalSum(
+  a: number | undefined,
+  b: number | undefined
+): number | undefined {
+  const total = (a ?? 0) + (b ?? 0);
+  return a === undefined && b === undefined ? undefined : total;
+}
+
+function _hasCost(cost: ModelUsageCost): boolean {
+  return (
+    cost.input > 0 ||
+    cost.output > 0 ||
+    cost.cacheRead > 0 ||
+    cost.cacheWrite > 0 ||
+    cost.total > 0
+  );
+}
+
+function _isUsageNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function _isModelUsageCost(cost: unknown): cost is ModelUsageCost {
+  if (!cost || typeof cost !== "object") {
+    return false;
+  }
+  const candidate = cost as Partial<ModelUsageCost>;
+  return (
+    _isUsageNumber(candidate.input) &&
+    _isUsageNumber(candidate.output) &&
+    _isUsageNumber(candidate.cacheRead) &&
+    _isUsageNumber(candidate.cacheWrite) &&
+    _isUsageNumber(candidate.total)
+  );
+}


### PR DESCRIPTION
Move run history, evaluation records, prompt variable rendering, and token
usage aggregation from the desktop app into a new browser-safe `./thread`
entrypoint.  Usage arithmetic, snapshot normalization, and lifecycle rules
are now testable and reusable outside of the desktop process.