### PR TITLE
feat(search): add Brave Search provider

### DIFF
--- a/apps/desktop/src/bun/search/search-settings-manager.ts
+++ b/apps/desktop/src/bun/search/search-settings-manager.ts
@@ -9,7 +9,11 @@ import {
   type SearchSettings,
 } from "../../shared/search";
 
-const VALID_PROVIDERS: readonly SearchProviderId[] = ["firecrawl", "tavily"];
+const VALID_PROVIDERS: readonly SearchProviderId[] = [
+  "brave",
+  "firecrawl",
+  "tavily",
+];
 
 /**
  * Owns `settings/search.json`: the in-memory source of truth for the built-in
@@ -78,6 +82,10 @@ export class SearchSettingsManager {
         : DEFAULT_SEARCH_SETTINGS.provider;
     return {
       provider,
+      braveApiKey:
+        typeof input.braveApiKey === "string"
+          ? input.braveApiKey
+          : DEFAULT_SEARCH_SETTINGS.braveApiKey,
       firecrawlApiKey:
         typeof input.firecrawlApiKey === "string"
           ? input.firecrawlApiKey

--- a/apps/desktop/src/bun/tools/built-in/built-in-tools-module.test.ts
+++ b/apps/desktop/src/bun/tools/built-in/built-in-tools-module.test.ts
@@ -20,6 +20,7 @@ describe("built-in tools module", () => {
               : null,
           getSearchSettings: () => ({
             provider: "firecrawl",
+            braveApiKey: "",
             firecrawlApiKey: "",
             tavilyApiKey: "",
           }),
@@ -67,6 +68,7 @@ describe("built-in tools module", () => {
           findSkill: undefined,
           getSearchSettings: () => ({
             provider: "firecrawl",
+            braveApiKey: "",
             firecrawlApiKey: "",
             tavilyApiKey: "",
           }),

--- a/apps/desktop/src/bun/tools/built-in/web.test.ts
+++ b/apps/desktop/src/bun/tools/built-in/web.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createWebBuiltInTools } from "./web";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("Brave Search provider", () => {
+  test("uses the official endpoint, auth header, and normalized result shape", async () => {
+    let request: { url: URL; headers: Headers } | undefined;
+    globalThis.fetch = ((input, init) => {
+      request = {
+        url:
+          input instanceof URL
+            ? input
+            : typeof input === "string"
+              ? new URL(input)
+              : new URL(input.url),
+        headers: new Headers(init?.headers),
+      };
+      return Promise.resolve(
+        Response.json({
+          web: {
+            results: [
+              {
+                title: "LLM Space",
+                url: "https://example.com/llm-space",
+                description: "A prompt and agent workbench.",
+                extra_snippets: ["Build and inspect agent runs."],
+              },
+            ],
+          },
+        })
+      );
+    }) as typeof fetch;
+
+    const search = createWebBuiltInTools({
+      env: {},
+      getSearchSettings: () => ({
+        provider: "brave",
+        braveApiKey: "brave-key",
+        firecrawlApiKey: "",
+        tavilyApiKey: "",
+      }),
+    }).find((entry) => entry.tool.name === "web_search");
+
+    const result = await search?.execute({
+      query: "LLM Space",
+      limit: 50,
+      includeContent: true,
+    });
+
+    expect(request).toBeDefined();
+    if (!request) throw new Error("Brave Search request was not captured");
+    expect(request.url.origin + request.url.pathname).toBe(
+      "https://api.search.brave.com/res/v1/web/search"
+    );
+    expect(request.url.searchParams.get("q")).toBe("LLM Space");
+    expect(request.url.searchParams.get("count")).toBe("20");
+    expect(request.url.searchParams.get("extra_snippets")).toBe("true");
+    expect(request.headers.get("X-Subscription-Token")).toBe("brave-key");
+    expect(result).toEqual([
+      {
+        title: "LLM Space",
+        url: "https://example.com/llm-space",
+        snippet: "A prompt and agent workbench.",
+        content:
+          "A prompt and agent workbench.\n\nBuild and inspect agent runs.",
+      },
+    ]);
+  });
+
+  test("requires a configured Brave Search API key", async () => {
+    const search = createWebBuiltInTools({
+      env: {},
+      getSearchSettings: () => ({
+        provider: "brave",
+        braveApiKey: "$BRAVE_SEARCH_API_KEY",
+        firecrawlApiKey: "",
+        tavilyApiKey: "",
+      }),
+    }).find((entry) => entry.tool.name === "web_search");
+
+    let rejection: unknown;
+    try {
+      await Promise.resolve(search!.execute({ query: "test" }));
+    } catch (error) {
+      rejection = error;
+    }
+    expect(rejection).toBeInstanceOf(Error);
+    expect((rejection as Error).message).toContain(
+      "Brave Search API key is not configured"
+    );
+  });
+
+  test("delegates web_fetch to Firecrawl", async () => {
+    let request: { url: string; headers: Headers } | undefined;
+    globalThis.fetch = ((input, init) => {
+      request = {
+        url:
+          input instanceof URL
+            ? input.toString()
+            : typeof input === "string"
+              ? input
+              : input.url,
+        headers: new Headers(init?.headers),
+      };
+      return Promise.resolve(
+        Response.json({
+          success: true,
+          data: {
+            markdown: "# Example",
+            metadata: { title: "Example" },
+          },
+        })
+      );
+    }) as typeof fetch;
+
+    const fetchTool = createWebBuiltInTools({
+      env: {},
+      getSearchSettings: () => ({
+        provider: "brave",
+        braveApiKey: "brave-key",
+        firecrawlApiKey: "firecrawl-key",
+        tavilyApiKey: "",
+      }),
+    }).find((entry) => entry.tool.name === "web_fetch");
+
+    const result = await fetchTool?.execute({ url: "https://example.com" });
+
+    expect(request).toBeDefined();
+    if (!request) throw new Error("Firecrawl request was not captured");
+    expect(request.url).toBe("https://api.firecrawl.dev/v2/scrape");
+    expect(request.headers.get("Authorization")).toBe("Bearer firecrawl-key");
+    expect(result).toEqual({
+      url: "https://example.com",
+      title: "Example",
+      content: "# Example",
+      metadata: { title: "Example" },
+    });
+  });
+});

--- a/apps/desktop/src/bun/tools/built-in/web.test.ts
+++ b/apps/desktop/src/bun/tools/built-in/web.test.ts
@@ -96,6 +96,46 @@ describe("Brave Search provider", () => {
     );
   });
 
+  test("surfaces error details returned by Brave Search", async () => {
+    globalThis.fetch = ((input) => {
+      void input;
+      return Promise.resolve(
+        Response.json(
+          {
+            type: "ErrorResponse",
+            error: {
+              status: 422,
+              detail: "The provided subscription token is invalid.",
+              code: "SUBSCRIPTION_TOKEN_INVALID",
+            },
+          },
+          { status: 422 }
+        )
+      );
+    }) as typeof fetch;
+
+    const search = createWebBuiltInTools({
+      env: {},
+      getSearchSettings: () => ({
+        provider: "brave",
+        braveApiKey: "invalid-brave-key",
+        firecrawlApiKey: "",
+        tavilyApiKey: "",
+      }),
+    }).find((entry) => entry.tool.name === "web_search");
+
+    let rejection: unknown;
+    try {
+      await Promise.resolve(search!.execute({ query: "test" }));
+    } catch (error) {
+      rejection = error;
+    }
+    expect(rejection).toBeInstanceOf(Error);
+    expect((rejection as Error).message).toBe(
+      "The provided subscription token is invalid."
+    );
+  });
+
   test("delegates web_fetch to Firecrawl", async () => {
     let request: { url: string; headers: Headers } | undefined;
     globalThis.fetch = ((input, init) => {

--- a/apps/desktop/src/bun/tools/built-in/web.ts
+++ b/apps/desktop/src/bun/tools/built-in/web.ts
@@ -10,6 +10,7 @@ export interface WebBuiltInToolsDependencies {
 
 const FIRECRAWL_BASE_URL = "https://api.firecrawl.dev";
 const TAVILY_BASE_URL = "https://api.tavily.com";
+const BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
 
 interface WebFetchResult {
   url: string;
@@ -81,6 +82,19 @@ interface TavilyExtractResponse {
     url?: string;
     error?: string;
   }[];
+}
+
+interface BraveSearchResponse {
+  web?: {
+    results?: {
+      title?: string;
+      url?: string;
+      description?: string;
+      extra_snippets?: string[];
+    }[];
+  };
+  message?: string;
+  detail?: string;
 }
 
 function _truncateText(text: string, maxChars: number): string {
@@ -261,12 +275,83 @@ class TavilySearchProvider implements SearchProvider {
   }
 }
 
+/**
+ * Brave-backed web search. Brave does not expose a single-page extraction
+ * endpoint, so `web_fetch` delegates to Firecrawl instead of fetching arbitrary
+ * URLs from the trusted Bun process, which would widen the tool's SSRF surface.
+ */
+class BraveSearchProvider implements SearchProvider {
+  constructor(
+    private readonly _apiKey: string,
+    private readonly _fetchProvider: SearchProvider
+  ) {
+    if (!_apiKey) {
+      throw new Error(
+        "Brave Search API key is not configured. Add one in Settings → Search."
+      );
+    }
+  }
+
+  fetch(url: string): Promise<WebFetchResult> {
+    return this._fetchProvider.fetch(url);
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    includeContent: boolean
+  ): Promise<WebSearchResult[]> {
+    const url = new URL(BRAVE_SEARCH_URL);
+    url.searchParams.set("q", query);
+    url.searchParams.set("count", String(Math.max(1, Math.min(20, limit))));
+    url.searchParams.set("text_decorations", "false");
+    if (includeContent) {
+      url.searchParams.set("extra_snippets", "true");
+    }
+
+    const res = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "X-Subscription-Token": this._apiKey,
+      },
+    });
+    const json = (await res.json()) as BraveSearchResponse;
+
+    if (!res.ok) {
+      throw new Error(
+        json.message ?? json.detail ?? `web_search failed: ${res.status}`
+      );
+    }
+
+    return (json.web?.results ?? []).map((item) => {
+      const snippets = [item.description, ...(item.extra_snippets ?? [])]
+        .filter((value): value is string => Boolean(value))
+        .join("\n\n");
+      return {
+        title: item.title ?? "Untitled",
+        url: item.url ?? "",
+        snippet: item.description,
+        content:
+          includeContent && snippets
+            ? _truncateText(snippets, 2_000)
+            : undefined,
+      };
+    });
+  }
+}
+
 /** Build the provider selected in `settings/search.json` with its resolved key. */
 function _getSearchProvider({
   env,
   getSearchSettings,
 }: WebBuiltInToolsDependencies): SearchProvider {
   const settings = getSearchSettings();
+  if (settings.provider === "brave") {
+    return new BraveSearchProvider(
+      _resolveApiKey(settings.braveApiKey, env),
+      new FirecrawlSearchProvider(_resolveApiKey(settings.firecrawlApiKey, env))
+    );
+  }
   if (settings.provider === "tavily") {
     return new TavilySearchProvider(_resolveApiKey(settings.tavilyApiKey, env));
   }

--- a/apps/desktop/src/bun/tools/built-in/web.ts
+++ b/apps/desktop/src/bun/tools/built-in/web.ts
@@ -93,6 +93,9 @@ interface BraveSearchResponse {
       extra_snippets?: string[];
     }[];
   };
