### PR TITLE
ci(release): free runner disk space before builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,25 @@ jobs:
         with:
           ref: ${{ needs.meta.outputs.tag }}
 
+      # DMG imaging once ran the x64 Performance leg out of disk (`hdiutil
+      # create` → "No space left on device", v0.1.1-canary.3): the hosted
+      # runners' free space leaves too little margin over what the CEF build
+      # plus DMG staging need. Evict the biggest preinstalled things this job
+      # never touches — Simulator runtimes (tens of GB in a handful of disk
+      # images, so seconds to delete), their dyld caches, and the Homebrew
+      # download cache. The build itself only needs mise/bun and the Xcode
+      # command-line tools (codesign, hdiutil, stapler), none of which live
+      # there. Best-effort insurance on every leg: cleanup must never fail the
+      # release, and the df bookends put the reclaimed headroom in each log.
+      - name: Free runner disk space (hdiutil "No space left on device")
+        continue-on-error: true
+        run: |
+          df -h /
+          sudo xcrun simctl runtime delete all || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Caches || true
+          rm -rf "$(brew --cache)" || true
+          df -h /
+
       # v4: reads mise.lock (installs the exact locked bun with checksum
       # verification) and exports the full `mise env` (incl. PATH) into
       # GITHUB_ENV — our [env] carries nothing beyond PATH.


### PR DESCRIPTION
## Intent

Harden the Release workflow against runner disk exhaustion: add ONE pre-build disk-cleanup step to the build job in .github/workflows/release.yml. Motivating incident: release run 29340757755 for tag v0.1.1-canary.3 failed in the build (macos-15-intel, x64, performance) job when hdiutil DMG creation died with 'No space left on device'; the regular builds passed, so it is a capacity-margin problem on GitHub-hosted macOS runners, not a code issue (this pipeline was previously hardened against two other runner flakes in dc3b3cf). Deliberate design decisions: the step is applied to ALL matrix legs as cheap insurance, not just the intel runner where it died; it is placed after checkout and before mise-action/bun install so disk is freed before anything writes; it must NEVER fail the build (both continue-on-error: true and || true on every command — belt and braces on purpose); it targets a few large fast wins only — 'sudo xcrun simctl runtime delete all' (Simulator runtimes are cryptex disk images, tens of GB in a few large files, seconds to delete; syntax verified against dotnet/maui and dotnet/dotnet production CI), the CoreSimulator dyld caches, and the Homebrew download cache — deliberately NOT deleting whole Xcode versions (many minutes) or Android/.NET toolchains (many small files, slower); df -h / bookends are required for observability so every run's log records reclaimed headroom; the job itself only needs mise/bun and Xcode command-line tools (codesign/hdiutil/stapler), none of which live in the deleted locations. The comment block documents the incident class, consistent with how release.yml documents its other hardening (e.g. the Spotlight/'Resource busy' step). Validated with actionlint 1.7.12 (clean, including shellcheck over the run block) and a YAML parse matching CI's own check. Diff is intentionally minimal: one step, 19 added lines, nothing else touched.

## What Changed

- Added a best-effort "Free runner disk space" step to the build job in `.github/workflows/release.yml`, running on all four matrix legs right after checkout and before mise/bun setup. It deletes Simulator runtimes (`sudo xcrun simctl runtime delete all`), the CoreSimulator dyld caches, and the Homebrew download cache — large preinstalled artifacts the build never touches — after the v0.1.1-canary.3 release run failed on the x64 Performance leg with `hdiutil: create failed - No space left on device`.
- The step can never fail the release: it uses `continue-on-error: true` plus `|| true` on every command, and `df -h /` bookends record the reclaimed headroom in each job log. The pipeline's test pass verified the step exits 0 even when `xcrun`/`brew` fail or `brew` is absent, and the review pass noted only a low-probability informational concern (an untimed `simctl` hang) requiring no action.

## Risk Assessment

✅ Low: Single additive, best-effort CI cleanup step that is fully error-suppressed, correctly placed before any disk writes, deletes only assets the build job never touches, and modifies no product code.

## Testing

Confirmed the real v0.1.1-canary.3 incident from CI logs, ran CI's own workflow-YAML validation (clean), asserted the step's placement/coverage/fail-safety from the parsed YAML, and executed the verbatim step script under bash -e in a stub sandbox across happy-path and failure-injection scenarios — all exit 0 with df bookends recorded. Actual disk reclaim on a hosted runner is only observable on the next tagged release (pushing a tag would cut a real release), which is exactly what the step's df bookends are designed to log; no UI surface exists for this CI-only change, so the workflow-log transcript is the end-user-visible artifact.

<details>
<summary>Evidence: Motivating incident: hdiutil &#39;No space left on device&#39; log from v0.1.1-canary.3 x64 Performance build (attempt 1)</summary>

