### PR TITLE
fix(settings): constrain skills list within settings dialog bounds

### DIFF
--- a/apps/desktop/src/components/settings/settings-dialog.tsx
+++ b/apps/desktop/src/components/settings/settings-dialog.tsx
@@ -83,9 +83,13 @@ export function SettingsDialog({
               ))}
             </TabsList>
           </aside>
-          <div className="min-w-0 grow">
+          <div className="flex min-w-0 grow flex-col overflow-hidden">
             {PAGES.map(({ value, Page }) => (
-              <TabsContent key={value} value={value} className="size-full">
+              <TabsContent
+                key={value}
+                value={value}
+                className="min-h-0 flex-1 data-[state=inactive]:hidden"
+              >
                 <Page />
               </TabsContent>
             ))}

--- a/apps/desktop/src/components/settings/skills-page.tsx
+++ b/apps/desktop/src/components/settings/skills-page.tsx
@@ -119,7 +119,6 @@ export function SkillsPage() {
 
   return (
     <SettingsPage
-      className="flex size-full min-h-0"
       title="Skills"
       description={
         <>
@@ -127,16 +126,18 @@ export function SkillsPage() {
         </>
       }
     >
-      <PathList
-        paths={paths}
-        selectedPath={selectedPath}
-        onSelect={setSelectedPath}
-        onAdd={() => void handleAdd()}
-        onRemove={(path) => void handleRemove(path)}
-        onEnableAll={(path) => void handleSetAll(path, false)}
-        onDisableAll={(path) => void handleSetAll(path, true)}
-      />
-      <PathSkills key={`${selectedPath}:${reloadToken}`} path={selectedPath} />
+      <div className="flex h-full min-h-0 gap-4">
+        <PathList
+          paths={paths}
+          selectedPath={selectedPath}
+          onSelect={setSelectedPath}
+          onAdd={() => void handleAdd()}
+          onRemove={(path) => void handleRemove(path)}
+          onEnableAll={(path) => void handleSetAll(path, false)}
+          onDisableAll={(path) => void handleSetAll(path, true)}
+        />
+        <PathSkills key={`${selectedPath}:${reloadToken}`} path={selectedPath} />
+      </div>
     </SettingsPage>
   );
 }
@@ -161,7 +162,7 @@ function PathList({
   const [listRef] = useAutoAnimation<HTMLDivElement>();
 
   return (
-    <div className="flex w-64 shrink-0 flex-col gap-3 border-r pr-4">
+    <div className="flex h-full w-64 shrink-0 flex-col gap-3 border-r pr-4">
       <ScrollArea className="min-h-0 grow">
         {paths.length === 0 ? (
           <div className="text-muted-foreground px-2 py-6 text-center text-xs text-balance">
@@ -382,7 +383,7 @@ function PathSkills({ path }: { path: string | null }) {
   }, [handleToggle, listRef, path, skills]);
 
   return (
-    <div className="flex min-w-0 grow flex-col">
+    <div className="flex h-full min-w-0 grow flex-col">
       <ScrollArea className="min-h-0 grow">
         <div className="flex flex-col gap-2 pr-4 pl-6">{content}</div>
       </ScrollArea>


### PR DESCRIPTION
     Fixes the Skills settings page overflowing the dialog when the skill list is long.

     Changes:
     - `settings-dialog.tsx`: make the right content area a flex column and let the active `TabsContent` fill the remaining height via `flex-1` instead of relying on `size-full`.
     - `skills-page.tsx`: wrap the left/right panes in an explicit `h-full` flex container and give both panes a defined height so their inner `ScrollArea` can scroll correctly.

     Verified locally with `bun run lint`, `bun run typecheck`, and CEF/CDP screenshot of the Skills dialog.