### PR TITLE
ci(release): harden the two flakes that broke v0.1.1-canary.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,15 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      # electrobun images the app with `hdiutil create -srcfolder .dmg-staging`,
+      # which fails with "Resource busy" if Spotlight is still indexing that
+      # directory — it took out the x64 Performance build once, since a ~400 MB
+      # CEF bundle keeps `mds` busy far longer than the regular one. A CI runner
+      # has no use for a Spotlight index. Non-fatal: never let the mitigation
+      # itself fail the release.
+      - name: Disable Spotlight indexing (hdiutil "Resource busy")
+        run: sudo mdutil -a -i off || true
+
       - name: Import signing certificate
         env:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
@@ -180,9 +189,10 @@ jobs:
           #
           # Do NOT go back to a fixed `sleep`: the extractor itself runs from
           # $APP/Contents/MacOS/, so a bare pgrep on that path is satisfied by
-          # extraction still being in flight. The Performance edition's 127 MB
-          # payload takes ~33s to decompress on Apple silicon and longer on the
-          # Intel runner, so any sleep short enough to be tolerable is a lie.
+          # extraction still being in flight. The Performance edition's ~120 MB
+          # compressed payload takes ~33s to decompress on Apple silicon and
+          # longer on the Intel runner, so any sleep short enough to be
+          # tolerable is a lie.
           # Poll for the swapped-in bundle instead (Resources/main.js only exists
           # in the real app, never in the wrapper), then assert the real process.
           open "$APP"
