### PR TITLE
[react-doctor] Fix no-ref-current-in-render in use-stream-text

### DIFF
--- a/apps/desktop/src/components/thread-playground/use-stream-text.ts
+++ b/apps/desktop/src/components/thread-playground/use-stream-text.ts
@@ -82,9 +82,14 @@ export function useStreamText({
     reasoning,
     model,
   });
-  argsRef.current = { systemPrompt, messages, userPrompt, reasoning, model };
   const defaultModelRef = useRef(defaultModel);
-  defaultModelRef.current = defaultModel;
+  // Sync the latest inputs/model into the refs after commit — they're read only
+  // inside `run` (a post-commit callback), so mutating them during render would
+  // leak from a render React might replay or discard.
+  useEffect(() => {
+    argsRef.current = { systemPrompt, messages, userPrompt, reasoning, model };
+    defaultModelRef.current = defaultModel;
+  });
 
   const controllerRef = useRef<AbortController | null>(null);
 


### PR DESCRIPTION
## Issue
`no-ref-current-in-render` (error tier) — `apps/desktop/src/components/thread-playground/use-stream-text.ts` mutated `argsRef.current` (line 85) and `defaultModelRef.current` (line 87) during the render body. React can replay or discard render work, so writing a ref during render can leak a value from a render that never commits.

## Fix
Both refs are read **only** inside `run` — a `useCallback(…, [])` invoked from user actions (post-commit) — so the render-time writes are unnecessary during render. Moved both assignments into a single passive `useEffect` (no dep array → runs after every commit), matching the latest-value-ref pattern from PR #37 / PR #44. `run`'s read path is unchanged; the effect always lands before any subsequent `run` call, so the callback still reads current values. No behavior change.

## Verification
- **Frozen worktree** (`bun install --frozen-lockfile`, off `origin/main` 9c91e4c): `apps/desktop` `tsc --noEmit` clean (exit 0); re-scan `no-ref-current-in-render` 14→10 raw (both `use-stream-text` sites resolved), total 752→748, **zero new diagnostics**.
- **Owner-checkout cross-check:** applied read-only, `apps/desktop` tsc **delta = 0** (only the pre-existing, unrelated `message-list-view.tsx:214` Radix `CSSProperties` skew remains), then reverted — tree clean.

## Score
Before/after: **58 → 59** (react-doctor 0.7.8; error count 18 → 14). Score not regressed.
