### PR TITLE
fix(build): raise the vite heap ceiling and build the renderer in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,10 @@ jobs:
       - run: mise run lint
 
       - run: mise run typecheck
+
+      # `vite build` otherwise runs only inside a release build, so a renderer
+      # change that breaks — or just outgrows the runner's V8 heap — stays
+      # invisible until a version tag is pushed, and takes the release with it.
+      # (That is exactly how v0.1.1-canary.0 died: 14701 modules OOMing a ~2 GB
+      # default heap. build:view raises it; this step is what keeps it honest.)
+      - run: bun --filter @llm-space/desktop build:view

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ A workbench for prompt and agent development — build, trace, debug, evaluate, 
 | Add a shadcn/ui component              | `bunx --bun shadcn@latest add <component>`                                  | run inside `apps/desktop`                                                                                              |
 | Run a script from root                 | `bun --filter <pkg> <script>`                                               | e.g. `bun --filter @llm-space/desktop start`                                                                           |
 
-There is **no test framework**. CI (`.github/workflows/ci.yml`) runs lint + typecheck on PRs and pushes to main.
+There is **no test framework**. CI (`.github/workflows/ci.yml`) runs lint + typecheck + a production `vite build` + workflow-YAML validation on PRs and pushes to main. The last two exist because both failure modes are invisible until a release tag is pushed, and then take the release down with them: a renderer bundle that outgrows the runner's V8 heap (`build:view` sets `--max-old-space-size=4096`; the default ~2 GB stopped being enough at 14701 modules) and a malformed workflow file. Keep the renderer bundle in mind — if `vite build` starts OOMing again, raise the ceiling in `build:view` or cut the bundle down, and don't discover it at release time.
 
 GUI commits (VS Code, Fork) failing with `bun: command not found`: husky hooks need bun on PATH — add `export PATH="$HOME/.local/share/mise/shims:$PATH"` to `~/.config/husky/init.sh` (husky's documented fix for version managers).
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,8 +7,9 @@
     "dev:hmr": "concurrently \"bun run hmr\" \"bun run start\"",
     "dev:cef": "LLM_SPACE_DESKTOP_RENDERER=cef LLM_SPACE_DESKTOP_CDP_PORT=${LLM_SPACE_DESKTOP_CDP_PORT:-9333} bun run dev:hmr",
     "hmr": "vite --port 5173",
-    "build:canary": "vite build && electrobun build --env=canary",
-    "build:stable": "vite build && electrobun build --env=stable"
+    "build:view": "NODE_OPTIONS=--max-old-space-size=4096 vite build",
+    "build:canary": "bun run build:view && electrobun build --env=canary",
+    "build:stable": "bun run build:view && electrobun build --env=stable"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",


### PR DESCRIPTION
`v0.1.1-canary.0` failed. The build died in `vite build`, before electrobun or CEF were ever reached:

```
✓ 14701 modules transformed.
Mark-Compact 2009.0 (2097.0) MB ...
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The renderer bundle no longer fits in node's ~2 GB default old-space on the macOS runners.

## Why it only showed up at release time

CI runs `lint` + `typecheck`, and **never runs `vite build`** — both pass happily on a bundle that cannot actually be built. `vite build` only executes inside a release build. So main stayed green while the production bundle grew past the heap ceiling (renderer work merged since the last release on Jul 9), and the first signal was a pushed version tag with no release behind it.

## Fix

- `build:view` sets `--max-old-space-size=4096`; `build:canary` / `build:stable` route through it.
- **CI now builds the renderer on every PR**, so this class of failure fails a PR instead of a release.

## Verified

Reproduced and fixed locally by pinning the heap to the runner's limit:

| | result |
|---|---|
| `NODE_OPTIONS=--max-old-space-size=2048 vite build` | `FATAL ERROR: Reached heap limit` (reproduces CI exactly) |
| `NODE_OPTIONS=--max-old-space-size=4096 vite build` | `✓ built in 16.80s` |

This is independent of the Performance/CEF edition — the regular arm64 build failed first and fail-fast cancelled the rest.