@@ -246,10 +256,18 @@ jobs:
         run: |
           publish_feed() {
             local dir="$1" release="$2" title="$3"
-            gh release view "$release" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1 || \
+            # `gh release view` is the existence check, but it fails transiently
+            # often enough to matter: one flaky read sent us into `create`, which
+            # then died on "HTTP 422: Release.tag_name already exists" and took
+            # the whole release with it. So a failed `create` is only forgiven
+            # when a re-check proves the release really does exist — a genuine
+            # create failure still fails the job.
+            if ! gh release view "$release" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
               gh release create "$release" --repo "$GITHUB_REPOSITORY" --prerelease \
                 --title "$title" \
-                --notes "Machine-readable update feed polled by the in-app updater. Download installers from the versioned releases instead."
+                --notes "Machine-readable update feed polled by the in-app updater. Download installers from the versioned releases instead." \
+                || gh release view "$release" --repo "$GITHUB_REPOSITORY" > /dev/null
+            fi
             # Upload order is load-bearing: update.json is the update trigger and
             # must land last, after the patches and tarballs it points at —
             # across both architectures.
@@ -278,7 +296,7 @@ jobs:
           Two editions. Install either, or both — they share the same `~/.llm-space` data, so switching keeps your threads and settings.
 
           - **LLM Space** — uses the system WebView. Small download (~27 MB), light on memory and battery.
-          - **LLM Space Performance** — embeds its own rendering engine (~127 MB). Rendering stays consistent across macOS versions, and usually performs better.
+          - **LLM Space Performance** — embeds its own rendering engine (~130 MB). Rendering stays consistent across macOS versions, and usually performs better.
 
           Download a DMG below. Existing installs update in place.
           EOF
@@ -290,6 +308,17 @@ jobs:
           # Always (re)set the static notes — edit if the release already
           # exists (e.g. a re-run, or a leftover from an earlier tag) so it
           # never keeps stale auto-generated notes.
+          #
+          # This deliberately does NOT get publish_feed's flake guard. The
+          # exposure is inverted: a feed release always exists, so one flaky
+          # `view` there escalates to a fatal 422 on every run. A versioned
+          # release does not exist yet on a tag push, so a flaky `view` lands in
+          # the `create` branch it was headed for anyway — the normal path is
+          # flake-immune. Only "re-run of a tag whose release already exists" +
+          # "a transient failure in that same run" can 422 here, and it fails
+          # closed: the feeds are already published and nothing is corrupted, so
+          # a plain re-run fixes it. Don't "unify" these two — the guard would be
+          # dead weight.
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes "$NOTES"
           else

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ apps/
 Grab a DMG from the [latest release](https://github.com/deer-flow/llm-space/releases/latest) — macOS, Apple Silicon and Intel. It comes in two editions:
 
 - **LLM Space** — uses the system WebView. Small download (~27 MB), light on memory and battery.
-- **LLM Space Performance** — embeds its own rendering engine (~127 MB). Rendering stays consistent across macOS versions, and usually performs better.
+- **LLM Space Performance** — embeds its own rendering engine (~130 MB). Rendering stays consistent across macOS versions, and usually performs better.
 
 Install either, or both. They share the same `~/.llm-space` data, so switching editions keeps your threads and settings, and both update themselves in place.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,7 +57,7 @@ apps/
 从 [最新 release](https://github.com/deer-flow/llm-space/releases/latest) 下载 DMG —— 支持 macOS 的 Apple Silicon 和 Intel。有两个版本：
 
 - **LLM Space** —— 使用系统 WebView。体积小（约 27 MB），内存和耗电更低。
-- **LLM Space Performance** —— 内嵌渲染引擎（约 127 MB）。渲染在不同 macOS 版本上保持一致，性能通常更好。
+- **LLM Space Performance** —— 内嵌渲染引擎（约 130 MB）。渲染在不同 macOS 版本上保持一致，性能通常更好。
 
 装其中一个，或者两个都装。它们共享同一份 `~/.llm-space` 数据，所以切换版本后 thread 和设置都还在，两者也都会自动更新。
 


### PR DESCRIPTION
`v0.1.1-canary.1` shipped, but only after two transient failures that each needed a manual re-run. Both passed on a plain re-run **with no code change**, so neither was a code defect — but a release that depends on someone noticing and re-running it will eventually ship late.

## 1. `hdiutil: create failed - Resource busy` (x64 Performance)

electrobun images the app with `hdiutil create -srcfolder .dmg-staging`. Spotlight is still crawling that tree — ~400 MB of freshly-written CEF — when the imaging engine starts walking it.

**Fix:** disable Spotlight indexing on the runner before the build.

Worth being precise about *why*, because the obvious explanation is wrong: the temp volume `hdiutil` mounts is `noowners,nobrowse`, and macOS **never indexes it** (measured — `mdutil -s` on that volume reports `Indexing disabled.` even with Spotlight fully on). The contention is on the **staging** side, on `/System/Volumes/Data`, where `.dmg-staging` lives and where `mds_stores` genuinely does crawl. `sudo mdutil -a -i off` covers exactly that volume.

This is a **mitigation, not a proof**: it removes the one contender we can observe. It is `|| true`-guarded and cannot fail the job.

## 2. `gh release view` transient failure → HTTP 422

This one was transient in cause but **deterministic in consequence**. The rolling feed releases (`updates` / `updates-performance`) *always* exist after the first release, so a flaky existence check falls through to `gh release create`, which dies on `HTTP 422: Release.tag_name already exists` — and takes the entire release with it.

**Fix:** `publish_feed()` forgives a failed `create` only when a re-check proves the release really does exist. A genuine create failure still fails the job.

Verified with stubbed-`gh` reproductions under `bash -e`:

| scenario | before | after |
|---|---|---|
| view flakes, release exists | 422 → **release dies** | re-check forgives → uploads → exit 0 |
| create genuinely fails | exit 1 | exit 1 (**still fails — not swallowed**) |

### Why the versioned-release step keeps the unguarded pattern

Deliberate, and commented in place so nobody "unifies" them. The exposure is inverted: a feed release *always* exists, so one flaky `view` there is fatal on every run. A versioned release does **not** exist yet on a tag push, so a flaky `view` lands in the `create` branch it was headed for anyway — the normal path is flake-immune. Only "re-run of a tag whose release already exists" **and** "a transient failure in that same run" can 422 there, and it fails closed (feeds already published, nothing corrupted, a re-run fixes it). Guarding it would be dead weight.

## 3. Size numbers

Corrected the Performance download to **~130 MB** (measured: 126 MB arm64, 135 MB x64) across both READMEs and the release notes; the smoke-test comment now says `~120 MB` for the *compressed payload*, which is a different number from the DMG and was being conflated.

## Also done outside this PR

Deleted the empty `v0.1.1-canary.0` tag (it died in the `vite build` OOM and had no release behind it).