+  error?: {
+    detail?: string;
+  };
   message?: string;
   detail?: string;
 }
@@ -319,7 +322,10 @@ class BraveSearchProvider implements SearchProvider {
 
     if (!res.ok) {
       throw new Error(
-        json.message ?? json.detail ?? `web_search failed: ${res.status}`
+        json.error?.detail ??
+          json.message ??
+          json.detail ??
+          `web_search failed: ${res.status}`
       );
     }
 

--- a/apps/desktop/src/components/settings/search-page.tsx
+++ b/apps/desktop/src/components/settings/search-page.tsx
@@ -59,8 +59,9 @@ export function SearchPage() {
       title="Search"
       description={
         <>
-          These settings only apply to the built-in <code>web_search</code> and{" "}
-          <code>web_fetch</code> tools.
+          Choose the provider for the built-in <code>web_search</code> tool.
+          When Brave Search is selected, <code>web_fetch</code> continues to use
+          Firecrawl for safe page extraction.
         </>
       }
     >
@@ -77,6 +78,7 @@ export function SearchPage() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value="brave">Brave Search</SelectItem>
               <SelectItem value="firecrawl">Firecrawl</SelectItem>
               <SelectItem value="tavily">Tavily</SelectItem>
             </SelectContent>
@@ -84,6 +86,16 @@ export function SearchPage() {
         </div>
 
         <Separator />
+
+        <ApiKeyField
+          label="Brave Search API key"
+          value={settings.braveApiKey}
+          getKeyUrl="https://api-dashboard.search.brave.com/app/keys"
+          onChange={(e) =>
+            setSettings({ ...settings, braveApiKey: e.target.value })
+          }
+          onBlur={() => void persist(settings)}
+        />
 
         <ApiKeyField
           label="Firecrawl API key"
@@ -107,7 +119,8 @@ export function SearchPage() {
 
         <p className="text-muted-foreground text-xs">
           Values starting with <code>$</code> are read from the environment
-          (e.g. <code>$FIRECRAWL_API_KEY</code>, <code>$TAVILY_API_KEY</code>).
+          (e.g. <code>$BRAVE_SEARCH_API_KEY</code>,{" "}
+          <code>$FIRECRAWL_API_KEY</code>, <code>$TAVILY_API_KEY</code>).
         </p>
       </div>
     </SettingsPage>

--- a/apps/desktop/src/shared/search.ts
+++ b/apps/desktop/src/shared/search.ts
@@ -1,5 +1,5 @@
 /** The web-search / web-fetch provider backing the built-in web tools. */
-export type SearchProviderId = "firecrawl" | "tavily";
+export type SearchProviderId = "brave" | "firecrawl" | "tavily";
 
 /**
  * User-configured search settings, persisted to `settings/search.json`. API keys
@@ -9,12 +9,14 @@ export type SearchProviderId = "firecrawl" | "tavily";
  */
 export interface SearchSettings {
   provider: SearchProviderId;
+  braveApiKey: string;
   firecrawlApiKey: string;
   tavilyApiKey: string;
 }
 
 export const DEFAULT_SEARCH_SETTINGS: SearchSettings = {
   provider: "firecrawl",
+  braveApiKey: "$BRAVE_SEARCH_API_KEY",
   firecrawlApiKey: "$FIRECRAWL_API_KEY",
   tavilyApiKey: "$TAVILY_API_KEY",
 };


### PR DESCRIPTION
## Summary

- add Brave Search as a configurable provider for the built-in web_search tool
- persist the Brave API key with backward-compatible search settings defaults
- keep web_fetch delegated to Firecrawl when Brave Search is selected
- add focused coverage for authentication, result normalization, missing credentials, and the Firecrawl fallback

## Testing

- bun test apps/desktop/src/bun/tools/built-in/web.test.ts apps/desktop/src/bun/tools/built-in/built-in-tools-module.test.ts
- bun run lint
- bun run typecheck
- bun run build:view (apps/desktop)
- Prettier check and git diff --check