### PR TITLE
docs: finish the mise front-door sweep of stale bun task invocations

### DIFF
--- a/.agents/skills/electrobun-cdp-debug/SKILL.md
+++ b/.agents/skills/electrobun-cdp-debug/SKILL.md
@@ -40,24 +40,24 @@ the project uses one-off `bunx --bun` invocations.
 From the repo root:
 
 ```sh
-bun run dev:cef
+mise run dev:cef
 ```
 
 This runs the desktop app with CEF and opens CDP on `127.0.0.1:9333`.
 If the port is busy:
 
 ```sh
-LLM_SPACE_DESKTOP_CDP_PORT=9334 bun run dev:cef
+LLM_SPACE_DESKTOP_CDP_PORT=9334 mise run dev:cef
 ```
 
-Normal `bun dev` keeps the native WebView renderer and does not expose CDP.
+Normal `mise run dev` keeps the native WebView renderer and does not expose CDP.
 
 When verification needs an isolated app data root, keep runtime data outside the
 repo:
 
 ```sh
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/llm-space-XXXXXX")"
-LLM_SPACE_HOME="$TMP_ROOT" bun run dev:cef
+LLM_SPACE_HOME="$TMP_ROOT" mise run dev:cef
 ```
 
 ## Inspect Electrobun With The Raw CDP AXI Wrapper
@@ -111,7 +111,7 @@ present, evaluates in the page context, and prints JSON.
 `chrome-devtools-axi` supports existing DevTools endpoints through
 `CHROME_DEVTOOLS_AXI_BROWSER_URL`, but the current CLI and its underlying
 `chrome-devtools-mcp` transport do not yet operate correctly against the