```text
2026-07-14T14:34:12.4597380Z   id: 620ba621-7a25-43df-acad-8f0347a16a79
2026-07-14T14:34:12.4597910Z   status: Accepted
2026-07-14T14:34:12.4598160Z 
2026-07-14T14:34:12.4598160Z 
2026-07-14T14:34:12.4598450Z uuid 620ba621-7a25-43df-acad-8f0347a16a79
2026-07-14T14:34:12.4599590Z stapling...
2026-07-14T14:34:12.8949850Z creating dmg...
2026-07-14T14:34:20.3971740Z hdiutil: create failed - No space left on device
2026-07-14T14:34:20.4191360Z Build failed: 993 |   if (!isURLInstance(fileURLOrPath))
2026-07-14T14:34:20.4192320Z 994 |     return fileURLOrPath;
2026-07-14T14:34:20.4193380Z 995 |   return Bun.fileURLToPath(fileURLOrPath);
2026-07-14T14:34:20.4199800Z 996 | }
2026-07-14T14:34:20.4250120Z 997 | var { Error, TypeError } = globalThis;
2026-07-14T14:34:20.4252460Z 998 |   let err = new Error(message);
2026-07-14T14:34:20.4255400Z                         ^
2026-07-14T14:34:20.4259030Z error: Command failed: hdiutil create -volname "LLM Space Performance-canary" -srcfolder '/Users/runner/work/llm-space/llm-space/apps/desktop/build/canary-macos-x64/.dmg-staging' -ov -format ULFO '/Users/runner/work/llm-space/llm-space/apps/desktop/build/canary-macos-x64/LLMSpacePerformance-canary.dmg'
2026-07-14T14:34:20.4262590Z hdiutil: create failed - No space left on device
2026-07-14T14:34:20.4263350Z 
2026-07-14T14:34:20.4263810Z  signal: null,
2026-07-14T14:34:20.4264520Z  status: 1,
2026-07-14T14:34:20.4266440Z  output: [ null, "could not access /Volumes/LLM Space Performance-canary/LLM Space Performance-canary.app/Contents/Resources/2acjlvv55dk5a.tar.zst - No space left on device\n", "hdiutil: create failed - No space left on device\n" ],
2026-07-14T14:34:20.4268500Z     pid: 31429,
2026-07-14T14:34:20.4269990Z  stdout: "could not access /Volumes/LLM Space Performance-canary/LLM Space Performance-canary.app/Contents/Resources/2acjlvv55dk5a.tar.zst - No space left on device\n",
2026-07-14T14:34:20.4271700Z  stderr: "hdiutil: create failed - No space left on device\n",
2026-07-14T14:34:20.4272410Z 
2026-07-14T14:34:20.4272680Z       at genericNodeError (node:child_process:998:13)
2026-07-14T14:34:20.4273480Z       at checkExecSyncError (node:child_process:458:27)
2026-07-14T14:34:20.4274740Z       at execSync (node:child_process:278:31)
2026-07-14T14:34:20.4275390Z       at runBuild (/$bunfs/root/electrobun:17891:19)
2026-07-14T14:34:20.4275870Z 
2026-07-14T14:34:20.5212010Z error: script "build:canary" exited with code 1
```
</details>
<details>
<summary>Evidence: Structural assertions on the new step (matrix coverage, placement, fail-safety)</summary>

<code>matrix legs sharing this step: 4 (macos-15/arm64 + macos-15-intel/x64, regular + performance)&#10;continue-on-error: true -&gt; step can never fail the job&#10;placement: after &#39;actions/checkout&#39; and before &#39;jdx/mise-action&#39; (runs before anything writes to disk)&#10;df -h / bookends: first and last line of the script&#10;every cleanup command ends in &#39;|| true&#39;</code>

```text
== Structural assertions on jobs.build (release.yml) ==
matrix legs sharing this step: 4
  - runner=macos-15 arch=arm64 edition=regular
  - runner=macos-15-intel arch=x64 edition=regular
  - runner=macos-15 arch=arm64 edition=performance
  - runner=macos-15-intel arch=x64 edition=performance
continue-on-error: true  -> step can never fail the job
placement: after 'actions/checkout' and before 'jdx/mise-action' (runs before anything writes to disk)
df -h / bookends: first and last line of the script
every cleanup command ends in '|| true'
```
</details>
<details>
<summary>Evidence: Step script executed under bash -e: happy path, xcrun+brew failure injection, brew absent — all exit 0</summary>

