### PR TITLE
fix: prevent thread rename overwrite

### DIFF
--- a/packages/core/src/server/storage/local/file-system.test.ts
+++ b/packages/core/src/server/storage/local/file-system.test.ts
@@ -1,0 +1,40 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { LocalFileSystem } from "./file-system";
+
+const TEMP_DIRS: string[] = [];
+
+async function _createFileSystem(): Promise<LocalFileSystem> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "llm-space-test-"));
+  TEMP_DIRS.push(root);
+  return new LocalFileSystem(root);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    TEMP_DIRS.splice(0).map((dir) => fs.rm(dir, { recursive: true }))
+  );
+});
+
+describe("LocalFileSystem.mv", () => {
+  test("rejects a rename to an existing path without replacing its contents", async () => {
+    const fileSystem = await _createFileSystem();
+    await fs.writeFile(fileSystem.realpath("alpha.json"), "alpha");
+    await fs.writeFile(fileSystem.realpath("beta.json"), "beta");
+
+    expect(fileSystem.mv("beta.json", "alpha.json")).rejects.toThrow(
+      "destination already exists"
+    );
+
+    expect(fs.readFile(fileSystem.realpath("alpha.json"), "utf8")).resolves.toBe(
+      "alpha"
+    );
+    expect(fs.readFile(fileSystem.realpath("beta.json"), "utf8")).resolves.toBe(
+      "beta"
+    );
+  });
+});

--- a/packages/core/src/server/storage/local/file-system.ts
+++ b/packages/core/src/server/storage/local/file-system.ts
@@ -68,7 +68,19 @@ export class LocalFileSystem implements FileSystem, ThreadStorage {
   }
 
   async mv(src: string, dest: string): Promise<void> {
-    await fs.rename(this._resolve(src), this._resolve(dest));
+    const source = this._resolve(src);
+    const destination = this._resolve(dest);
+    if (source === destination) return;
+
+    try {
+      await fs.lstat(destination);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      await fs.rename(source, destination);
+      return;
+    }
+
+    throw new Error(`Cannot move: destination already exists: ${dest}`);
   }
 
   async rm(p: string): Promise<void> {

--- a/packages/core/src/types/storage/file-system.ts
+++ b/packages/core/src/types/storage/file-system.ts
@@ -48,7 +48,9 @@ export interface FileSystem {
   cp(src: string, dest: string): Promise<void>;
 
   /**
-   * Move or rename a file or directory.
+   * Move or rename a file or directory. Rejects if the destination already
+   * exists; callers that explicitly support replacing an entry must remove it
+   * first.
    */
   mv(src: string, dest: string): Promise<void>;
 


### PR DESCRIPTION
## Summary
- reject file-system moves when the destination already exists
- preserve explicit overwrite behavior after moving the destination to Trash
- cover conflicting thread renames with a regression test

Fixes #61

## Verification
- bun test
- mise run typecheck
- mise run lint