### PR TITLE
fix(models): restore Codex CLI authentication

### DIFF
--- a/apps/desktop/src/bun/models/providers/builtin-providers.ts
+++ b/apps/desktop/src/bun/models/providers/builtin-providers.ts
@@ -13,7 +13,6 @@ import { moonshotaiProvider } from "@earendil-works/pi-ai/providers/moonshotai";
 import { moonshotaiCnProvider } from "@earendil-works/pi-ai/providers/moonshotai-cn";
 import { nvidiaProvider } from "@earendil-works/pi-ai/providers/nvidia";
 import { openaiProvider } from "@earendil-works/pi-ai/providers/openai";
-import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
 import { openrouterProvider } from "@earendil-works/pi-ai/providers/openrouter";
 import { vercelAIGatewayProvider } from "@earendil-works/pi-ai/providers/vercel-ai-gateway";
 import { xaiProvider } from "@earendil-works/pi-ai/providers/xai";
@@ -24,6 +23,7 @@ import { zaiCodingCnProvider } from "@earendil-works/pi-ai/providers/zai-coding-
 import { arkProvider } from "./ark";
 import { arkAgentPlanProvider } from "./ark-agent-plan";
 import { arkCodingPlanProvider } from "./ark-coding-plan";
+import { openaiCodexProvider } from "./openai-codex";
 
 /** Static, non-`Provider` metadata for a builtin provider. */
 export interface BuiltinProviderMeta {

--- a/apps/desktop/src/bun/models/providers/openai-codex.test.ts
+++ b/apps/desktop/src/bun/models/providers/openai-codex.test.ts
@@ -1,0 +1,22 @@
+import { createModels } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "bun:test";
+
+import { openaiCodexProvider } from "./openai-codex";
+
+describe("openaiCodexProvider", () => {
+  test("resolves the Codex CLI access token passed as an API-key override", async () => {
+    const provider = openaiCodexProvider();
+    const model = provider.getModels()[0];
+    const models = createModels();
+    models.setProvider(provider);
+
+    expect(provider.auth.oauth).toBeDefined();
+    expect(await models.getAuth(model)).toBeUndefined();
+
+    const auth = await models.getAuth(model, {
+      apiKey: "codex-cli-access-token",
+    });
+
+    expect(auth?.auth.apiKey).toBe("codex-cli-access-token");
+  });
+});

--- a/apps/desktop/src/bun/models/providers/openai-codex.ts
+++ b/apps/desktop/src/bun/models/providers/openai-codex.ts
@@ -1,0 +1,21 @@
+import { envApiKeyAuth } from "@earendil-works/pi-ai";
+import { openaiCodexProvider as _openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
+
+/**
+ * Keep the upstream Codex OAuth provider, while accepting the access token
+ * that ModelManager reads from the Codex CLI's auth.json as a per-run API-key
+ * override. pi-ai 0.80.10 rejects explicit API-key overrides for OAuth-only
+ * providers, so without this compatibility auth method the token is ignored.
+ */
+export function openaiCodexProvider(): ReturnType<
+  typeof _openaiCodexProvider
+> {
+  const provider = _openaiCodexProvider();
+  return {
+    ...provider,
+    auth: {
+      ...provider.auth,
+      apiKey: envApiKeyAuth("OpenAI Codex access token", []),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- preserve the upstream OpenAI Codex OAuth provider behavior
- accept the Codex CLI access token supplied by `ModelManager` as an explicit per-run credential
- add regression coverage for OAuth and explicit token authentication

## Background

`@earendil-works/pi-ai` 0.80.10 rejects explicit API-key overrides for OAuth-only providers. LLM Space reads the access token from the Codex CLI `auth.json` and passes it explicitly, so the upstream `openai-codex` provider ignored that token and failed with `Provider is not configured: openai-codex`.

## Validation

- `mise run test`
- `mise run lint`
- `mise run typecheck`
- verified a real OpenAI Codex response in the CEF desktop app