### PR TITLE
fix: prevent skill descriptions from overflowing settings dialog

### DIFF
--- a/apps/desktop/src/components/skill-list-item.tsx
+++ b/apps/desktop/src/components/skill-list-item.tsx
@@ -33,9 +33,13 @@ function _SkillListItem({
       <ItemMedia>
         <SparklesIcon className="text-muted-foreground size-4" />
       </ItemMedia>
-      <ItemContent className={cn(!checked && "opacity-50")}>
+      <ItemContent className={cn("min-w-0", !checked && "opacity-50")}>
         <ItemTitle>{name}</ItemTitle>
-        {description && <ItemDescription>{description}</ItemDescription>}
+        {description && (
+          <ItemDescription className="wrap-anywhere">
+            {description}
+          </ItemDescription>
+        )}
       </ItemContent>
       <Switch
         size="sm"


### PR DESCRIPTION
## Summary

Prevent long skill descriptions from expanding the Skills settings viewport beyond the dialog boundary.

## Root cause

`ItemContent` is a flex child whose default `min-width: auto` preserves the description's intrinsic minimum width. Long command names, URLs, slash-separated text, or other hard-to-break content can therefore prevent the item from shrinking.

The Skills list is rendered inside Radix ScrollArea, whose internal table-based wrapper can expand to that intrinsic width. Once the content crosses the available-width threshold, the whole list grows horizontally, descriptions escape the dialog, and switches may be pushed out of alignment.

This appeared machine-dependent because skill descriptions are loaded from each machine's local `SKILL.md` files. Window width, font metrics, scaling, and WKWebView/CEF differences change the threshold, but they are amplifiers rather than the underlying cause.

## Fix

- Add `min-w-0` to `ItemContent` so the flex child is allowed to shrink within the card.
- Add `wrap-anywhere` to `ItemDescription` so long tokens can wrap and contribute a safe intrinsic width.
- Keep the existing two-line clamp and switch layout unchanged.
- Avoid global overflow clipping or changes to generated shadcn/Radix primitives.

## Validation

- `mise run lint`
- `mise run typecheck`
- Production Vite build
- `mise run pack` — macOS arm64 WKWebView edition
- `mise run pack:perf` — macOS arm64 Performance/CEF edition
- `hdiutil verify` passed for both DMGs
- Both packaged macOS editions were launched and checked with real local skill data
- 700-character unbroken token stress case passed
- 150% text scaling passed
- Overflowing items: 33 before, 0 after
- Dialog `clientWidth / scrollWidth`: 1024 / 1383 before, 1024 / 1024 after

Windows packaging is intentionally out of scope because that edition is not currently public.
