### PR TITLE
fix: ignore image content on assistant messages

### DIFF
--- a/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
+++ b/apps/desktop/src/components/thread-playground/message/message-list-item.tsx
@@ -63,13 +63,17 @@ function _MessageListItem({
   const text = useMemo(() => getMessageText(message), [message]);
   const imageContents = useMemo(() => {
     const result: { content: ImageDataContent; contentIndex: number }[] = [];
+    // Assistant messages must not display images.
+    if (message.role === "assistant") {
+      return result;
+    }
     message.content.forEach((content, contentIndex) => {
       if (content.type === "image_data") {
         result.push({ content, contentIndex });
       }
     });
     return result;
-  }, [message.content]);
+  }, [message.content, message.role]);
   const toolCallSummary = useMemo(
     () =>
       message.role === "assistant" && message.toolCalls?.length

--- a/packages/core/src/client/converters.ts
+++ b/packages/core/src/client/converters.ts
@@ -107,6 +107,9 @@ function _convertMessageContents(
     for (const content of message.content) {
       if (content.type === "text") {
         contents.push({ ...content } satisfies pi.TextContent);
+      } else if (content.type === "image_data") {
+        // Assistant messages may not carry images; drop them on conversion.
+        continue;
       } else {
         throw new Error(`Unsupported content type: ${JSON.stringify(content)}`);
       }


### PR DESCRIPTION
## Summary

Fixes the invalid message state described in #59. A user message can hold image content, and the role toggle switches it to Assistant while preserving the image — but Assistant messages don't support images. The result: the image stays visible, its Remove action is a no-op, and PI conversion throws `Unsupported content type: image_data` before any model request is sent.

This takes the backward-compatibility path suggested in the issue (let the invalid state exist harmlessly rather than block/confirm the toggle):

- **Display** (`message-list-item.tsx`): image content is not rendered on assistant messages, so no dead Remove action is shown.
- **Conversion** (`converters.ts`): the assistant branch drops `image_data` content instead of throwing, so a thread with a leftover image still runs.

## Test plan

- Follow the repro steps in #59: add an image to a user message, toggle to Assistant → image no longer displays.
- Run the thread → conversion no longer throws.
- `mise run typecheck` passes.

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)