### PR TITLE
[react-doctor] Fix no-ref-current-in-render in commands/index (handlers ref)

### DIFF
--- a/apps/desktop/src/commands/index.tsx
+++ b/apps/desktop/src/commands/index.tsx
@@ -109,7 +109,12 @@ export function useCommands(): CommandContextValue {
 export function useRegisterCommands(handlers: CommandHandlers, enabled = true) {
   const { registerCommandHandlers } = useCommands();
   const latest = useRef(handlers);
-  latest.current = handlers;
+  // Keep the latest handlers in a ref without mutating during render. The ref is
+  // read only post-commit (the registration effect below and the trampoline
+  // closures it installs), so syncing after every commit is behavior-preserving.
+  useEffect(() => {
+    latest.current = handlers;
+  });
 
   useEffect(() => {
     if (!enabled) return;


### PR DESCRIPTION
## Issue
react-doctor (0.7.8) error-tier diagnostic `no-ref-current-in-render` at `apps/desktop/src/commands/index.tsx:112`:

> This ref is mutated during render. React can replay or discard render.

`useRegisterCommands` did `latest.current = handlers` in the render body.

## Fix
Move the sync into a passive `useEffect` (no dep array → runs after every commit). The `latest` ref is read **only post-commit**:
- the registration `useEffect` reads `latest.current` to build trampoline keys (on mount / `enabled` toggle), and
- the trampoline closures read it when a command is dispatched (an event/post-commit path).

So deferring the write to a post-commit effect is behavior-preserving. The sync effect is declared before the registration effect, so on an `enabled` re-registration it updates the ref first; on first mount `useRef(handlers)` already seeds the correct value. Same latest-value-ref pattern as PR #37 / #44 / #50 / #60.

## Verification
- Frozen worktree (`bun install --frozen-lockfile`, off `origin/main` `beb1c69`): `apps/desktop` `tsc --noEmit` **clean (exit 0)**.
- Re-scan: `no-ref-current-in-render` **8 → 6** raw, error tier **12 → 10**, total **650 → 648**, site resolved, **zero new diagnostics**. Score held **58 / Critical**.
- Owner-checkout cross-check: applied read-only, `apps/desktop` tsc **delta = 0** (only the pre-existing unrelated `message-list-view.tsx:214` Radix `CSSProperties` skew), then reverted — tree clean.

1 file changed, 6 insertions(+), 1 deletion(-).