### PR TITLE
feat(models): support JSON response format and JSON schema

### DIFF
--- a/apps/desktop/src/components/thread-playground/model/json-schema-dialog.tsx
+++ b/apps/desktop/src/components/thread-playground/model/json-schema-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { CodeEditor } from "@/components/code-editor";
+
+import { Button } from "../../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../ui/dialog";
+
+/**
+ * The JSON Schema seeded into the editor when none is configured yet.
+ * `additionalProperties: false` keeps it valid for OpenAI strict mode.
+ */
+export const DEFAULT_JSON_SCHEMA: object = {
+  type: "object",
+  properties: {},
+  required: [],
+  additionalProperties: false,
+};
+
+/**
+ * A modal editor for the structured-output JSON Schema. Editing lives here
+ * rather than inline in the model params popover so there is room for a real
+ * `CodeEditor` — the same JSON editing experience as the tool editor: validate
+ * on save, toast on invalid JSON, and commit only a well-formed object.
+ */
+export function JsonSchemaDialog({
+  open,
+  onOpenChange,
+  schema,
+  onSave,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  schema: object | undefined;
+  onSave: (schema: object) => void;
+}) {
+  const [text, setText] = useState("");
+  // Reinitialize the editor when the dialog opens (adjust during render, not in
+  // an effect, to avoid a stale frame). See ToolEditorDialog for the pattern.
+  const [prevOpen, setPrevOpen] = useState(false);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setText(JSON.stringify(schema ?? DEFAULT_JSON_SCHEMA, null, 2));
+    }
+  }
+
+  const handleSave = () => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      toast.error("Error", { description: "Invalid JSON" });
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      toast.error("Error", { description: "Schema must be a JSON object" });
+      return;
+    }
+    onSave(parsed);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex h-[75vh]! w-full flex-col gap-4 sm:max-w-4xl"
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Edit response schema</DialogTitle>
+          <DialogDescription>
+            The model constrains its response to this JSON Schema. Support and
+            strictness vary by provider.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          <CodeEditor
+            className="min-h-80 flex-1 font-mono text-sm"
+            language="json"
+            value={text}
+            autoFocus
+            onChange={setText}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/thread-playground/model/model-config-editor.tsx
+++ b/apps/desktop/src/components/thread-playground/model/model-config-editor.tsx
@@ -38,6 +38,12 @@ export function ModelConfigEditor({
   if (resolvedModel?.reasoning && model?.params?.reasoning !== undefined) {
     paramSummary.push({ label: "reasoning", value: model.params.reasoning });
   }
+  if (model?.params?.responseType !== undefined) {
+    paramSummary.push({
+      label: "response_format",
+      value: model.params.responseType.type,
+    });
+  }
 
   return (
     <div className={cn("group flex w-full", className)}>

--- a/apps/desktop/src/components/thread-playground/model/model-params-popover.tsx
+++ b/apps/desktop/src/components/thread-playground/model/model-params-popover.tsx
@@ -40,6 +40,7 @@ import { Slider } from "../../ui/slider";
 import { Switch } from "../../ui/switch";
 import { useThreadStore, useThreadStoreActions } from "../stores/thread-store";
 
+import { DEFAULT_JSON_SCHEMA, JsonSchemaDialog } from "./json-schema-dialog";
 import { ModelCard } from "./model-card";
 
 const REASONING_LEVELS: { value: ReasoningLevel; label: string }[] = [
@@ -119,6 +120,14 @@ export function ModelParamsPopover({
   const temperature = params.temperature ?? DEFAULT_TEMPERATURE;
   const reasoning = params.reasoning ?? DEFAULT_REASONING;
   const maxTokens = params.maxTokens;
+
+  const responseType = params.responseType;
+  const hasResponseFormat = responseType !== undefined;
+  const responseFormat =
+    responseType?.type === "json_schema" ? "json_schema" : "json_object";
+  const responseSchema =
+    responseType?.type === "json_schema" ? responseType.jsonSchema : undefined;
+  const [schemaDialogOpen, setSchemaDialogOpen] = useState(false);
 
   const [draftMaxTokens, setDraftMaxTokens] = useState(
     maxTokens !== undefined ? String(maxTokens) : ""
@@ -304,8 +313,70 @@ export function ModelParamsPopover({
               </SelectContent>
             </Select>
           </ParamField>
+
+          <ParamField
+            label="Response format"
+            enabled={hasResponseFormat}
+            readonly={readonly}
+            onEnabledChange={(enabled) => {
+              updateModelParams({
+                responseType: enabled ? { type: "json_object" } : undefined,
+              });
+            }}
+          >
+            <Select
+              value={responseFormat}
+              disabled={readonly}
+              onValueChange={(value) => {
+                updateModelParams({
+                  responseType:
+                    value === "json_schema"
+                      ? {
+                          type: "json_schema",
+                          jsonSchema: responseSchema ?? DEFAULT_JSON_SCHEMA,
+                        }
+                      : { type: "json_object" },
+                });
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="mt-2 w-full"
+                aria-label="Response format"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="font-mono">
+                <SelectItem value="json_object">JSON object</SelectItem>
+                <SelectItem value="json_schema">JSON schema</SelectItem>
+              </SelectContent>
+            </Select>
+            {responseFormat === "json_schema" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2 w-full"
+                disabled={readonly}
+                onClick={() => setSchemaDialogOpen(true)}
+              >
+                Edit schema
+              </Button>
+            ) : null}
+          </ParamField>
         </PopoverContent>
       </Popover>
+      {/* Rendered outside the Popover so the modal survives the popover closing
+          when focus moves into the dialog. */}
+      <JsonSchemaDialog
+        open={schemaDialogOpen}
+        onOpenChange={setSchemaDialogOpen}
+        schema={responseSchema}
+        onSave={(jsonSchema) => {
+          updateModelParams({
+            responseType: { type: "json_schema", jsonSchema },
+          });
+        }}
+      />
     </div>
   );
 }

--- a/packages/core/src/server/agent/response-format.ts
+++ b/packages/core/src/server/agent/response-format.ts
@@ -1,0 +1,79 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+import type { ResponseType } from "../../types/models/response-type";
+
+/**
+ * The name pi/OpenAI/Anthropic require for a JSON-schema response format. The
+ * schema editor only captures the schema itself, so we supply a stable name.
+ */
+const SCHEMA_NAME = "response";
+
+/**
+ * Translate a configured `responseType` into a provider-specific structured
+ * output request by mutating the outgoing provider payload.
+ *
+ * pi-ai exposes no first-class `response_format`/`json_schema` option, so this
+ * runs through the `onPayload` escape hatch: it receives the fully-built request
+ * body right before it is sent and rewrites the field each provider expects,
+ * keyed off `model.api`. Unsupported APIs (and the default `text` type) leave
+ * the payload untouched so the provider falls back to plain text.
+ */
+export function applyResponseFormat(
+  payload: unknown,
+  model: Model<Api>,
+  responseType: ResponseType
+): unknown {
+  // "text" is the provider default — nothing to inject.
+  if (responseType.type === "text") return payload;
+  if (!payload || typeof payload !== "object") return payload;
+
+  const body = payload as Record<string, unknown>;
+  const schema =
+    responseType.type === "json_schema" ? responseType.jsonSchema : undefined;
+
+  switch (model.api) {
+    case "openai-completions": {
+      body.response_format = schema
+        ? {
+            type: "json_schema",
+            json_schema: { name: SCHEMA_NAME, schema, strict: true },
+          }
+        : { type: "json_object" };
+      return body;
+    }
+    case "openai-responses":
+    case "azure-openai-responses": {
+      body.text = {
+        ...(body.text as Record<string, unknown> | undefined),
+        format: schema
+          ? { type: "json_schema", name: SCHEMA_NAME, schema, strict: true }
+          : { type: "json_object" },
+      };
+      return body;
+    }
+    case "anthropic-messages": {
+      // Anthropic's structured outputs only accept a JSON Schema
+      // (`output_config.format`); there is no plain "json object" mode, so a
+      // json_object request falls back to default text behavior.
+      if (!schema) return payload;
+      body.output_config = {
+        format: { type: "json_schema", name: SCHEMA_NAME, schema },
+      };
+      return body;
+    }
+    case "google-generative-ai":
+    case "google-vertex": {
+      // The @google/genai SDK carries generation settings on `config`.
+      const config: Record<string, unknown> = {
+        ...((body.config as Record<string, unknown> | undefined) ?? {}),
+        responseMimeType: "application/json",
+      };
+      if (schema) config.responseSchema = schema;
+      body.config = config;
+      return body;
+    }
+    default:
+      // Unknown/unsupported API — leave the payload untouched.
+      return payload;
+  }
+}

--- a/packages/core/src/server/agent/stream.ts
+++ b/packages/core/src/server/agent/stream.ts
@@ -9,6 +9,8 @@ import type { Api, Message, Model, Models, Tool } from "@earendil-works/pi-ai";
 import { RUN_LAST_MESSAGE_ERROR } from "../../client/run-eligibility";
 import type { AgentStreamRequest } from "../../types/agent";
 
+import { applyResponseFormat } from "./response-format";
+
 /**
  * Run a single agent stream: validate, resolve the model from the given
  * `Models` collection, and drive the agent loop — yielding each `AgentEvent`.
@@ -86,6 +88,12 @@ export async function* streamAgent(
   const hasConfiguredHeaders =
     configuredHeaders && Object.keys(configuredHeaders).length > 0;
 
+  // A configured structured-output format ("json_object"/"json_schema"). pi-ai
+  // has no typed option for it, so we inject it per-provider through the
+  // `onPayload` hook in the streamFn below (see `applyResponseFormat`).
+  const responseType = request.config?.model?.responseType;
+  const hasResponseFormat = responseType && responseType.type !== "text";
+
   const agentStream = agentLoopContinue(
     {
       ...request.context,
@@ -108,17 +116,30 @@ export async function* streamAgent(
     // provider's own `auth` config (e.g. `envApiKeyAuth`). The default
     // streamFn is the legacy compat layer, which only knows a hardcoded
     // builtin provider→env-var map and ignores custom providers' auth.
-    (streamModel, streamContext, streamOptions) =>
-      models.streamSimple(
-        streamModel,
-        streamContext,
-        hasConfiguredHeaders
-          ? {
-              ...streamOptions,
-              headers: { ...configuredHeaders, ...streamOptions?.headers },
-            }
-          : streamOptions
-      )
+    (streamModel, streamContext, streamOptions) => {
+      const mergedOptions = { ...streamOptions };
+      if (hasConfiguredHeaders) {
+        mergedOptions.headers = {
+          ...configuredHeaders,
+          ...streamOptions?.headers,
+        };
+      }
+      if (hasResponseFormat) {
+        // Chain onto any existing payload hook, then inject the response format.
+        const priorOnPayload = mergedOptions.onPayload;
+        mergedOptions.onPayload = async (payload, payloadModel) => {
+          const replaced = priorOnPayload
+            ? await priorOnPayload(payload, payloadModel)
+            : undefined;
+          return applyResponseFormat(
+            replaced ?? payload,
+            payloadModel,
+            responseType
+          );
+        };
+      }
+      return models.streamSimple(streamModel, streamContext, mergedOptions);
+    }
   );
 
   try {


### PR DESCRIPTION
## What

Adds structured-output support so a thread can request a JSON response format or a JSON schema from models that support it. This wires up the previously-defined-but-unused `ModelConfigParams.responseType` end to end.

## How

pi-ai exposes no typed `response_format` field, so `applyResponseFormat` (new, `packages/core/src/server/agent/response-format.ts`) translates the configured `responseType` into each provider's payload shape through pi-ai's `onPayload` hook, keyed on `model.api`:

| `model.api` | Injection |
|---|---|
| `openai-completions` | `response_format` |
| `openai-responses` / `azure-openai-responses` | `text.format` |
| `anthropic-messages` | `output_config` (json_schema only; json_object has no native mode) |
| `google-generative-ai` / `google-vertex` | `config.responseMimeType` + `responseSchema` |
| unknown APIs / plain `text` | untouched (no-op) |

It's injected in the existing `streamFn` wrapper in `stream.ts`, chaining onto any prior `onPayload`.

## UI

- New **"Response format"** field in the model params popover, mirroring the Temperature / Max tokens / Thinking effort controls (enable switch + `json_object` / `json_schema` select).
- The JSON schema is edited in a dedicated modal (`JsonSchemaDialog`) rather than inline, so there's room for a real `CodeEditor` - same JSON editing experience as the tool editor.
- `response_format` added to the read-only param summary.

No changes needed to the thread store, client `api.ts`, wire types, or RPC - `responseType` already flows through them.

## Notes / follow-ups

- JSON-schema `name` is fixed to `"response"` and OpenAI `strict: true` is on (the point of schema mode).
- **Unsupported-model handling is currently silent**: switching to a model whose API can't honor the format keeps the config and falls back to plain text (or errors from the provider if the API partially supports it). No UI gating yet - reliable capability detection only exists server-side. Worth a follow-up if we want a warning.
- Anthropic structured outputs are assumed GA (no beta header). If a model rejects `output_config`, the fix is a one-line conditional header add in the same `streamFn` merge.

## Verification

- `tsc` clean in both packages (2 pre-existing unrelated desktop errors untouched); eslint + prettier clean.
- Translator output verified per-provider with a runtime harness (correct `response_format` / `text.format` / `output_config` / `responseSchema` shapes; correct no-op for Anthropic json_object, Bedrock, and plain text).
