### PR TITLE
feat: rename input commits on blur to match editor UX conventions

### DIFF
--- a/apps/desktop/src/components/file-system-tree-view/file-system-tree-view.tsx
+++ b/apps/desktop/src/components/file-system-tree-view/file-system-tree-view.tsx
@@ -553,7 +553,7 @@ function _FileSystemTreeView({
 // mode-derived className) are stable across tab changes.
 export const FileSystemTreeView = memo(_FileSystemTreeView);
 
-/** In-place rename input: Enter confirms, Esc / blur cancels. */
+/** In-place rename input: Enter / blur confirms, Esc cancels. */
 function RenameInput({
   initial,
   onConfirm,
@@ -580,7 +580,13 @@ function RenameInput({
         onClick={(e) => e.stopPropagation()}
         onPointerDown={(e) => e.stopPropagation()}
         onFocus={(e) => e.currentTarget.select()}
-        onBlur={onCancel}
+        onBlur={() => {
+          if (validation.valid) {
+            onConfirm(validation.value);
+          } else {
+            onCancel();
+          }
+        }}
         onKeyDown={(e) => {
           // Stop the accordion trigger (this input lives inside its button) from
           // reacting to keys like Space/Enter that would toggle the node.


### PR DESCRIPTION
## Summary

Changed the in-place rename input behavior in the file tree: clicking away (blur) now commits the rename instead of canceling it.

## Before

`onBlur` always canceled the rename, reverting to the original name.

## After

`onBlur` behaves like pressing Enter:
- If the name passes validation → the rename is confirmed
- If the name is invalid (empty, reserved characters, etc.) → the rename is cancelled

This matches how most editors and file managers handle in-place rename.

## Files Changed

- `apps/desktop/src/components/file-system-tree-view/file-system-tree-view.tsx` — changed `RenameInput` blur handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)