### PR TITLE
[react-doctor] Fix no-ref-current-in-render in use-auto-animation

### DIFF
--- a/apps/desktop/src/lib/use-auto-animation.ts
+++ b/apps/desktop/src/lib/use-auto-animation.ts
@@ -18,7 +18,13 @@ export function useAutoAnimation<T extends HTMLElement = HTMLElement>(
   const frameIdsRef = useRef<number[]>([]);
   const nodeRef = useRef<T | null>(null);
 
-  configRef.current = config;
+  // Keep the latest config in a ref for the post-commit rAF consumer
+  // (`initialize`) to read. Assign in a passive effect rather than the render
+  // body so the ref is never mutated during a render React may replay or
+  // discard.
+  useEffect(() => {
+    configRef.current = config;
+  });
 
   const cancelScheduledInit = useCallback(() => {
     for (const frameId of frameIdsRef.current) {


### PR DESCRIPTION
## Issue
`no-ref-current-in-render` (error tier) — `apps/desktop/src/lib/use-auto-animation.ts:21` assigned `configRef.current = config` during the render body. React can replay or discard render work, so mutating a ref during render can leak from a render that never commits.

## Fix
Move the assignment into a passive `useEffect`. `configRef.current` is read **only** inside `initialize` — a `requestAnimationFrame` callback (line 72) that fires post-commit — so the effect assignment lands before any consumer reads it. Textbook latest-value-ref fix; no behavior change on the post-commit read path.

## Verification
- **react-doctor 0.7.7**, off `origin/main` (2ed0012), fresh `bun install --frozen-lockfile` worktree.
- `apps/desktop` `tsc --noEmit`: no new errors (only the pre-existing out-of-scope `prompts.ts:94` unused const).
- Re-scan: `no-ref-current-in-render` 16→14 raw, total 836→834, the `use-auto-animation` site resolved, **zero new diagnostics**. Score held (0 / Critical — pinned this version).
- Owner-checkout cross-check: applied read-only, `tsc` delta = 0 (same 2 pre-existing errors with and without the fix), reverted, tree clean.

Before/after health score: **0 → 0** (score is pinned at 0 at react-doctor 0.7.7; the progress signal is the diagnostic-count trend, 836→834).