### PR TITLE
[react-doctor] Fix no-ref-current-in-render in page.tsx (activeTabIdRef)

### DIFF
--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -191,8 +191,12 @@ function PageInner() {
   const { tracingEnabled } = useExperimental();
 
   // The active tab is read through a ref so command handlers never go stale.
+  // The ref is read only inside post-commit command handlers, so the sync
+  // lives in a passive effect rather than the render body.
   const activeTabIdRef = useRef(tabs.activeId);
-  activeTabIdRef.current = tabs.activeId;
+  useEffect(() => {
+    activeTabIdRef.current = tabs.activeId;
+  });
   const {
     close,
     closeOthers,


### PR DESCRIPTION
## Issue

`react-doctor` `no-ref-current-in-render` (error severity) at `apps/desktop/src/app/page.tsx:195`: `activeTabIdRef.current = tabs.activeId` was assigned in the render body.

## Fix

The ref is read **only** inside the `closeTab` / `closeOtherTabs` command handlers registered via `useRegisterCommands`. Those handlers are stored in a `latest` ref and invoked post-commit through the command registry (`executeCommand`), never during render. So the sync is moved out of the render body into a passive `useEffect` (no dep array → runs after every commit). This is the same latest-value-ref pattern shipped in PRs #37 / #44 / #50; no behavior change on the post-commit read path.

One issue, one file, one focused diff.

## Verification

- Frozen worktree off `origin/main` (`3f4f79e`), `bun install --frozen-lockfile`: `apps/desktop` `tsc --noEmit` clean (exit 0).
- Re-scan: `no-ref-current-in-render` 10 → 8 raw, error tier 14 → 12, total 752 → 750, site `page.tsx:195` resolved, **zero new diagnostics** (the two page.tsx entries that shifted are pre-existing, +4 lines from the insertion).
- Health score 59 → 59 / Critical (react-doctor 0.7.8).
- Owner-checkout cross-check: applied the same diff read-only, `tsc` **delta = 0** (only the pre-existing `message-list-view.tsx:214` Radix skew, unrelated), reverted, tree clean.