### PR TITLE
fix: confirm variable deletion across thread references

### DIFF
--- a/apps/desktop/src/components/thread-playground/variable/prompt-variables-panel.tsx
+++ b/apps/desktop/src/components/thread-playground/variable/prompt-variables-panel.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_VARIABLE_VARIANT_NAME,
   formatCurrentDateVariable,
   formatSkillsVariable,
+  hasThreadPromptVariableReference,
   normalizePromptVariableState,
   VARIABLE_NAME_RE,
 } from "@llm-space/core/thread";
@@ -93,6 +94,7 @@ function _PromptVariablesPanel({
   const systemPrompt = useThreadStore(
     (s) => s.thread.context?.systemPrompt ?? ""
   );
+  const messages = useThreadStore((s) => s.thread.context?.messages);
   const {
     updatePromptVariable,
     renamePromptVariable,
@@ -132,9 +134,10 @@ function _PromptVariablesPanel({
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [skillsLoading, setSkillsLoading] = useState(false);
   const [skillsError, setSkillsError] = useState<string | null>(null);
-  const [pendingRemoveCustom, setPendingRemoveCustom] = useState<string | null>(
-    null
-  );
+  const [pendingRemoveCustom, setPendingRemoveCustom] = useState<{
+    name: string;
+    hasReferences: boolean;
+  } | null>(null);
   const initialSelectionKey = initialSelection
     ? `${initialSelection.kind}:${initialSelection.name}`
     : null;
@@ -253,13 +256,15 @@ function _PromptVariablesPanel({
 
   const confirmRemoveCustom = useCallback(
     (name: string) => {
-      if (_promptContainsVariable(systemPrompt, name)) {
-        setPendingRemoveCustom(name);
-        return;
-      }
-      removeCustomVariable(name);
+      setPendingRemoveCustom({
+        name,
+        hasReferences: hasThreadPromptVariableReference(
+          { systemPrompt, messages },
+          name
+        ),
+      });
     },
-    [removeCustomVariable, systemPrompt]
+    [messages, systemPrompt]
   );
   const detailFillsAvailableHeight =
     selection?.kind === "custom" ||
@@ -377,13 +382,15 @@ function _PromptVariablesPanel({
         title="Delete custom variable?"
         description={
           pendingRemoveCustom
-            ? `The system prompt references "{{${pendingRemoveCustom}}}". Deleting this variable will block runs until the prompt is updated.`
+            ? pendingRemoveCustom.hasReferences
+              ? `This thread references "{{${pendingRemoveCustom.name}}}". Deleting this variable will leave unresolved placeholders.`
+              : `This removes "{{${pendingRemoveCustom.name}}}" and its value from this thread.`
             : undefined
         }
         confirmLabel="Delete variable"
         onConfirm={() => {
           if (pendingRemoveCustom) {
-            removeCustomVariable(pendingRemoveCustom);
+            removeCustomVariable(pendingRemoveCustom.name);
           }
           setPendingRemoveCustom(null);
         }}
@@ -1028,11 +1035,6 @@ function _isCustomNameAvailable(
   );
 }
 
-function _promptContainsVariable(systemPrompt: string, name: string): boolean {
-  const re = new RegExp(`\\{\\{\\s*${_escapeRegExp(name)}\\s*\\}\\}`);
-  return re.test(systemPrompt);
-}
-
 function _uniqueName(base: string, used: Set<string>): string {
   if (!used.has(base)) {
     return base;
@@ -1042,10 +1044,6 @@ function _uniqueName(base: string, used: Set<string>): string {
     index += 1;
   }
   return `${base}_${index}`;
-}
-
-function _escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export const PromptVariablesPanel = memo(_PromptVariablesPanel);

--- a/packages/core/src/thread/prompt-variables.ts
+++ b/packages/core/src/thread/prompt-variables.ts
@@ -139,6 +139,30 @@ export function replaceThreadPromptVariableReferences(
   return next;
 }
 
+/** Return whether an editable, model-facing text surface references a variable. */
+export function hasThreadPromptVariableReference(
+  context: ThreadContext | undefined,
+  name: string
+): boolean {
+  const probeName = `${name}__reference_probe`;
+  if (
+    context?.systemPrompt !== undefined &&
+    replacePromptVariableReferences(context.systemPrompt, name, probeName) !==
+      context.systemPrompt
+  ) {
+    return true;
+  }
+
+  return Boolean(
+    context?.messages &&
+    _replaceMessagesPromptVariableReferences(
+      context.messages,
+      name,
+      probeName
+    ) !== context.messages
+  );
+}
+
 /**
  * Drop frozen values for prompt places whose editable source text changed.
  * Other places remain frozen, preserving cache-stable historical values.

--- a/packages/core/src/thread/thread-workflow.test.ts
+++ b/packages/core/src/thread/thread-workflow.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { ModelUsage, Thread } from "@llm-space/core";
 import {
   aggregateMessageUsage,
+  hasThreadPromptVariableReference,
   normalizePromptVariableState,
   recordRun,
   renderThreadPromptVariables,
@@ -263,6 +264,55 @@ describe("public headless thread workflow", () => {
       "message:user-1:text": { value: "frozen" },
       "toolResult:assistant-1:tool-1:text": { value: "frozen" },
     });
+  });
+
+  test("detects references across every model-facing text surface", () => {
+    const contexts: NonNullable<Thread["context"]>[] = [
+      { systemPrompt: "System {{customer}}" },
+      {
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            content: [{ type: "text", text: "User {{ customer }}" }],
+          },
+        ],
+      },
+      {
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            content: [],
+            toolCalls: [
+              {
+                id: "tool-1",
+                input: { name: "lookup", arguments: {} },
+                output: {
+                  content: [{ type: "text", text: "Tool {{customer}}" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        systemPrompt: "System {{other}}",
+        messages: [
+          {
+            id: "user-2",
+            role: "user",
+            content: [{ type: "text", text: "User {{other}}" }],
+          },
+        ],
+      },
+    ];
+
+    expect(
+      contexts.map((context) =>
+        hasThreadPromptVariableReference(context, "customer")
+      )
+    ).toEqual([true, true, true, false]);
   });
 
   test("preserves the missing-skill error contract", async () => {


### PR DESCRIPTION
## Summary

- detect custom-variable references across the system prompt, message text, and assistant tool results
- reuse the thread-level prompt-variable traversal contract for deletion checks
- require confirmation for custom-variable deletion and warn accurately when unresolved placeholders will remain
- add a regression test covering every model-facing text surface

## Root cause

The Variables panel subscribed only to `thread.context.systemPrompt` and used a local system-prompt-only matcher before deleting a custom variable. Rename and materialization already traversed messages and tool results, so deletion could disagree with the rest of the prompt-variable contract.

## Impact

Deleting a custom variable referenced only by a message or tool result now opens the confirmation dialog and preserves the variable until the user explicitly confirms. Unreferenced deletions are also confirmed, matching the repository's destructive-action convention.

Closes #57

## Validation

- `bun test` — 59 passed
- `bun run lint`
- `bun run typecheck`
- `bun run build:view`
- real Electrobun CEF/CDP verification for message, tool-result, referenced, and unreferenced deletion paths