-Electrobun CEF endpoint exposed by `bun run dev:cef`.
+Electrobun CEF endpoint exposed by `mise run dev:cef`.
 
 The observed smoke test shape is:
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Contributing, or want the exact toolchain CI uses? Install [mise](https://mise.j
 Start the desktop app for local development:
 
 ```bash
-bun dev
+mise run dev
 ```
 
 Build a canary release:
 
 ```bash
-bun run build:canary
+mise run build:canary
 ```
 
 ## User guide

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,13 +68,13 @@ bun install
 启动本地开发版桌面应用：
 
 ```bash
-bun dev
+mise run dev
 ```
 
 构建 canary 版本：
 
 ```bash
-bun run build:canary
+mise run build:canary
 ```
 
 ## 用户指南

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -4,10 +4,10 @@
  * release workflow; the `-canary` suffix selects the channel.
  *
  * Usage:
- *   bun run release                         # stable (graduates a prerelease)
- *   bun run release:canary                  # next canary prerelease
- *   bun run release --release-as 0.2.0      # force an exact version
- *   bun run release --dry-run               # preview without touching anything
+ *   mise run release                          # stable (graduates a prerelease)
+ *   mise run release:canary                   # next canary prerelease
+ *   mise run release -- --release-as 0.2.0    # force an exact version
+ *   mise run release -- --dry-run             # preview without touching anything
  */
 import { $ } from "bun";
 


### PR DESCRIPTION
## Intent

Apply Option A (minimal one-off patch) from the completed doc-drift audit of PR #42 ('mise as the single task front door'), as explicitly chosen by the captain over Options B and C. Scope is exactly the 10 stale task invocations in the audit's section-2 findings table, across 4 files, as minimal in-place verb swaps: README.md and README.zh-CN.md swap 'bun dev' -> 'mise run dev' and 'bun run build:canary' -> 'mise run build:canary' (the zh-CN pair stays structurally identical to the en file; deliberately NO fallback prose or policy paragraphs — those README section rewrites are Option B and were ruled out); .agents/skills/electrobun-cdp-debug/SKILL.md gets five edits swapping 'bun run dev:cef'/'bun dev' mentions to the 'mise run' verb; scripts/release.ts gets its usage-header examples replaced with the mise run forms using '--' argument forwarding (mise run release -- --release-as 0.2.0, etc.), which the audit verified empirically. Deliberately untouched per the audit's 'verified NOT stale' list: the 'bun run .agents/.../*.mjs' file-path invocations and 'bunx --bun chrome-devtools-axi' lines in SKILL.md, all package-manager operations (bun install, bun add, bunx, bun --filter), AGENTS.md/CLAUDE.md (including its task-body column notes like 'cd apps/desktop && bun run dev:hmr' which describe the implementation layer, not the front door), docs/, workflows, and TELEMETRY.md. One docs-only commit in conventional style; the stale invocations still worked (root package.json keeps the scripts as the bun-only trial path), so this is policy/consistency drift, not breakage.

## What Changed

- `README.md` and `README.zh-CN.md` now use the mise front door for the dev-loop commands: `bun dev` → `mise run dev` and `bun run build:canary` → `mise run build:canary` (the zh-CN edits mirror the English file; no surrounding prose was rewritten, so the README's bun-only install default remains — noted as a known tradeoff in review).
- `.agents/skills/electrobun-cdp-debug/SKILL.md` swaps its five `bun run dev:cef` / `bun dev` mentions to `mise run dev:cef` / `mise run dev`, including the env-prefixed variants; the deliberately-kept `bun run .agents/…/*.mjs` file-path and `bunx --bun chrome-devtools-axi` invocations are untouched.
- The usage-header comment in `scripts/release.ts` now shows `mise run release` / `mise run release:canary`, with `--` argument forwarding for flags (`mise run release -- --dry-run`) — comment-only, no code change.

## Risk Assessment

✅ Low: Docs-only diff of 10 in-place command swaps; every referenced mise task exists in mise.toml, the '--' arg-forwarding examples in release.ts are mechanically correct, env-prefix forms still propagate, and the deliberately-untouched invocations were correctly left alone.

## Testing

Confirmed the diff is exactly the audit's Option-A scope (10 stale invocations across README.md, README.zh-CN.md, SKILL.md, scripts/release.ts; untouched list intact), then exercised the newly documented commands for real: all referenced mise tasks exist, `mise run release -- --dry-run` forwards args through mise into release.ts, and the README quickstart `mise run dev` launched the desktop app end-to-end from a fresh worktree; captured rendered-README screenshots plus CLI transcripts as evidence and restored the worktree to clean.

- Evidence: English README — Run the app section now showing mise run dev / mise run build:canary (bun install intact under Install) (local file: <code>/var/folders/hv/5dt_hrvx0193s11sph8g8cvc0000gn/T/no-mistakes-evidence/01KXE7AD0CTTXZZF6AFRQGBJKC/readme-en-run-the-app.png</code>)
- Evidence: Chinese README — 运行应用 section structurally identical to the English file (local file: <code>/var/folders/hv/5dt_hrvx0193s11sph8g8cvc0000gn/T/no-mistakes-evidence/01KXE7AD0CTTXZZF6AFRQGBJKC/readme-zh-run-the-app.png</code>)
<details>
<summary>Evidence: Transcript: mise run release -- --dry-run forwards --dry-run into bun scripts/release.ts (stops at off-main preflight as designed)</summary>

<code>$ mise run release -- --dry-run&#10;[release] $ bun run release --dry-run&#10;$ bun scripts/release.ts --dry-run&#10;✖ releases are cut from main (current: HEAD)&#10;error: script &#34;release&#34; exited with code 1&#10;[release] ERROR task failed&#10;exit=1</code>

```text
$ mise run release -- --dry-run
[release] $ bun run release --dry-run
$ bun scripts/release.ts --dry-run
✖ releases are cut from main (current: HEAD)
error: script "release" exited with code 1
[release] ERROR task failed
exit=1
```
</details>
<details>
<summary>Evidence: Transcript: README quickstart `mise run dev` launching the desktop app (Vite :5173 + Electrobun app with HMR)</summary>

```text
$ mise run dev   # (LLM_SPACE_HOME pointed at a temp dir)
[dev] $ bun run dev
$ cd apps/desktop && bun run dev:hmr
$ concurrently "bun run hmr" "bun run start"
[0] $ vite --port 5173
[1] $ vite build && electrobun dev
[1] vite v6.4.3 building for production...
[0] 
[0]   VITE v6.4.3  ready in 760 ms
[0] 
[0]   ➜  Local:   http://localhost:5173/
[0]   ➜  Network: use --host to expose
[1] transforming...
  [... vite build output elided ...]
[1] ✓ built in 9.39s
[1] Downloading electrobun CLI for your platform...
[1] electrobun CLI downloaded successfully!
[1] Using config file: electrobun.config.ts
[1] Core dependencies not found for macos-arm64. Missing files: ./dist-macos-arm64/bun, ./dist-macos-arm64/bsdiff, ./dist-macos-arm64/bspatch, ./dist-macos-arm64/launcher, ./dist-macos-arm64/libNativeWrapper.dylib
[1] Downloading core binaries for macos-arm64...
[1] Downloading core binaries from: https://github.com/blackboardsh/electrobun/releases/download/v1.18.1/electrobun-core-darwin-arm64.tar.gz
[1] Downloaded 27572486 bytes for macos-arm64
[1] Verified download: /Users/anx/.no-mistakes/worktrees/d7e9440c0ed2/01KXE7AD0CTTXZZF6AFRQGBJKC/apps/desktop/node_modules/electrobun/core-macos-arm64-temp.tar.gz (27572486 bytes)
[1] Extracting core dependencies for macos-arm64...
[1] Extracted files to /Users/anx/.no-mistakes/worktrees/d7e9440c0ed2/01KXE7AD0CTTXZZF6AFRQGBJKC/apps/desktop/node_modules/electrobun/dist-macos-arm64: [
[1]   "libasar.dylib", "npmbin.js", "launcher", "libwebgpu_dawn.dylib", "process_helper", "zig-asar",
[1]   "zig-zstd", "extractor", "bun", "main.js", "api", "bsdiff", "bspatch", "libNativeWrapper.dylib"
[1] ]
[1]   api/: shared, bun, browser
[1] Core dependencies for macos-arm64 downloaded and cached successfully
[1] Running postBuild script: scripts/fix-x64-headerpad.ts
[1] skipping codesign
[1] skipping notarization
[1] Launcher starting on macos...
[1] Current directory: /Users/anx/.no-mistakes/worktrees/d7e9440c0ed2/01KXE7AD0CTTXZZF6AFRQGBJKC/apps/desktop/build/dev-macos-arm64/LLM Space-dev.app/Contents/MacOS
[1] Spawning: ./bun /Users/anx/.no-mistakes/worktrees/d7e9440c0ed2/01KXE7AD0CTTXZZF6AFRQGBJKC/apps/desktop/build/dev-macos-arm64/LLM Space-dev.app/Contents/MacOS/../Resources/main.js
[1] Dev build detected - console output enabled
[1] Child process spawned with PID 42024
[1] [LAUNCHER] Loaded identifier: tech.deerflow.llm-space, name: LLMSpace-dev, channel: dev
[1] [LAUNCHER] Loading app code from flat files
[1] Server started at http://localhost:50000
[1] HMR enabled: Using Vite dev server at http://localhost:5173
[0] 1:16:00 AM [vite] (client) ✨ new dependencies optimized: @earendil-works/pi-ai
[0] 1:16:00 AM [vite] (client) ✨ optimized dependencies changed. reloading
[1] 2026-07-14 01:16:03.397 bun[42024:8225421] error messaging the mach port for IMKCFRunLoopWakeUpReliable
```
</details>
<details>
<summary>Evidence: Rendered English README (GitHub-styled HTML)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown-dark.min.css"><style>body{background:#0d1117;margin:0;padding:32px}.markdown-body{max-width:880px;margin:0 auto}</style></head><body><article class="markdown-body"><p>English | <a href="./README.zh-CN.md">中文</a></p>
<hr>
<h1>LLM Space 4</h1>
<p><img src="https://github.com/user-attachments/assets/e207bc62-4dab-4b13-a541-d176a8f96c40" alt="screenshot"></p>
<p><a href="https://github.com/deer-flow/llm-space"><strong>LLM Space</strong> v4</a> is a desktop app for agent builders — prototype your next agent ideas, inspect every step of your harness execution, debug failures, and evaluate performance, all in one place.</p>
<p>LLM Space is a sister project of <a href="https://github.com/bytedance/deer-flow">DeerFlow</a>, and we dogfood it heavily: every version of DeerFlow is built and debugged with LLM Space. The project started in March 2023, and v4 is its fourth major iteration.</p>
<h2>Contents</h2>
<ul>
<li><a href="#features">Features</a></li>
<li><a href="#tech-stack">Tech stack</a></li>
<li><a href="#project-layout">Project layout</a></li>
<li><a href="#install">Install</a></li>
<li><a href="#run-the-app">Run the app</a></li>
<li><a href="#user-guide">User guide</a></li>
<li><a href="#contributing">Contributing</a></li>
<li><a href="#sponsors">Sponsors</a></li>
<li><a href="#donate">Donate</a></li>
<li><a href="#license">License</a></li>
</ul>
<h2>Features</h2>
<ul>
<li><strong>Build</strong> — write and version your prompts, system messages, tools, and model settings.</li>
<li><strong>Trace</strong> — see every model call and tool run inside the agent loop as it happens.</li>
<li><strong>Debug</strong> — replay a run from history and step through it to find what went wrong.</li>
<li><strong>Evaluate</strong> — measure how your agent performs across runs.</li>
<li><strong>Manage</strong> — keep your threads organized as files on your own machine.</li>
</ul>
<p>Your files and API keys stay on your local computer. LLM Space collects a small amount of anonymous usage data to improve the app - see <a href="./TELEMETRY.md">TELEMETRY.md</a> for exactly what is collected and how to opt out.</p>
<h2>Tech stack</h2>
<ul>
<li><strong>Language &amp; tooling</strong> — TypeScript, built and managed with <a href="https://bun.com">Bun</a>.</li>
<li><strong>Desktop shell</strong> — <a href="https://electrobun.dev">Electrobun</a>, a lightweight way to ship a native app.</li>
<li><strong>UI</strong> — React with Tailwind CSS and shadcn/ui.</li>
<li><strong>Agent framework</strong> — <a href="https://github.com/earendil-works/pi">Pi Agent Core</a>, a lightweight agent framework for building agents.</li>
</ul>
<h2>Project layout</h2>
<p>LLM Space is a Bun monorepo:</p>
<pre><code>packages/
  core/       # Shared logic: types, the agent loop, thread storage
apps/
  desktop/    # The desktop app (Electrobun shell + React UI)
</code></pre>
<h2>Install</h2>
<p>You need <a href="https://bun.com">Bun</a> first. Bun is a fast, all-in-one runtime and package manager for JavaScript — think of it as a drop-in replacement for Node.js and npm. Follow the <a href="https://bun.com/docs/installation">official install guide</a>.</p>
<p>Once Bun is ready, install the project from the repo root:</p>
<pre><code class="language-bash">bun install
</code></pre>
<p>Contributing, or want the exact toolchain CI uses? Install <a href="https://mise.jdx.dev">mise</a> and run <code>mise run setup</code> instead — it installs the locked Bun version (from <code>mise.lock</code>) plus JS deps in one step.</p>
<h2>Run the app</h2>
<p>Start the desktop app for local development:</p>
<pre><code class="language-bash">mise run dev
</code></pre>
<p>Build a canary release:</p>
<pre><code class="language-bash">mise run build:canary
</code></pre>
<h2>User guide</h2>
<p>The user guide lives in this repository:</p>
<ul>
<li><a href="./docs/get-started.md">Quick start</a></li>
<li><a href="./docs/index.md">User manual</a></li>
<li><a href="./docs/core-concepts.md">Core concepts</a></li>
</ul>
<h2>Contributing</h2>
<p>For now, we only merge pull requests from the <a href="https://github.com/bytedance/deer-flow">DeerFlow</a> core team members.</p>
<p>Everyone else is very welcome to help by <a href="https://github.com/deer-flow/llm-space/issues">opening an issue</a> — bug reports, ideas, and feedback all make the project better.</p>
<h2>Sponsors</h2>
<p>LLM Space is free and open source, and it stays that way thanks to our sponsors. We are proud and grateful to be backed by them.</p>
<h3>🏆 Platinum sponsor</h3>
<p align="center">
  <a href="https://superdesign.dev" target="_blank" rel="noopener">
    <img src="./docs/images/sponsor-superdesign.svg" alt="Superdesign - AI product design agent that turns prompts into designs on an infinite canvas (Platinum Sponsor)" width="600" />
  </a>
</p><p align="center">
  <strong><a href="https://superdesign.dev">Superdesign</a></strong> is an AI product design agent that turns natural-language prompts into UI mockups, components, and full designs on an infinite canvas. Thank you for making LLM Space possible. 💜
</p><p>Want to see your logo here? We would love to talk - <a href="https://github.com/deer-flow/llm-space/issues">reach out by opening an issue</a> or <a href="#donate">support the project</a>.</p>
<h2>Donate</h2>
<p>If LLM Space is useful to you and you would like to support its development, you can donate here:</p>
<p><strong><a href="https://my.feishu.cn/wiki/OvLBwVuSkiCR1ik5wGEcBXZfnye">Support LLM Space →</a></strong></p>
<p>Thank you.</p>
<h2>License</h2>
<p>LLM Space is released under the <a href="LICENSE">MIT License</a>.</p>
</article></body></html>
```
</details>
<details>
<summary>Evidence: Rendered Chinese README (GitHub-styled HTML)</summary>

```text
<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown-dark.min.css"><style>body{background:#0d1117;margin:0;padding:32px}.markdown-body{max-width:880px;margin:0 auto}</style></head><body><article class="markdown-body"><p><a href="./README.md">English</a> | 中文</p>
<hr>
<h1>LLM Space 4</h1>
<p><img src="https://github.com/user-attachments/assets/7fe0a937-a7fa-4a3c-9417-34ee5a35b19d" alt="screenshot"></p>
<p><a href="https://github.com/deer-flow/llm-space"><strong>LLM Space</strong> v4</a> 是一款为 Agent 开发者打造的桌面应用。你可以在一个地方原型验证新的 Agent 想法，观察 harness 执行的每一步，调试失败原因，并评估性能表现。</p>
<p>LLM Space 是 <a href="https://github.com/bytedance/deer-flow">DeerFlow</a> 的姊妹项目，DeerFlow 团队也一直在重度使用它：DeerFlow 的每个版本都会用 LLM Space 来构建和调试。这个项目始于 2023 年 3 月，v4 是它的第四次大版本迭代。</p>
<h2>目录</h2>
<ul>
<li><a href="#%E5%8A%9F%E8%83%BD%E7%89%B9%E6%80%A7">功能特性</a></li>
<li><a href="#%E6%8A%80%E6%9C%AF%E6%A0%88">技术栈</a></li>
<li><a href="#%E9%A1%B9%E7%9B%AE%E7%BB%93%E6%9E%84">项目结构</a></li>
<li><a href="#%E5%AE%89%E8%A3%85">安装</a></li>
<li><a href="#%E8%BF%90%E8%A1%8C%E5%BA%94%E7%94%A8">运行应用</a></li>
<li><a href="#%E7%94%A8%E6%88%B7%E6%8C%87%E5%8D%97">用户指南</a></li>
<li><a href="#%E5%8F%82%E4%B8%8E%E8%B4%A1%E7%8C%AE">参与贡献</a></li>
<li><a href="#%E8%B5%9E%E5%8A%A9%E5%95%86">赞助商</a></li>
<li><a href="#%E6%8D%90%E5%8A%A9">捐助</a></li>
<li><a href="#%E8%AE%B8%E5%8F%AF%E8%AF%81">许可证</a></li>
</ul>
<h2>功能特性</h2>
<ul>
<li><strong>构建</strong>：编写并版本化你的 prompts、system messages、tools 和 model settings。</li>
<li><strong>追踪</strong>：实时查看 agent loop 中的每一次模型调用和工具运行。</li>
<li><strong>调试</strong>：从运行历史中回放一次执行，并逐步排查问题。</li>
<li><strong>评估</strong>：跨多次运行衡量你的 Agent 表现。</li>
<li><strong>管理</strong>：把 threads 作为本机文件组织和管理。</li>
</ul>
<p>你的文件和 API keys 都保存在本机。LLM Space 会收集少量匿名使用数据来改进应用；具体收集内容和退出方式见 <a href="./TELEMETRY.md">TELEMETRY.md</a>。</p>
<h2>技术栈</h2>
<ul>
<li><strong>语言与工具链</strong>：TypeScript，使用 <a href="https://bun.com">Bun</a> 构建和管理。</li>
<li><strong>桌面壳</strong>：<a href="https://electrobun.dev">Electrobun</a>，一种轻量的原生应用交付方式。</li>
<li><strong>UI</strong>：React、Tailwind CSS 和 shadcn/ui。</li>
<li><strong>Agent 框架</strong>：<a href="https://github.com/earendil-works/pi">Pi Agent Core</a>，一个用于构建 Agent 的轻量框架。</li>
</ul>
<h2>项目结构</h2>
<p>LLM Space 是一个 Bun monorepo：</p>
<pre><code class="language-text">packages/
  core/       # 共享逻辑：类型、agent loop、thread storage
apps/
  desktop/    # 桌面应用：Electrobun shell + React UI
</code></pre>
<h2>安装</h2>
<p>你需要先安装 <a href="https://bun.com">Bun</a>。Bun 是一个快速、一体化的 JavaScript runtime 和 package manager，可以理解为 Node.js 和 npm 的替代方案。请参考 <a href="https://bun.com/docs/installation">官方安装指南</a>。</p>
<p>Bun 准备好后，在仓库根目录安装依赖：</p>
<pre><code class="language-bash">bun install
</code></pre>
<p>如果要参与开发、或想使用与 CI 完全一致的工具链：安装 <a href="https://mise.jdx.dev">mise</a> 后运行 <code>mise run setup</code>，它会一步装好锁定版本的 Bun（来自 <code>mise.lock</code>）和 JS 依赖。</p>
<h2>运行应用</h2>
<p>启动本地开发版桌面应用：</p>
<pre><code class="language-bash">mise run dev
</code></pre>
<p>构建 canary 版本：</p>
<pre><code class="language-bash">mise run build:canary
</code></pre>
<h2>用户指南</h2>
<p>中文用户指南在这个仓库中：</p>
<ul>
<li><a href="./docs/get-started.zh-CN.md">快速开始</a></li>
<li><a href="./docs/index.zh-CN.md">用户手册</a></li>
<li><a href="./docs/core-concepts.zh-CN.md">核心概念</a></li>
</ul>
<h2>参与贡献</h2>
<p>目前我们只合并来自 <a href="https://github.com/bytedance/deer-flow">DeerFlow</a> 核心团队成员的 Pull Request。</p>
<p>其他朋友也非常欢迎通过 <a href="https://github.com/deer-flow/llm-space/issues">提交 issue</a> 来帮助项目成长。Bug report、想法和反馈都会让项目变得更好。</p>
<h2>赞助商</h2>
<p>LLM Space 是免费开源项目，并且依靠赞助保持持续发展。我们很荣幸，也非常感谢赞助商的支持。</p>
<h3>🏆 白金赞助商</h3>
<p align="center">
  <a href="https://superdesign.dev" target="_blank" rel="noopener">
    <img src="./docs/images/sponsor-superdesign.svg" alt="Superdesign - AI product design agent that turns prompts into designs on an infinite canvas (Platinum Sponsor)" width="600" />
  </a>
</p><p align="center">
  <strong><a href="https://superdesign.dev">Superdesign</a></strong> 是一款 AI 产品设计 Agent，可以把自然语言 prompt 转换成 UI mockup、组件和完整设计，并呈现在无限画布上。感谢它让 LLM Space 成为可能。💜
</p><p>想在这里看到你的 logo？欢迎联系我们：<a href="https://github.com/deer-flow/llm-space/issues">提交 issue</a> 或 <a href="#%E6%8D%90%E5%8A%A9">支持这个项目</a>。</p>
<h2>捐助</h2>
<p>如果 LLM Space 对你有帮助，并且你愿意支持它的开发，可以在这里捐助：</p>
<p><strong><a href="https://my.feishu.cn/wiki/OvLBwVuSkiCR1ik5wGEcBXZfnye">支持 LLM Space →</a></strong></p>
<p>感谢支持。</p>
<h2>许可证</h2>
<p>LLM Space 基于 <a href="LICENSE">MIT License</a> 发布。</p>
</article></body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `README.md:71` - README&#39;s install section still presents bun-only install as the default path (mise is an optional aside at line 64), while the &#39;Run the app&#39; section now uses mise-only commands — a reader who skips the mise sentence gets &#39;command not found: mise&#39;. This is the deliberate Option A scope (no README prose rewrites, ruled out as Option B), so no action needed; recorded as a known tradeoff.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 9f745f3..1a74e16` — confirmed 4 files/13 lines matching the audit&#39;s Option-A scope, nothing else</code>
- <code>grep of README.md, README.zh-CN.md, SKILL.md — verified deliberately-untouched `bun install`, `bun run .agents/…/*.mjs`, and `bunx --bun chrome-devtools-axi` invocations remain</code>
- <code>`git diff 9f745f3..1a74e16 -- AGENTS.md CLAUDE.md docs/ .github/ TELEMETRY.md` — empty, out-of-scope files untouched</code>
- <code>`mise tasks ls` — all documented tasks (dev, dev:cef, build:canary, release, release:canary) exist</code>
- <code>`mise run release -- --dry-run` — demonstrated `--` argument forwarding (`$ bun scripts/release.ts --dry-run`) with the script safely refusing off-main</code>
- <code>`bun install` + `mise run dev` (LLM_SPACE_HOME in temp dir) — README quickstart end-to-end: Vite HMR on :5173, app built, Electrobun desktop app launched with HMR connected, then stopped</code>
- `Rendered both READMEs to GitHub-styled HTML and screenshotted the changed "Run the app" / "运行应用" sections via chrome-devtools-axi`
- <code>Cleaned up transient artifacts (node_modules, apps/desktop/dist, apps/desktop/build, temp app-data root); `git status` clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
