### PR TITLE
fix: merge tabs after thread overwrite

### DIFF
--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -479,6 +479,7 @@ function PageInner() {
                 activeId={tabs.activeId}
                 activate={tabs.activate}
                 refresh={tabs.refresh}
+                consumeDiscardedPane={tabs.consumeDiscardedPane}
                 sidebarOpen={sidebarOpen}
                 fullScreen={fullScreen}
                 close={handleCloseTab}

--- a/apps/desktop/src/components/thread-tabs/thread-tab-pane.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tab-pane.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 const rpcTransport = createRpcTransport();
 
 interface ThreadTabPaneProps {
+  paneId: string;
   path: string;
   active: boolean;
   /**
@@ -25,6 +26,8 @@ interface ThreadTabPaneProps {
   onMove?: (from: string, to: string) => void;
   /** Close this pane's tab, e.g. after its thread fails to load. */
   onClose?: (path: string) => void;
+  /** Return true once when an overwritten pane must drop pending writes. */
+  consumeDiscardedPane?: (paneId: string) => boolean;
 }
 
 /**
@@ -33,14 +36,21 @@ interface ThreadTabPaneProps {
  * in-progress streaming run survive tab switches.
  */
 export function ThreadTabPane({
+  paneId,
   path,
   active,
   refreshNonce = 0,
   onMove,
   onClose,
+  consumeDiscardedPane,
 }: ThreadTabPaneProps) {
   const qc = useQueryClient();
-  const { data: thread, isLoading, isError, error } = useQuery({
+  const {
+    data: thread,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
     queryKey: ["thread", path],
     queryFn: () => localFs.read(path),
     // A workspace file can change on disk outside the app, so never serve a
@@ -93,12 +103,19 @@ export function ThreadTabPane({
     [flushPending]
   );
 
-  // Flush any pending write when the tab closes so the last edit is never dropped.
+  // Flush pending edits on a normal close. An editor displaced by an overwrite
+  // instead drops them so stale destination content cannot replace the moved file.
   useEffect(() => {
     return () => {
+      if (consumeDiscardedPane?.(paneId)) {
+        if (writeTimer.current) clearTimeout(writeTimer.current);
+        writeTimer.current = null;
+        pending.current = null;
+        return;
+      }
       void flushPending();
     };
-  }, [flushPending]);
+  }, [consumeDiscardedPane, flushPending, paneId]);
 
   // "Refresh" the thread from disk: re-read the file and remount the playground
   // on a fresh store (via reloadKey), discarding any in-memory edits. Driven by

--- a/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tabs.tsx
@@ -63,6 +63,7 @@ interface ThreadTabsProps {
   fullScreen?: boolean;
   activate: (id: string) => void;
   refresh: (id: string) => void;
+  consumeDiscardedPane: (paneId: string) => boolean;
   close: (id: string) => void;
   closeOthers: (id: string) => void;
   closeAll: () => void;
@@ -90,6 +91,7 @@ export function ThreadTabs({
   fullScreen = false,
   activate,
   refresh,
+  consumeDiscardedPane,
   close,
   closeOthers,
   closeAll,
@@ -348,12 +350,14 @@ export function ThreadTabs({
         {tabs.map((tab) =>
           tab.type === "thread" ? (
             <ThreadTabPane
-              key={tab.id}
+              key={tab.paneId}
+              paneId={tab.paneId}
               path={tab.path}
               active={tab.id === activeId}
               refreshNonce={tab.refreshNonce ?? 0}
               onMove={onMove}
               onClose={(path) => close(`thread:${path}`)}
+              consumeDiscardedPane={consumeDiscardedPane}
             />
           ) : (
             <TraceTabPane

--- a/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
+++ b/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { uuid } from "@llm-space/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { localFs, traceClient } from "@/client";
@@ -10,6 +11,8 @@ export interface ThreadTab {
   id: string;
   type: "thread";
   path: string;
+  /** Stable editor identity that survives path rewrites. */
+  paneId: string;
   /** Bumped by `refresh(id)` to force the pane to reload from disk. */
   refreshNonce?: number;
 }
@@ -75,6 +78,8 @@ export interface ThreadTabs {
   handleRemove: (removed: string) => void;
   /** File-tree rename/move: rewrite open thread tab paths under `from` to `to`. */
   handleMove: (from: string, to: string) => void;
+  /** Consume the marker that prevents an overwritten editor from writing back. */
+  consumeDiscardedPane: (paneId: string) => boolean;
   /** Trace metadata edit: update labels for already-open trace tabs. */
   handleTraceTitleChange: (
     projectId: string,
@@ -101,7 +106,12 @@ function _traceTabId(projectId: string, traceKey: string): string {
 }
 
 function _createThreadTab(path: string): ThreadTab {
-  return { id: _threadTabId(path), type: "thread", path };
+  return {
+    id: _threadTabId(path),
+    type: "thread",
+    path,
+    paneId: `thread-pane:${uuid()}`,
+  };
 }
 
 function _createTraceTab({
@@ -147,6 +157,15 @@ function _fromPersisted(tab: PersistedTab): AppTab | null {
   return null;
 }
 
+function _dedupeTabs(tabs: AppTab[]): AppTab[] {
+  const seen = new Set<string>();
+  return tabs.filter((tab) => {
+    if (seen.has(tab.id)) return false;
+    seen.add(tab.id);
+    return true;
+  });
+}
+
 function _loadPersistedTabs(): AppTab[] {
   if (typeof window === "undefined") return [];
   try {
@@ -154,23 +173,27 @@ function _loadPersistedTabs(): AppTab[] {
     if (raw !== null) {
       const parsed: unknown = JSON.parse(raw);
       if (!Array.isArray(parsed)) return [];
-      return parsed
-        .map((item): PersistedTab | null => {
-          if (!item || typeof item !== "object") return null;
-          const t = item as PersistedTab;
-          return t.type === "thread" || t.type === "trace" ? t : null;
-        })
-        .map((item) => (item ? _fromPersisted(item) : null))
-        .filter((tab): tab is AppTab => tab !== null);
+      return _dedupeTabs(
+        parsed
+          .map((item): PersistedTab | null => {
+            if (!item || typeof item !== "object") return null;
+            const t = item as PersistedTab;
+            return t.type === "thread" || t.type === "trace" ? t : null;
+          })
+          .map((item) => (item ? _fromPersisted(item) : null))
+          .filter((tab): tab is AppTab => tab !== null)
+      );
     }
 
     const legacyRaw = window.localStorage.getItem(LEGACY_STORAGE_KEY);
     if (legacyRaw === null) return [];
     const legacy: unknown = JSON.parse(legacyRaw);
     return Array.isArray(legacy)
-      ? legacy
-          .filter((path): path is string => typeof path === "string")
-          .map(_createThreadTab)
+      ? _dedupeTabs(
+          legacy
+            .filter((path): path is string => typeof path === "string")
+            .map(_createThreadTab)
+        )
       : [];
   } catch {
     return [];
@@ -257,6 +280,7 @@ export function useThreadTabs(): ThreadTabs {
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
   const closedStack = useRef<PersistedTab[][]>([]);
+  const discardedPaneIds = useRef(new Set<string>());
   const pushClosed = useCallback((closed: AppTab[]) => {
     if (closed.length > 0) {
       closedStack.current.push(closed.map(_persistable));
@@ -408,10 +432,14 @@ export function useThreadTabs(): ThreadTabs {
       )
     ).filter((tab): tab is AppTab => tab !== null);
     if (alive.length === 0) return;
-    setTabs((prev) => [
-      ...prev,
-      ...alive.filter((tab) => !prev.some((current) => current.id === tab.id)),
-    ]);
+    setTabs((prev) =>
+      _dedupeTabs([
+        ...prev,
+        ...alive.filter(
+          (tab) => !prev.some((current) => current.id === tab.id)
+        ),
+      ])
+    );
     setActiveId(alive[alive.length - 1]?.id ?? null);
   }, []);
 
@@ -451,26 +479,56 @@ export function useThreadTabs(): ThreadTabs {
     const rewrite = (p: string): string =>
       p === from ? to : _isUnder(p, from) ? to + p.slice(from.length) : p;
 
-    setTabs((prev) => {
-      if (
-        !prev.some((tab) => tab.type === "thread" && _isUnder(tab.path, from))
-      ) {
-        return prev;
+    const currentTabs = tabsRef.current;
+    const sourceTabs = currentTabs.filter(
+      (tab): tab is ThreadTab =>
+        tab.type === "thread" && _isUnder(tab.path, from)
+    );
+    const destinationTabs = currentTabs.filter(
+      (tab): tab is ThreadTab => tab.type === "thread" && _isUnder(tab.path, to)
+    );
+    const sourceIsOpen = sourceTabs.length > 0;
+
+    if (sourceIsOpen) {
+      for (const tab of destinationTabs) {
+        discardedPaneIds.current.add(tab.paneId);
       }
-      return prev.map((tab) => {
-        if (tab.type !== "thread" || !_isUnder(tab.path, from)) {
-          return tab;
+    }
+
+    setTabs((prev) => {
+      const next = prev.flatMap((tab): AppTab[] => {
+        if (tab.type !== "thread") return [tab];
+        if (_isUnder(tab.path, from)) {
+          const path = rewrite(tab.path);
+          return [{ ...tab, id: _threadTabId(path), path }];
         }
-        const path = rewrite(tab.path);
-        return { ...tab, id: _threadTabId(path), path };
+        if (!_isUnder(tab.path, to)) return [tab];
+        if (sourceIsOpen) return [];
+        return [{ ...tab, refreshNonce: (tab.refreshNonce ?? 0) + 1 }];
       });
+      return _dedupeTabs(next);
     });
     setActiveId((current) => {
-      const activeTab = tabsRef.current.find((tab) => tab.id === current);
-      return activeTab?.type === "thread" && _isUnder(activeTab.path, from)
-        ? _threadTabId(rewrite(activeTab.path))
-        : current;
+      const activeTab = currentTabs.find((tab) => tab.id === current);
+      if (activeTab?.type !== "thread") return current;
+      if (_isUnder(activeTab.path, from)) {
+        return _threadTabId(rewrite(activeTab.path));
+      }
+      if (!_isUnder(activeTab.path, to) || !sourceIsOpen) return current;
+
+      const replacement = sourceTabs.find(
+        (tab) => rewrite(tab.path) === activeTab.path
+      );
+      return replacement
+        ? _threadTabId(rewrite(replacement.path))
+        : _threadTabId(rewrite(sourceTabs[0].path));
     });
+  }, []);
+
+  const consumeDiscardedPane = useCallback((paneId: string) => {
+    if (!discardedPaneIds.current.has(paneId)) return false;
+    discardedPaneIds.current.delete(paneId);
+    return true;
   }, []);
 
   const handleTraceTitleChange = useCallback(
@@ -508,6 +566,7 @@ export function useThreadTabs(): ThreadTabs {
     activateNext,
     activatePrevious,
     refresh,
+    consumeDiscardedPane,
     handleRemove,
     handleMove,
     handleTraceTitleChange,


### PR DESCRIPTION
## Summary

- merge source and destination tabs deterministically after replacing a moved thread
- preserve the moved editor instance while discarding stale pending writes from the overwritten destination editor
- deduplicate previously persisted tab entries and refresh an already-open destination when the source tab is closed

## Root cause

`handleMove` rewrote every open source tab to the destination path without removing an already-open destination tab. Because the React pane key was also derived from the path, the two editor instances could collide and the displaced destination editor could write stale pending content back to the moved file.

## Validation

- `mise run typecheck`
- ESLint on the modified files
- CEF reproduction of the original drag-and-drop overwrite flow
- CEF pending-write race check on the overwritten destination editor
- persisted duplicate-tab recovery check

Fixes #62
