### PR TITLE
[react-doctor] Fix no-ref-current-in-render in use-thread-playground-events

### DIFF
--- a/apps/desktop/src/components/thread-playground/use-thread-playground-events.ts
+++ b/apps/desktop/src/components/thread-playground/use-thread-playground-events.ts
@@ -14,13 +14,17 @@ export function useThreadPlaygroundEvents(
   callbacks: ThreadPlaygroundEventCallbacks
 ): void {
   const onChangeRef = useRef(callbacks.onChange);
-  onChangeRef.current = callbacks.onChange;
-
   const onStreamingStartRef = useRef(callbacks.onStreamingStart);
-  onStreamingStartRef.current = callbacks.onStreamingStart;
-
   const onStreamingEndRef = useRef(callbacks.onStreamingEnd);
-  onStreamingEndRef.current = callbacks.onStreamingEnd;
+
+  // Keep the callback refs current after each commit. The store subscription
+  // below reads them only when the store fires (always post-commit), so a
+  // passive effect is enough and avoids mutating refs during render.
+  useEffect(() => {
+    onChangeRef.current = callbacks.onChange;
+    onStreamingStartRef.current = callbacks.onStreamingStart;
+    onStreamingEndRef.current = callbacks.onStreamingEnd;
+  });
 
   useEffect(() => {
     return store.subscribe((state, prevState) => {


### PR DESCRIPTION
## Issue
react-doctor **0.7.6** (bumped from 0.7.4 this run) added the error-tier rule `no-ref-current-in-render`. In `useThreadPlaygroundEvents`, three callback refs were assigned during render:

```ts
const onChangeRef = useRef(callbacks.onChange);
onChangeRef.current = callbacks.onChange;   // mutated during render
// …onStreamingStartRef, onStreamingEndRef same shape
```

React can replay or discard render work, so a render-time ref mutation can leak from UI that never commits.

## Fix
Move the three assignments into a single post-commit `useEffect`. The refs are read **only** inside the `store.subscribe` callback, which fires when the store transitions (always after commit), so a passive effect keeps them current without the render-time mutation. No behavior change for the existing post-commit read path.

## Verification
- **Frozen worktree off `origin/main` (69decb2), `bun install --frozen-lockfile`:** `apps/desktop` `tsc --noEmit` shows no new errors (only the pre-existing out-of-scope `prompts.ts:94`). Re-scan: `no-ref-current-in-render` 24→18, total 706→700, all 3 file sites resolved (deduped ×2 projects = 6 diagnostics), **zero new diagnostics**.
- **Owner-checkout cross-check:** applied the same diff read-only, `apps/desktop` `tsc` delta = 0 vs clean baseline, reverted, tree clean.
- Health score held **56 / Critical** (single-fix moves are below the score's resolution).