### PR TITLE
[react-doctor] Fix no-ref-current-in-render in thread-tab-pane (pathRef)

### DIFF
--- a/apps/desktop/src/components/thread-tabs/thread-tab-pane.tsx
+++ b/apps/desktop/src/components/thread-tabs/thread-tab-pane.tsx
@@ -78,7 +78,12 @@ export function ThreadTabPane({
   const writeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pending = useRef<Thread | null>(null);
   const pathRef = useRef(path);
-  pathRef.current = path;
+  // Keep the latest path in a ref for post-commit reads (debounced write flush,
+  // refresh refetch, rename) without mutating during render. Declared before the
+  // effects below so they observe the fresh path.
+  useEffect(() => {
+    pathRef.current = path;
+  });
 
   const flushPending = useCallback(async () => {
     if (writeTimer.current) {


### PR DESCRIPTION
### Issue
`no-ref-current-in-render` (error) — `apps/desktop/src/components/thread-tabs/thread-tab-pane.tsx:81` mutated `pathRef.current = path` directly in the render body. React can replay or discard render work, so mutating a ref during render is unsafe.

### Fix
`pathRef` is a latest-value ref: it is read **only post-commit** — in `flushPending` (debounced write timer, unmount cleanup, rename), the refresh effect's refetch `queryKey`, and the `handleRenameTitle` event handler. None read it during render. So the sync moves into a passive `useEffect` (no dep array → after every commit), seeded by `useRef(path)` on first mount and declared before the effects that read it. No behavior change.

Same latest-value-ref pattern as PR #37/#44/#50/#60/#82. One file, +6/-1.

### Verification (react-doctor 0.7.8, off `origin/main`)
- Frozen worktree `apps/desktop` `tsc --noEmit`: clean, exit 0 (2 runs).
- Re-scan: `no-ref-current-in-render` 6→4 raw, error tier 10→8, total 608→606, site resolved, **score 57 → 58**. Zero rule+file+severity increases (no regression).
- Owner-checkout cross-check: minimal diff applied read-only, `tsc` delta = 0 (baseline unchanged), reverted, tree clean.
