### PR TITLE
[react-doctor] Fix no-ref-current-in-render in use-thread-tabs (tabsRef)

### DIFF
--- a/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
+++ b/apps/desktop/src/components/thread-tabs/use-thread-tabs.ts
@@ -278,7 +278,13 @@ export function useThreadTabs(): ThreadTabs {
   );
 
   const tabsRef = useRef(tabs);
-  tabsRef.current = tabs;
+  // Keep tabsRef pointing at the latest committed tabs. Syncing in a passive
+  // effect instead of the render body avoids leaking work from renders React
+  // discards or replays; every read of tabsRef happens post-commit (effects and
+  // event handlers), so the seeded ref stays consistent.
+  useEffect(() => {
+    tabsRef.current = tabs;
+  });
   const closedStack = useRef<PersistedTab[][]>([]);
   const discardedPaneIds = useRef(new Set<string>());
   const pushClosed = useCallback((closed: AppTab[]) => {


### PR DESCRIPTION
## Issue
`react-doctor` **no-ref-current-in-render** (error): `apps/desktop/src/components/thread-tabs/use-thread-tabs.ts` mutated `tabsRef.current = tabs` in the render body. React can replay or discard render work, so a render-body ref write can leak from renders that never commit.

## Fix
`tabsRef` is a latest-value ref read **only post-commit** — every read (`open`/`openTrace`/`activateSibling`/`closeAll`/`handleMove` callbacks and the mount restoration effect) happens after commit, and the ref is already seeded via `useRef(tabs)`. Moved the sync into a passive `useEffect` (no dep array → after every commit). Behavior-preserving; same latest-value-ref pattern as #37/#44/#50/#60/#82/#84. 1 file, +7/-1.

## Verification (react-doctor 0.8.1, base origin/main 1838886)
- Frozen worktree `apps/desktop` `tsc --noEmit` **clean (exit 0)**.
- Re-scan: `no-ref-current-in-render` **8→6** raw, error tier **8→6**, total **607→605**, site resolved, **score 58→59**. Zero rule+file+severity increases (impure-updater sites only line-shifted by the insertion).
- Owner-checkout cross-check via minimal diff: `tsc` **delta = 0** (owner-clean baseline = 1 pre-existing Radix `CSSProperties` skew, unchanged), reverted, tree clean.