### PR TITLE
feat(web): embedded mode for shared thread viewer

### DIFF
--- a/apps/web/src/thread-viewer.tsx
+++ b/apps/web/src/thread-viewer.tsx
@@ -8,11 +8,11 @@ import { readLatestThread } from "@llm-space/core/storage";
 import { ThreadPlayground } from "@llm-space/ui/components/thread-playground";
 import { Tooltip } from "@llm-space/ui/components/tooltip";
 import { Button } from "@llm-space/ui/ui/button";
+import { Skeleton } from "@llm-space/ui/ui/skeleton";
 import {
   ExpandIcon,
   ExternalLinkIcon,
   FileJsonIcon,
-  Loader2Icon,
   ShrinkIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -25,6 +25,21 @@ import { NotFound } from "@/not-found";
 /** `llm-space://shared/{connectorId}/threads/{threadId}` — desktop deep link. */
 function deepLink(connectorId: string, threadId: string): string {
   return `llm-space://shared/${connectorId}/threads/${threadId}`;
+}
+
+/** At or below this width, the viewer opens in embedded (chrome-free) mode. */
+const EMBEDDED_MAX_WIDTH_PX = 850;
+
+/**
+ * Whether the URL opts into compact/embedded rendering via an `embedded` query
+ * param in the hash (e.g. `#/shared/gist/threads/x?embedded`). Read straight off
+ * `window.location.hash` so it's independent of how the router splits the hash.
+ */
+function _isEmbedded(): boolean {
+  const hash = window.location.hash;
+  const queryIndex = hash.indexOf("?");
+  if (queryIndex < 0) return false;
+  return new URLSearchParams(hash.slice(queryIndex + 1)).has("embedded");
 }
 
 function formatDate(iso: string): string {
@@ -82,6 +97,14 @@ export function ThreadViewer({
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const [fullscreen, setFullscreen] = useState(false);
   const navigate = useNavigate();
+  // Decide embedded/compact rendering once, at open — kept in state so later
+  // resizes don't reflow (and don't flash thumbnails in) after the thread loads.
+  // Embedded (strips the site chrome + collapses images) when the URL opts in
+  // (`?embedded`) or the viewport is narrow.
+  const [embedded] = useState(
+    () => _isEmbedded() || window.innerWidth <= EMBEDDED_MAX_WIDTH_PX
+  );
+  const compactImages = embedded;
 
   // Try to hand off to the installed desktop app; if it doesn't take over
   // within the timeout, fall back to the homepage (where the download lives).
@@ -109,6 +132,17 @@ export function ThreadViewer({
     };
   }, [connector, threadId]);
 
+  // Reflect the thread title in the tab/window title while it's open.
+  useEffect(() => {
+    if (state.status !== "ready") return;
+    const title = state.shared.meta.title ?? "Untitled thread";
+    const previous = document.title;
+    document.title = `${title} - LLM Space`;
+    return () => {
+      document.title = previous;
+    };
+  }, [state]);
+
   // Let Escape leave full screen.
   useEffect(() => {
     if (!fullscreen) return;
@@ -120,12 +154,7 @@ export function ThreadViewer({
   }, [fullscreen]);
 
   if (state.status === "loading") {
-    return (
-      <div className="dark flex h-dvh items-center justify-center gap-2 bg-[#08080a] text-sm text-neutral-400">
-        <Loader2Icon className="size-4 animate-spin" />
-        Loading shared thread…
-      </div>
-    );
+    return <ThreadViewerSkeleton embedded={embedded} />;
   }
   if (state.status === "error") {
     return <NotFound message={state.message} />;
@@ -134,43 +163,55 @@ export function ThreadViewer({
   const { thread, meta } = state.shared;
   const headerActions = (
     <div className="flex items-center gap-2">
-      {fullscreen ? (
+      {/* Embedded has no meta block, so keep the "Open" affordance in-header. */}
+      {fullscreen || embedded ? (
         <Button size="sm" onClick={openApp}>
           Open in LLM Space
           <ExternalLinkIcon className="size-3.5" />
         </Button>
       ) : null}
-      <Tooltip content={fullscreen ? "Exit full screen" : "Full screen"}>
-        <Button
-          variant="ghost"
-          size="icon-lg"
-          aria-label={fullscreen ? "Exit full screen" : "Enter full screen"}
-          aria-pressed={fullscreen}
-          onClick={() => setFullscreen((value) => !value)}
-        >
-          {fullscreen ? (
-            <ShrinkIcon className="size-4" />
-          ) : (
-            <ExpandIcon className="size-4" />
-          )}
-        </Button>
-      </Tooltip>
+      {/* Full-screen toggle is redundant when already embedded/full-bleed. */}
+      {embedded ? null : (
+        <Tooltip content={fullscreen ? "Exit full screen" : "Full screen"}>
+          <Button
+            variant="ghost"
+            size="icon-lg"
+            aria-label={fullscreen ? "Exit full screen" : "Enter full screen"}
+            aria-pressed={fullscreen}
+            onClick={() => setFullscreen((value) => !value)}
+          >
+            {fullscreen ? (
+              <ShrinkIcon className="size-4" />
+            ) : (
+              <ExpandIcon className="size-4" />
+            )}
+          </Button>
+        </Tooltip>
+      )}
     </div>
   );
   const playground = (
     <ThreadPlayground
       className={
-        fullscreen
+        fullscreen || embedded
           ? "size-full overflow-hidden"
           : "size-full overflow-hidden rounded-xl border shadow-lg"
       }
       path={`shared/${connector.connectorId}/threads/${threadId}`}
       title={meta.title}
       readonly
+      compactImages={compactImages}
       initialValue={thread}
       headerActions={headerActions}
     />
   );
+  // Embedded: strip the site chrome (header + meta block) and let the playground
+  // fill the frame, for use inside an iframe.
+  if (embedded) {
+    return (
+      <div className="dark h-dvh bg-[#08080a] text-[#ededf0]">{playground}</div>
+    );
+  }
   return (
     <div className="dark flex h-dvh flex-col bg-[#08080a] text-[#ededf0]">
       <SiteHeader />
@@ -184,6 +225,47 @@ export function ThreadViewer({
           >
             {playground}
           </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+/**
+ * Loading placeholder that mirrors the ready layout — same header, meta block,
+ * and playground shell — so the page doesn't shift once the thread arrives. In
+ * embedded mode it drops the chrome to match the embedded ready view.
+ */
+function ThreadViewerSkeleton({ embedded = false }: { embedded?: boolean }) {
+  if (embedded) {
+    return (
+      <div className="dark h-dvh bg-[#08080a] text-[#ededf0]">
+        <Skeleton className="size-full rounded-none" />
+      </div>
+    );
+  }
+  return (
+    <div className="dark flex h-dvh flex-col bg-[#08080a] text-[#ededf0]">
+      <SiteHeader />
+      <main className="mx-auto flex w-full max-w-[1400px] flex-1 flex-col px-6 min-h-0 sm:px-10">
+        <section className="flex shrink-0 flex-col gap-6 py-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="h-8 w-72 max-w-full" />
+            <Skeleton className="h-4 w-96 max-w-full" />
+            <Skeleton className="h-3 w-40" />
+          </div>
+          <div className="flex flex-col items-start gap-4 sm:items-end">
+            <Skeleton className="h-3 w-32" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="size-8 rounded-full" />
+              <Skeleton className="h-4 w-28" />
+            </div>
+            <Skeleton className="h-10 w-40 rounded-md" />
+          </div>
+        </section>
+        <div className="min-h-0 flex-1 pb-6">
+          <Skeleton className="h-full w-full rounded-xl" />
         </div>
       </main>
     </div>

--- a/packages/ui/src/components/thread-playground/message/image-content-view.tsx
+++ b/packages/ui/src/components/thread-playground/message/image-content-view.tsx
@@ -1,5 +1,5 @@
 import type { ImageDataContent } from "@llm-space/core";
-import { XIcon } from "lucide-react";
+import { ImageIcon, XIcon } from "lucide-react";
 import React, { useCallback, useState } from "react";
 
 import { Tooltip } from "@llm-space/ui/components/tooltip";
@@ -9,6 +9,8 @@ import { Dialog, DialogContent, DialogTitle } from "@llm-space/ui/ui/dialog";
 
 import { useThreadStoreActions } from "../stores";
 
+import { useImageDisplay } from "./image-display-context";
+
 const FRAME_SIZE_PX = 192; // size-48
 
 function _ImageContentView({
@@ -16,11 +18,16 @@ function _ImageContentView({
   readonly,
   onRemove,
   className,
+  compact,
+  imageNumber,
 }: {
   image: ImageDataContent;
   readonly?: boolean;
   onRemove?: () => void;
   className?: string;
+  /** Render as a `[Image #N]` placeholder that opens the preview on click. */
+  compact?: boolean;
+  imageNumber?: number;
 }) {
   const [fit, setFit] = useState<"contain" | "cover">("contain");
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -53,46 +60,60 @@ function _ImageContentView({
 
   return (
     <>
-      <div
-        className={cn(
-          "group/image relative flex size-48 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border shadow",
-          className
-        )}
-        onClick={handleOpenPreview}
-        role="button"
-        tabIndex={0}
-        aria-label="Open image preview"
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            handleOpenPreview();
-          }
-        }}
-      >
-        <img
-          src={imageSrc}
-          alt=""
-          onLoad={handleLoad}
+      {compact ? (
+        <button
+          type="button"
+          onClick={handleOpenPreview}
           className={cn(
-            fit === "cover"
-              ? "size-full object-cover"
-              : "max-h-full max-w-full object-contain"
+            "text-muted-foreground hover:text-foreground bg-muted/40 hover:bg-muted inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-xs transition-colors",
+            className
           )}
-        />
-        {!readonly && onRemove && (
-          <Tooltip content="Remove image">
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="bg-background/80 absolute top-1 right-1 rounded-full border opacity-0 transition-opacity group-hover/image:opacity-100"
-              aria-label="Remove image"
-              onClick={handleRemove}
-            >
-              <XIcon className="size-4" />
-            </Button>
-          </Tooltip>
-        )}
-      </div>
+          aria-label="Open image preview"
+        >
+          <ImageIcon className="size-3.5" />[Image #{imageNumber}]
+        </button>
+      ) : (
+        <div
+          className={cn(
+            "group/image relative flex size-48 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border shadow",
+            className
+          )}
+          onClick={handleOpenPreview}
+          role="button"
+          tabIndex={0}
+          aria-label="Open image preview"
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              handleOpenPreview();
+            }
+          }}
+        >
+          <img
+            src={imageSrc}
+            alt=""
+            onLoad={handleLoad}
+            className={cn(
+              fit === "cover"
+                ? "size-full object-cover"
+                : "max-h-full max-w-full object-contain"
+            )}
+          />
+          {!readonly && onRemove && (
+            <Tooltip content="Remove image">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="bg-background/80 absolute top-1 right-1 rounded-full border opacity-0 transition-opacity group-hover/image:opacity-100"
+                aria-label="Remove image"
+                onClick={handleRemove}
+              >
+                <XIcon className="size-4" />
+              </Button>
+            </Tooltip>
+          )}
+        </div>
+      )}
 
       <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
         <DialogContent
@@ -127,18 +148,27 @@ function _ImageContentList({
   className?: string;
 }) {
   const { removeMessageImageContent } = useThreadStoreActions();
+  const { compact, numberOf } = useImageDisplay();
 
   if (images.length === 0) {
     return null;
   }
 
   return (
-    <div className={cn("flex w-full flex-wrap gap-3 px-3 pt-2", className)}>
+    <div
+      className={cn(
+        "flex w-full flex-wrap px-3 pt-2",
+        compact ? "gap-1.5" : "gap-3",
+        className
+      )}
+    >
       {images.map(({ content, contentIndex }) => (
         <ImageContentView
           key={`${content.mimeType}-${contentIndex}`}
           image={content}
           readonly={readonly}
+          compact={compact}
+          imageNumber={numberOf(messageId, contentIndex)}
           onRemove={() => {
             removeMessageImageContent(messageId, contentIndex);
           }}

--- a/packages/ui/src/components/thread-playground/message/image-display-context.tsx
+++ b/packages/ui/src/components/thread-playground/message/image-display-context.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from "react";
+
+export interface ImageDisplayContextValue {
+  /**
+   * Render image attachments as compact `[Image #N]` placeholders (that still
+   * open the preview on click) instead of inline thumbnails. Used by the shared
+   * viewer when embedded or on narrow viewports.
+   */
+  compact: boolean;
+  /** 1-based number of the image at (messageId, contentIndex), for its label. */
+  numberOf: (messageId: string, contentIndex: number) => number;
+}
+
+const ImageDisplayContext = createContext<ImageDisplayContextValue | null>(null);
+
+export const ImageDisplayProvider = ImageDisplayContext.Provider;
+
+/** Image display options; defaults to full (non-compact) rendering. */
+export function useImageDisplay(): ImageDisplayContextValue {
+  return (
+    useContext(ImageDisplayContext) ?? { compact: false, numberOf: () => 0 }
+  );
+}

--- a/packages/ui/src/components/thread-playground/message/message-list-view.tsx
+++ b/packages/ui/src/components/thread-playground/message/message-list-view.tsx
@@ -15,6 +15,10 @@ import { ScrollArea } from "@llm-space/ui/ui/scroll-area";
 
 import { useThreadStore, useThreadStoreActions } from "../stores";
 
+import {
+  ImageDisplayProvider,
+  type ImageDisplayContextValue,
+} from "./image-display-context";
 import { MessageListItem } from "./message-list-item";
 
 export function MessageListView({
@@ -22,11 +26,14 @@ export function MessageListView({
   context: contextFromProps,
   messages: messagesFromProps,
   readonly: readonlyFromProps = false,
+  compactImages = false,
 }: {
   className?: string;
   context?: ThreadContext;
   messages?: Message[];
   readonly?: boolean;
+  /** Render image attachments as `[Image #N]` placeholders. */
+  compactImages?: boolean;
 }) {
   const isSnapshotView = messagesFromProps !== undefined;
   const status = useThreadStore((s) => s.status);
@@ -35,10 +42,33 @@ export function MessageListView({
   const storeMessages = useThreadStore((s) => s.thread.context?.messages);
   const { appendMessage, moveMessage } = useThreadStoreActions();
   const [dragging, setDragging] = useState(false);
-  const messages = messagesFromProps ?? storeMessages ?? [];
+  const messages = useMemo(
+    () => messagesFromProps ?? storeMessages ?? [],
+    [messagesFromProps, storeMessages]
+  );
   const readonly = useMemo(() => {
     return readonlyFromProps || dragging || isSnapshotView;
   }, [dragging, isSnapshotView, readonlyFromProps]);
+
+  // Number every image attachment sequentially across the thread so the compact
+  // placeholder can label it `[Image #N]`.
+  const imageDisplay = useMemo<ImageDisplayContextValue>(() => {
+    const numbers = new Map<string, number>();
+    let count = 0;
+    for (const message of messages) {
+      message.content.forEach((content, contentIndex) => {
+        if (content.type === "image_data") {
+          count += 1;
+          numbers.set(`${message.id}:${contentIndex}`, count);
+        }
+      });
+    }
+    return {
+      compact: compactImages,
+      numberOf: (messageId, contentIndex) =>
+        numbers.get(`${messageId}:${contentIndex}`) ?? 0,
+    };
+  }, [messages, compactImages]);
 
   const handleDragStart = useCallback(() => {
     setDragging(true);
@@ -73,6 +103,7 @@ export function MessageListView({
 
   return (
     <ScrollArea type="auto" className={cn("size-full", className)}>
+      <ImageDisplayProvider value={imageDisplay}>
       <div ref={contentRef} className="flex flex-col p-3 pt-0.5">
         {isSnapshotView ? (
           <StaticMessageList
@@ -118,6 +149,7 @@ export function MessageListView({
           Add message
         </Button>
       </div>
+      </ImageDisplayProvider>
     </ScrollArea>
   );
 }

--- a/packages/ui/src/components/thread-playground/thread-playground.tsx
+++ b/packages/ui/src/components/thread-playground/thread-playground.tsx
@@ -81,6 +81,12 @@ export interface ThreadPlaygroundProps {
   initialValue: Thread;
   readonly?: boolean;
   /**
+   * Render image attachments as compact `[Image #N]` placeholders instead of
+   * inline thumbnails. Decided once by the caller (e.g. embedded viewer or a
+   * narrow viewport); not reactive to later resizes.
+   */
+  compactImages?: boolean;
+  /**
    * Whether this playground belongs to the active tab. Only the active one
    * registers the `runThread` command handler (the command registry keeps a
    * single handler per type), so a global run always targets the active tab.
@@ -178,6 +184,7 @@ function ThreadPlaygroundContent({
   validateTitle,
   readonly: readonlyFromProps = false,
   active = false,
+  compactImages = false,
 }: Omit<
   ThreadPlaygroundProps,
   "initialValue" | "onChange" | "onStreamingStart" | "onStreamingEnd"
@@ -462,7 +469,10 @@ function ThreadPlaygroundContent({
             </ResizablePanel>
             <ResizableHandle className="opacity-50 hover:opacity-100" />
             <ResizablePanel minSize="300px">
-              <MessageListView readonly={readonly} />
+              <MessageListView
+                readonly={readonly}
+                compactImages={compactImages}
+              />
             </ResizablePanel>
           </ResizablePanelGroup>
         </ResizablePanel>


### PR DESCRIPTION
## Summary
- Opens the shared-thread viewer in a chrome-free **embedded** mode when the URL opts in (`#/shared/.../threads/...?embedded`) or the viewport is **≤ 850px** — decided once at open, so there's no reflow/flash after the thread loads.
- Embedded mode drops the `SiteHeader` + meta block, lets the playground fill the frame, moves "Open in LLM Space" into the playground header, and hides the redundant full-screen toggle. The loading skeleton matches the embedded layout.
- Image attachments render as clickable `[Image #N]` placeholders (numbered sequentially across the thread, still open the preview on click) instead of inline thumbnails.
- Sets `document.title` to `"{title} - LLM Space"` while a thread is open.

## Implementation
- New `compactImages` prop on `ThreadPlayground` → `MessageListView`, which numbers the images and provides a small `ImageDisplayContext` consumed by `ImageContentView`. Defaults off everywhere else, so the desktop app is unaffected.

## Test plan
- `tsc` (web, ui, desktop) + `eslint` clean; `build:web` succeeds.
- Manual: hard-reload `#/shared/gist/threads/mock?embedded` (or a ≤850px window) → no site chrome, playground full-bleed, image shown as `[Image #1]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)