### PR TITLE
fix: support macOS 14 release packages (#53)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,17 @@ jobs:
           codesign --verify --deep --strict "$APP"
           spctl -a -t exec -vv "$APP"
           xcrun stapler validate "$APP"
+          MINOS="$(vtool -show-build "$APP/Contents/MacOS/launcher" \
+            | awk '$1 == "minos" { print $2; exit }')"
+          if [ -z "$MINOS" ] || ! awk -v version="$MINOS" 'BEGIN {
+            split(version, part, ".")
+            supported = part[1] + 0 < 14 || \
+              (part[1] + 0 == 14 && part[2] + 0 == 0 && part[3] + 0 == 0)
+            exit !supported
+          }'; then
+            echo "::error::wrapper requires macOS $MINOS; expected 14.0 or older"
+            exit 1
+          fi
           # The bundle left in build/ is the self-extracting installer wrapper
           # (the real app only exists inside the tar.zst): on first launch it
           # swaps the real app into the same bundle path and relaunches it. This

--- a/apps/desktop/electrobun.config.ts
+++ b/apps/desktop/electrobun.config.ts
@@ -84,10 +84,11 @@ export default {
     },
   },
   scripts: {
-    // Both run right before their respective codesign step. Workaround for
-    // electrobun#485 (x64-only, no-op elsewhere); see the script header.
-    postBuild: "scripts/fix-x64-headerpad.ts",
-    postWrap: "scripts/fix-x64-headerpad.ts",
+    // Both run right before their respective codesign step. They pin the
+    // deployment target to macOS 14 and apply the electrobun#485 x64 headerpad
+    // workaround; see the individual script headers.
+    postBuild: "scripts/prepare-macos-binaries.ts",
+    postWrap: "scripts/prepare-macos-binaries.ts",
   },
   release: {
     // Burned into every shipped bundle — the updater fetches

--- a/apps/desktop/scripts/fix-macos-deployment-target.ts
+++ b/apps/desktop/scripts/fix-macos-deployment-target.ts
@@ -1,0 +1,164 @@
+/**
+ * Electrobun 1.18.1's prebuilt macOS binaries inherit the OS version of the
+ * machine that built them. That makes the arm64 wrapper require macOS 14.8.5
+ * and the x64 wrapper require macOS 15.7.5, even though Electrobun supports
+ * macOS 14+.
+ *
+ * Run immediately before signing and lower LC_BUILD_VERSION /
+ * LC_VERSION_MIN_MACOSX in every thin 64-bit Mach-O in the bundle to 14.0.
+ * The edit is in-place and does not change command sizes or file offsets.
+ * Electrobun signs all affected binaries after this hook runs.
+ */
+
+import {
+  closeSync,
+  lstatSync,
+  openSync,
+  readSync,
+  readdirSync,
+  writeSync,
+} from "node:fs";
+import { join, relative } from "node:path";
+
+const MH_MAGIC_64_LE = 0xfeedfacf;
+const LC_VERSION_MIN_MACOSX = 0x24;
+const LC_BUILD_VERSION = 0x32;
+const MACHO_HEADER_SIZE = 32;
+const TARGET_MACOS_VERSION = 0x000e0000;
+const TARGET_MACOS_VERSION_LABEL = "14.0";
+
+function _findBundle(): string {
+  const wrapperPath = process.env.ELECTROBUN_WRAPPER_BUNDLE_PATH;
+  if (wrapperPath) return wrapperPath;
+
+  const buildDir = process.env.ELECTROBUN_BUILD_DIR;
+  if (!buildDir) {
+    throw new Error("no ELECTROBUN_BUILD_DIR in env");
+  }
+  const app = readdirSync(buildDir).find((name) => name.endsWith(".app"));
+  if (!app) {
+    throw new Error(`no .app bundle in ${buildDir}`);
+  }
+  return join(buildDir, app);
+}
+
+function _walkFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) {
+      files.push(..._walkFiles(path));
+    } else if (stat.isFile()) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function _fixFile(filePath: string): "fixed" | "ok" | "skipped" {
+  const fd = openSync(filePath, "r+");
+  try {
+    const header = Buffer.alloc(MACHO_HEADER_SIZE);
+    if (readSync(fd, header, 0, header.length, 0) !== header.length) {
+      return "skipped";
+    }
+    if (header.readUInt32LE(0) !== MH_MAGIC_64_LE) return "skipped";
+
+    const ncmds = header.readUInt32LE(16);
+    const sizeofcmds = header.readUInt32LE(20);
+    if (ncmds === 0 || sizeofcmds < 8 || sizeofcmds > 1024 * 1024) {
+      throw new Error("invalid Mach-O load-command table");
+    }
+
+    const commands = Buffer.alloc(sizeofcmds);
+    if (
+      readSync(fd, commands, 0, commands.length, MACHO_HEADER_SIZE) !==
+      commands.length
+    ) {
+      throw new Error("truncated Mach-O load-command table");
+    }
+
+    let offset = 0;
+    let fixed = false;
+    for (let i = 0; i < ncmds; i++) {
+      if (offset + 8 > commands.length) {
+        throw new Error("invalid Mach-O load command offset");
+      }
+      const cmd = commands.readUInt32LE(offset);
+      const cmdsize = commands.readUInt32LE(offset + 4);
+      if (cmdsize < 8 || offset + cmdsize > commands.length) {
+        throw new Error("invalid Mach-O load command size");
+      }
+
+      const versionOffset =
+        cmd === LC_BUILD_VERSION
+          ? offset + 12
+          : cmd === LC_VERSION_MIN_MACOSX
+            ? offset + 8
+            : undefined;
+      if (versionOffset !== undefined) {
+        const currentVersion = commands.readUInt32LE(versionOffset);
+        if (currentVersion > TARGET_MACOS_VERSION) {
+          const target = Buffer.alloc(4);
+          target.writeUInt32LE(TARGET_MACOS_VERSION);
+          writeSync(
+            fd,
+            target,
+            0,
+            target.length,
+            MACHO_HEADER_SIZE + versionOffset
+          );
+          fixed = true;
+        }
+      }
+      offset += cmdsize;
+    }
+    return fixed ? "fixed" : "ok";
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function _adhocSign(filePath: string): void {
+  const result = Bun.spawnSync(
+    ["codesign", "--force", "--sign", "-", filePath],
+    {
+      stderr: "inherit",
+      stdout: "inherit",
+    }
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`failed to ad-hoc sign ${filePath}`);
+  }
+}
+
+if (process.env.ELECTROBUN_OS === "macos") {
+  try {
+    const bundle = _findBundle();
+    let fixed = 0;
+    for (const filePath of _walkFiles(bundle)) {
+      const result = _fixFile(filePath);
+      if (result !== "fixed") continue;
+      // arm64 Mach-O signatures are mandatory even without Gatekeeper. A local
+      // `mise run pack` skips Electrobun's signing pass, so replace the invalid
+      // signature created by the in-place edit. Canary/stable release builds
+      // are signed normally by Electrobun immediately after this hook.
+      if (process.env.LLM_SPACE_SKIP_SIGNING) _adhocSign(filePath);
+      fixed++;
+      console.info(
+        `fix-macos-deployment-target: ${relative(bundle, filePath)} -> ${TARGET_MACOS_VERSION_LABEL}`
+      );
+    }
+    console.info(
+      `fix-macos-deployment-target: patched ${fixed} Mach-O file(s)`
+    );
+  } catch (error) {
+    console.error(
+      "fix-macos-deployment-target:",
+      error instanceof Error ? error.message : error
+    );
+    process.exit(1);
+  }
+}

--- a/apps/desktop/scripts/prepare-macos-binaries.ts
+++ b/apps/desktop/scripts/prepare-macos-binaries.ts
@@ -1,0 +1,19 @@
+import { join } from "node:path";
+
+const SCRIPTS = [
+  "fix-x64-headerpad.ts",
+  "fix-macos-deployment-target.ts",
+] as const;
+
+for (const script of SCRIPTS) {
+  const result = Bun.spawnSync(
+    [process.execPath, join(import.meta.dir, script)],
+    {
+      cwd: process.cwd(),
+      env: process.env,
+      stderr: "inherit",
+      stdout: "inherit",
+    }
+  );
+  if (result.exitCode !== 0) process.exit(result.exitCode);
+}


### PR DESCRIPTION
Closes #53

## Summary

- lower Electrobun macOS bundle Mach-O deployment targets to macOS 14.0 before signing
- keep the existing x64 headerpad workaround in the same packaging hook order
- add a release smoke assertion so signed wrappers cannot require a newer macOS version again

## Root cause

Electrobun 1.18.1's prebuilt macOS binaries inherit the OS version from the machine that built them. The published v4.0.1 artifacts therefore contained wrappers requiring macOS 14.8.5 on arm64 and macOS 15.7.5 on x64, which macOS 14.8 rejects before the app can launch.

## Verification

- `mise run lint`
- `mise run typecheck`
- workflow YAML parse check
- `LLM_SPACE_UPDATE_BASE_URL=http://127.0.0.1:9 mise run pack` on macOS 14.8
- verified the built wrapper reports `minos 14.0`
- verified `codesign --verify --deep --strict` on the built wrapper
- launched the local package on macOS 14.8 and confirmed self-extraction plus the relaunched app process