```text
### Executing the exact 'Free runner disk space' run script extracted from release.yml
### Shell: bash -e (GitHub Actions' default for macOS run steps); sudo/xcrun/brew/rm stubbed, df real

--- Scenario A: happy path (all cleanup commands succeed) ---
  pre-existing brew cache: total 1024
  pre-existing brew cache: -rw-r--r--@ 1 anx  staff  524288 Jul 14 23:22 some-bottle.tar.gz
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   926Gi    13Gi   546Gi     3%    459k  4.3G    0%   /
[stub sudo] xcrun simctl runtime delete all
[stub xcrun] invoked: xcrun simctl runtime delete all
[stub xcrun] Deleting simulator runtime 'iOS 18.4 (22E238)' ... done (simulated, ~15 GB)
[stub sudo] rm -rf /Library/Developer/CoreSimulator/Caches
[stub rm] rm -rf /Library/Developer/CoreSimulator/Caches
  -> simulated delete (outside sandbox, untouched): /Library/Developer/CoreSimulator/Caches
[stub rm] rm -rf /var/folders/hv/5dt_hrvx0193s11sph8g8cvc0000gn/T//disk-cleanup-step-TK5pxO/brew-cache
  -> deleted for real (inside sandbox): /var/folders/hv/5dt_hrvx0193s11sph8g8cvc0000gn/T//disk-cleanup-step-TK5pxO/brew-cache
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   926Gi    13Gi   546Gi     3%    459k  4.3G    0%   /
step exit code: 0
PASS: step succeeds and df bookends recorded
PASS: brew download cache actually removed

--- Scenario B: failure injection (xcrun and brew both fail) ---
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   926Gi    13Gi   546Gi     3%    459k  4.3G    0%   /
[stub sudo] xcrun simctl runtime delete all
[stub xcrun] simctl runtime delete all -> Failed to delete runtimes: Operation not permitted
[stub sudo] rm -rf /Library/Developer/CoreSimulator/Caches
[stub rm] rm -rf /Library/Developer/CoreSimulator/Caches
  -> simulated delete (outside sandbox, untouched): /Library/Developer/CoreSimulator/Caches
Error: brew broke
[stub rm] rm -rf 
rm: : No such file or directory
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   926Gi    13Gi   546Gi     3%    459k  4.3G    0%   /
step exit code: 0
PASS: '|| true' insurance holds — failing cleanup commands cannot fail the step

--- Scenario C: brew missing from PATH entirely ---
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   926Gi    13Gi   546Gi     3%    459k  4.3G    0%   /
[stub sudo] xcrun simctl runtime delete all
[stub xcrun] invoked: xcrun simctl runtime delete all
[stub xcrun] Deleting simulator runtime 'iOS 18.4 (22E238)' ... done (simulated, ~15 GB)
[stub sudo] rm -rf /Library/Developer/CoreSimulator/Caches
[stub rm] rm -rf /Library/Developer/CoreSimulator/Caches
  -> simulated delete (outside sandbox, untouched): /Library/Developer/CoreSimulator/Caches
/var/folders/hv/5dt_hrvx0193s11sph8g8cvc0000gn/T/no-mistakes-evidence/01KXGK7QFEBH77Q5QDX6DGB1Y9/step-script.sh: line 4: brew: command not found
[stub rm] rm -rf 
rm: : No such file or directory
Filesystem        Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s1s1   926Gi    13Gi   546Gi     3%    459k  4.3G    0%   /
step exit code: 0
PASS: step still exits 0 with brew absent
```
</details>
<details>
<summary>Evidence: Verbatim run script extracted from release.yml via YAML parser</summary>

```text
df -h /
sudo xcrun simctl runtime delete all || true
sudo rm -rf /Library/Developer/CoreSimulator/Caches || true
rm -rf "$(brew --cache)" || true
df -h /
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `.github/workflows/release.yml:122` - `continue-on-error: true` and `|| true` guard against command failures but not hangs: `xcrun simctl runtime delete` can wedge if the CoreSimulator service is unhealthy, and since this step runs on all four matrix legs, a hang would consume the 90-minute job timeout instead of merely flaking. Probability is low (the same untimed invocation runs in large production CI such as dotnet/maui), so no action needed; a `timeout`-style bound is an option only if a hang is ever observed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 5042871..571e58e` — confirmed the change is exactly one 19-line step in .github/workflows/release.yml</code>
- <code>`gh api /repos/deer-flow/llm-space/actions/runs/29340757755/attempts/1/jobs` + job log fetch — confirmed the motivating incident: build (macos-15-intel, x64, performance) failed with `hdiutil: create failed - No space left on device`</code>
- <code>`python -c &#34;import glob, yaml; [yaml.safe_load(open(f)) for f in glob.glob(&#39;.github/workflows/*.yml&#39;)]&#34;` — CI&#39;s exact workflow-YAML validation, passed</code>
- <code>Parsed-YAML structural assertions: step present in the 4-leg build matrix job, placed directly after actions/checkout and before jdx/mise-action, `continue-on-error: true`, `df -h /` bookends, `|| true` on every cleanup command</code>
- <code>Executed the verbatim extracted step script with `bash -e` (GitHub&#39;s default run-step shell) in a stub sandbox (sudo/xcrun/brew/rm stubbed, df real): exit 0 on happy path with brew cache actually deleted; exit 0 with xcrun and brew failure injection; exit 0 with brew absent from PATH</code>
- <code>`gh api search/code` — corroborated `sudo xcrun simctl runtime delete all` syntax against dotnet/maui&#39;s production pipeline (eng/pipelines/common/provision.yml) and 21 other public repos</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
