### PR TITLE
fix: 修复远程服务器删除交互

### DIFF
--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -771,8 +771,6 @@ function PageWorkspace({
             discardRuntimeWorkspace(runtimeId);
             if (workspaceRuntimeIdRef.current === runtimeId) {
               transitionWorkspaceRuntime("local");
-            } else if (runtimeId.startsWith("remote:")) {
-              setSettingsOpen(false);
             }
           }}
         />

--- a/apps/desktop/src/bun/remote/remote-server-manager.test.ts
+++ b/apps/desktop/src/bun/remote/remote-server-manager.test.ts
@@ -462,6 +462,121 @@ describe("RemoteServerManager", () => {
     expect(statuses.at(-1)).toBe("disconnected");
   });
 
+  test("does not allow removing a connected server", async () => {
+    const stopped: string[] = [];
+    const manager = _manager((config) =>
+      Promise.resolve({
+        client: _remoteRuntime(config.id),
+        stop: () => {
+          stopped.push(config.id);
+          return Promise.resolve();
+        },
+      })
+    );
+
+    const [server] = manager.addServer({ name: "host", host: "host" });
+    await manager.connectServer(server.id);
+
+    try {
+      await manager.removeServer(server.id);
+      throw new Error("remove should fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Disconnect remote server before remove: " + server.id
+      );
+    }
+
+    const [view] = manager.listServers();
+    expect(stopped).toEqual([]);
+    expect(view?.id).toBe(server.id);
+    expect(view?.status).toBe("connected");
+    expect(view?.defaultRuntime).toBe(true);
+  });
+
+  test("removes a disconnected server without stopping a runtime", async () => {
+    const stopped: string[] = [];
+    const manager = _manager((config) =>
+      Promise.resolve({
+        client: _remoteRuntime(config.id),
+        stop: () => {
+          stopped.push(config.id);
+          return Promise.resolve();
+        },
+      })
+    );
+
+    const [server] = manager.addServer({ name: "host", host: "host" });
+    const next = await manager.removeServer(server.id);
+
+    expect(next).toEqual([]);
+    expect(manager.listServers()).toEqual([]);
+    expect(stopped).toEqual([]);
+  });
+
+  test("removes a failed server configuration", async () => {
+    const statuses: string[] = [];
+    const manager = _manager(
+      () => Promise.reject(new Error("connect failed")),
+      undefined,
+      ({ servers }) => statuses.push(servers[0]?.status ?? "missing")
+    );
+
+    const [server] = manager.addServer({ name: "host", host: "host" });
+    try {
+      await manager.connectServer(server.id);
+      throw new Error("connect should fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("connect failed");
+    }
+
+    expect(manager.listServers()[0]?.status).toBe("error");
+
+    const next = await manager.removeServer(server.id);
+
+    expect(next).toEqual([]);
+    expect(manager.listServers()).toEqual([]);
+    expect(statuses.at(-1)).toBe("missing");
+  });
+
+  test("allows removing a server after it is disconnected", async () => {
+    const stopped: string[] = [];
+    const manager = _manager((config) =>
+      Promise.resolve({
+        client: _remoteRuntime(config.id),
+        stop: () => {
+          stopped.push(config.id);
+          return Promise.resolve();
+        },
+      })
+    );
+
+    const [server] = manager.addServer({ name: "host", host: "host" });
+    await manager.connectServer(server.id);
+    await manager.disconnectServer(server.id);
+    const next = await manager.removeServer(server.id);
+
+    expect(next).toEqual([]);
+    expect(stopped).toEqual([server.runtimeId]);
+  });
+
+  test("does not allow editing a connected server", async () => {
+    const manager = _manager((config) =>
+      Promise.resolve({
+        client: _remoteRuntime(config.id),
+        stop: () => Promise.resolve(),
+      })
+    );
+
+    const [server] = manager.addServer({ name: "host", host: "host" });
+    await manager.connectServer(server.id);
+
+    expect(() =>
+      manager.updateServer(server.id, { name: "changed", host: "other" })
+    ).toThrow("Disconnect remote server before update");
+  });
+
   test("publishes connection progress stages", async () => {
     const stages: string[] = [];
     let lastSteps: string[] = [];
@@ -684,5 +799,47 @@ describe("RemoteServerManager", () => {
     expect(() =>
       manager.updateServer(server.id, { name: "changed", host: "other" })
     ).toThrow("Disconnect remote server before update");
+  });
+
+  test("does not allow removing while waiting for host key trust", async () => {
+    const manager = _manager(
+      (config) =>
+        Promise.resolve({
+          client: _remoteRuntime(config.id),
+          stop: () => Promise.resolve(),
+        }),
+      undefined,
+      undefined,
+      {
+        check: () =>
+          Promise.resolve({
+            status: "first-time",
+            request: {
+              requestId: "trust-1",
+              kind: "first-time",
+              target: "host",
+              host: "host",
+              keyType: "ssh-ed25519",
+              fingerprint: "SHA256:test",
+              publicKeyLine: "host ssh-ed25519 AAAA",
+            },
+          }),
+        trust: () => Promise.resolve(),
+      }
+    );
+
+    const [server] = manager.addServer({ name: "host", host: "host" });
+    await manager.connectServer(server.id);
+
+    try {
+      await manager.removeServer(server.id);
+      throw new Error("remove should fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        "Disconnect remote server before remove: " + server.id
+      );
+    }
+    expect(manager.listServers()[0]?.status).toBe("trust-required");
   });
 });

--- a/apps/desktop/src/bun/remote/remote-server-manager.ts
+++ b/apps/desktop/src/bun/remote/remote-server-manager.ts
@@ -121,14 +121,16 @@ export class RemoteServerManager {
   }
 
   async removeServer(id: string): Promise<RemoteServerView[]> {
-    return this._enqueue(async () => {
-      await this._disconnectServer(id);
+    return this._enqueue(() => {
       const next = this._servers.filter((server) => server.id !== id);
       if (next.length === this._servers.length) {
         throw new Error(`Remote server not found: ${id}`);
       }
+      this._assertNotConnected(id, "remove");
+      this._connections.delete(id);
       this._servers = next;
       this._save();
+      this._emitStatusChanged();
       return this.listServers();
     });
   }

--- a/apps/desktop/src/bun/remote/ssh-remote-runtime.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-remote-runtime.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
+import type { ManagedProcess } from "./process-utils";
 import { currentDesktopVersion } from "./server-package";
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
+import { startSshRemoteRuntime } from "./ssh-remote-runtime";
 
 let scenario:
   | "missing-runtime-binary"
@@ -16,25 +18,33 @@ let stopCalls = 0;
 let diagnosticCalls = 0;
 let remoteExecCalls: string[] = [];
 
-await mock.module("./port", () => ({
-  findFreePort: () => Promise.resolve(40000),
-}));
+const CONFIG: SshRemoteRuntimeConfig = {
+  id: "remote:test",
+  name: "test",
+  host: "host",
+  extraArgs: [],
+  remoteRepo: "",
+  remoteInstallDir: "~/.llm-space/remote-runtime",
+  remoteHome: "~/.llm-space-server",
+  remoteServerPort: 39123,
+  makeDefault: false,
+};
 
-await mock.module("./remote-server-installer", () => ({
-  RemoteServerInstallError: class RemoteServerInstallError extends Error {
-    readonly stage = "server-install";
-  },
+const TEST_DEPENDENCIES = {
+  findFreePort: () => Promise.resolve(40000),
   installRemoteServerPackage: () => {
     installCalls += 1;
     return Promise.resolve({
       entrypoint: `/opt/runtime/versions/test-${installCalls}/bin/llm-space-server`,
       version: "test",
-      platform: { os: "linux", arch: "x64" },
+      platform: { os: "linux" as const, arch: "x64" as const },
     });
   },
-}));
-
-await mock.module("./remote-exec", () => ({
+  getOrDownloadServerPackage: () =>
+    Promise.resolve({
+      path: "/tmp/llm-space-server-test.tar.gz",
+    }),
+  uploadRemoteFile: () => Promise.resolve(),
   execRemoteCommand: (_config: SshRemoteRuntimeConfig, command: string) => {
     remoteExecCalls.push(command);
     if (command.includes("PIDS")) {
@@ -56,9 +66,6 @@ await mock.module("./remote-exec", () => ({
       stderr: "",
     });
   },
-}));
-
-await mock.module("./process-utils", () => ({
   spawnManagedProcess: (label: string) => {
     const attempt = installCalls;
     if (label === "remote server") {
@@ -96,22 +103,8 @@ await mock.module("./process-utils", () => ({
         stopCalls += 1;
         return Promise.resolve();
       },
-    };
+    } as unknown as ManagedProcess;
   },
-}));
-
-const { startSshRemoteRuntime } = await import("./ssh-remote-runtime");
-
-const CONFIG: SshRemoteRuntimeConfig = {
-  id: "remote:test",
-  name: "test",
-  host: "host",
-  extraArgs: [],
-  remoteRepo: "",
-  remoteInstallDir: "~/.llm-space/remote-runtime",
-  remoteHome: "~/.llm-space-server",
-  remoteServerPort: 39123,
-  makeDefault: false,
 };
 
 beforeEach(() => {
@@ -125,7 +118,7 @@ beforeEach(() => {
 
 describe("startSshRemoteRuntime", () => {
   test("does not reinstall when the runtime binary is missing", async () => {
-    await startSshRemoteRuntime(CONFIG).then(
+    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
       () => {
         throw new Error("connect should fail");
       },
@@ -148,7 +141,7 @@ describe("startSshRemoteRuntime", () => {
   test("does not reinstall for non-runtime startup failures", async () => {
     scenario = "non-runtime-failure";
 
-    await startSshRemoteRuntime(CONFIG).then(
+    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
       () => {
         throw new Error("connect should fail");
       },
@@ -168,7 +161,9 @@ describe("startSshRemoteRuntime", () => {
     scenario = "port-in-use";
 
     await _withFetch(async () => {
-      const handle = await startSshRemoteRuntime(CONFIG);
+      const handle = await startSshRemoteRuntime(CONFIG, {
+        dependencies: TEST_DEPENDENCIES,
+      });
       await handle.stop();
     });
 
@@ -186,7 +181,7 @@ describe("startSshRemoteRuntime", () => {
   test("does not stop unknown remote port owners", async () => {
     scenario = "port-in-use-unknown-owner";
 
-    await startSshRemoteRuntime(CONFIG).then(
+    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
       () => {
         throw new Error("connect should fail");
       },
@@ -209,7 +204,7 @@ describe("startSshRemoteRuntime", () => {
   test("retries remote port recovery only once", async () => {
     scenario = "port-in-use-retry-fails";
 
-    await startSshRemoteRuntime(CONFIG).then(
+    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
       () => {
         throw new Error("connect should fail");
       },

--- a/apps/desktop/src/bun/remote/ssh-remote-runtime.ts
+++ b/apps/desktop/src/bun/remote/ssh-remote-runtime.ts
@@ -51,24 +51,46 @@ export interface SshRemoteRuntimeProgress {
 
 export interface SshRemoteRuntimeOptions {
   onProgress?: (progress: SshRemoteRuntimeProgress) => void;
+  /** @internal Test seam. Production callers should use the default deps. */
+  dependencies?: Partial<SshRemoteRuntimeDependencies>;
 }
+
+interface SshRemoteRuntimeDependencies {
+  findFreePort: typeof findFreePort;
+  installRemoteServerPackage: typeof installRemoteServerPackage;
+  getOrDownloadServerPackage: typeof getOrDownloadServerPackage;
+  uploadRemoteFile: typeof uploadRemoteFile;
+  spawnManagedProcess: typeof spawnManagedProcess;
+  execRemoteCommand: typeof execRemoteCommand;
+}
+
+const DEFAULT_DEPENDENCIES: SshRemoteRuntimeDependencies = {
+  findFreePort,
+  installRemoteServerPackage,
+  getOrDownloadServerPackage,
+  uploadRemoteFile,
+  spawnManagedProcess,
+  execRemoteCommand,
+};
 
 export async function startSshRemoteRuntime(
   config: SshRemoteRuntimeConfig,
   options: SshRemoteRuntimeOptions = {}
 ): Promise<SshRemoteRuntimeHandle> {
   const token = _generateToken();
-  const localPort = config.localPort ?? (await findFreePort());
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...options.dependencies };
+  const localPort = config.localPort ?? (await dependencies.findFreePort());
   const allProcesses: ManagedProcess[] = [];
 
   try {
-    const install = await _installRemoteServer(config, options);
+    const install = await _installRemoteServer(config, options, dependencies);
     const started = await _startInstalledRuntime({
       config,
       install,
       token,
       localPort,
       options,
+      dependencies,
     });
     allProcesses.push(...started.processes);
     return _handle(started.client, allProcesses);
@@ -80,10 +102,11 @@ export async function startSshRemoteRuntime(
 
 async function _installRemoteServer(
   config: SshRemoteRuntimeConfig,
-  options: SshRemoteRuntimeOptions
+  options: SshRemoteRuntimeOptions,
+  dependencies: SshRemoteRuntimeDependencies
 ): Promise<RemoteServerInstallResult> {
   try {
-    return await installRemoteServerPackage(config, undefined, {
+    return await dependencies.installRemoteServerPackage(config, undefined, {
       onProgress: options.onProgress,
       packageUploader: {
         upload: async ({
@@ -93,7 +116,7 @@ async function _installRemoteServer(
           checksumUrl,
           remoteArchivePath,
         }) => {
-          const localPackage = await getOrDownloadServerPackage({
+          const localPackage = await dependencies.getOrDownloadServerPackage({
             assetName,
             assetUrl,
             checksumUrl,
@@ -102,7 +125,7 @@ async function _installRemoteServer(
             stage: "server-install",
             message: "Uploading remote runtime package over SSH",
           });
-          await uploadRemoteFile({
+          await dependencies.uploadRemoteFile({
             config: sshConfig,
             localPath: localPackage.path,
             remotePath: remoteArchivePath,
@@ -132,6 +155,7 @@ async function _startInstalledRuntime(input: {
   token: string;
   localPort: number;
   options: SshRemoteRuntimeOptions;
+  dependencies: SshRemoteRuntimeDependencies;
 }): Promise<{ client: RemoteRuntimeClient; processes: ManagedProcess[] }> {
   let retriedPortRecovery = false;
   while (true) {
@@ -141,7 +165,12 @@ async function _startInstalledRuntime(input: {
       const portFailure = parseRemotePortInUseFailure(_errorMessage(error));
       if (portFailure && !retriedPortRecovery) {
         retriedPortRecovery = true;
-        await _recoverRemotePortInUse(input.config, input.options, portFailure.port);
+        await _recoverRemotePortInUse(
+          input.config,
+          input.options,
+          input.dependencies,
+          portFailure.port
+        );
         continue;
       }
       throw await _appendRemoteRuntimeDiagnostics(error, input);
@@ -155,6 +184,7 @@ async function _startInstalledRuntimeOnce(input: {
   token: string;
   localPort: number;
   options: SshRemoteRuntimeOptions;
+  dependencies: SshRemoteRuntimeDependencies;
 }): Promise<{ client: RemoteRuntimeClient; processes: ManagedProcess[] }> {
   const processes: ManagedProcess[] = [];
   try {
@@ -162,7 +192,7 @@ async function _startInstalledRuntimeOnce(input: {
       stage: "server-start",
       message: "Starting remote runtime",
     });
-    const serverProcess = spawnManagedProcess(
+    const serverProcess = input.dependencies.spawnManagedProcess(
       "remote server",
       "ssh",
       process.env.LLM_SPACE_REMOTE_SERVER_MODE === "source"
@@ -190,7 +220,7 @@ async function _startInstalledRuntimeOnce(input: {
       stage: "tunnel-start",
       message: "Opening SSH tunnel",
     });
-    const tunnelProcess = spawnManagedProcess(
+    const tunnelProcess = input.dependencies.spawnManagedProcess(
       "ssh tunnel",
       "ssh",
       buildTunnelArgs({ config: input.config, localPort: input.localPort })
@@ -219,6 +249,7 @@ async function _startInstalledRuntimeOnce(input: {
 async function _recoverRemotePortInUse(
   config: SshRemoteRuntimeConfig,
   options: SshRemoteRuntimeOptions,
+  dependencies: SshRemoteRuntimeDependencies,
   port: number
 ): Promise<void> {
   if (port !== config.remoteServerPort) {
@@ -230,7 +261,7 @@ async function _recoverRemotePortInUse(
     stage: "server-start",
     message: "Checking stale remote runtime port owner",
   });
-  const probe = await execRemoteCommand(
+  const probe = await dependencies.execRemoteCommand(
     config,
     buildRemotePortOwnerProbeCommand(config),
     10_000
@@ -252,7 +283,7 @@ async function _recoverRemotePortInUse(
     stage: "server-start",
     message: "Restarting stale remote runtime server",
   });
-  await execRemoteCommand(
+  await dependencies.execRemoteCommand(
     config,
     buildStopRemotePortOwnerCommand(owner.pid),
     10_000
@@ -264,6 +295,7 @@ async function _appendRemoteRuntimeDiagnostics(
   input: {
     config: SshRemoteRuntimeConfig;
     install: RemoteServerInstallResult;
+    dependencies: SshRemoteRuntimeDependencies;
   }
 ): Promise<Error> {
   const message = _errorMessage(error);
@@ -282,6 +314,7 @@ async function _appendRemoteRuntimeDiagnostics(
 async function _collectRemoteRuntimeDiagnostics(input: {
   config: SshRemoteRuntimeConfig;
   install: RemoteServerInstallResult;
+  dependencies: SshRemoteRuntimeDependencies;
 }): Promise<string> {
   const installDir = input.config.remoteInstallDir;
   const packageDir = joinRemotePath(installDir, "versions", input.install.version);
@@ -311,7 +344,11 @@ async function _collectRemoteRuntimeDiagnostics(input: {
     'ls -ld "$PWD/~" "$PWD/~/.llm-space" "$PWD/~/.llm-space/remote-runtime" 2>&1',
     "true",
   ].join("; ");
-  const result = await execRemoteCommand(input.config, command, 10_000);
+  const result = await input.dependencies.execRemoteCommand(
+    input.config,
+    command,
+    10_000
+  );
   return [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join("\n");
 }
 

--- a/apps/desktop/src/components/settings/remote-server-display.test.ts
+++ b/apps/desktop/src/components/settings/remote-server-display.test.ts
@@ -6,6 +6,9 @@ import type {
 } from "@/shared/remote-servers";
 
 import {
+  canConnectRemoteServer,
+  canEditRemoteServer,
+  canRemoveRemoteServer,
   remoteConnectionChecked,
   remoteConnectionDisabled,
   remoteConnectionFlow,
@@ -79,6 +82,34 @@ describe("remote server display helpers", () => {
     expect(remoteConnectionDisabled(server({ status: "error" }), false)).toBe(
       false
     );
+  });
+
+  test("allows actions only for stable disconnected states", () => {
+    const cases: [
+      RemoteServerView["status"],
+      { connect: boolean; edit: boolean; remove: boolean },
+    ][] = [
+      ["connected", { connect: false, edit: false, remove: false }],
+      ["connecting", { connect: false, edit: false, remove: false }],
+      ["trust-required", { connect: false, edit: false, remove: false }],
+      ["disconnected", { connect: true, edit: true, remove: true }],
+      ["error", { connect: true, edit: true, remove: true }],
+    ];
+
+    for (const [status, expected] of cases) {
+      const view = server({ status });
+      expect(canConnectRemoteServer(view, false)).toBe(expected.connect);
+      expect(canEditRemoteServer(view, false)).toBe(expected.edit);
+      expect(canRemoveRemoteServer(view, false)).toBe(expected.remove);
+    }
+  });
+
+  test("disables server actions while the selected server is busy", () => {
+    const view = server({ status: "disconnected" });
+
+    expect(canConnectRemoteServer(view, true)).toBe(false);
+    expect(canEditRemoteServer(view, true)).toBe(false);
+    expect(canRemoveRemoteServer(view, true)).toBe(false);
   });
 
   test("exposes connection flow steps from the server view", () => {

--- a/apps/desktop/src/components/settings/remote-server-display.ts
+++ b/apps/desktop/src/components/settings/remote-server-display.ts
@@ -33,11 +33,31 @@ export function remoteConnectionDisabled(
   server: RemoteServerView,
   busy: boolean
 ): boolean {
+  return !canConnectRemoteServer(server, busy);
+}
+
+export function canConnectRemoteServer(
+  server: RemoteServerView,
+  busy: boolean
+): boolean {
   return (
-    busy ||
-    server.status === "connecting" ||
-    server.status === "trust-required"
+    !busy &&
+    (server.status === "disconnected" || server.status === "error")
   );
+}
+
+export function canEditRemoteServer(
+  server: RemoteServerView,
+  busy: boolean
+): boolean {
+  return _canMutateRemoteServerConfig(server, busy);
+}
+
+export function canRemoveRemoteServer(
+  server: RemoteServerView,
+  busy: boolean
+): boolean {
+  return _canMutateRemoteServerConfig(server, busy);
 }
 
 export function remoteConnectionFlow(
@@ -45,4 +65,14 @@ export function remoteConnectionFlow(
 ): RemoteConnectionStepView[] {
   if (server.status === "connected") return [];
   return server.steps ?? [];
+}
+
+function _canMutateRemoteServerConfig(
+  server: RemoteServerView,
+  busy: boolean
+): boolean {
+  return (
+    !busy &&
+    (server.status === "disconnected" || server.status === "error")
+  );
 }

--- a/apps/desktop/src/components/settings/remote-servers-page.tsx
+++ b/apps/desktop/src/components/settings/remote-servers-page.tsx
@@ -44,7 +44,12 @@ import type {
 } from "@/shared/remote-servers";
 import type { RuntimeId } from "@/shared/runtime";
 
-import { remoteConnectionFlow } from "./remote-server-display";
+import {
+  canConnectRemoteServer,
+  canEditRemoteServer,
+  canRemoveRemoteServer,
+  remoteConnectionFlow,
+} from "./remote-server-display";
 import { SettingsPage } from "./settings-page";
 
 interface FormState {
@@ -141,7 +146,11 @@ export function RemoteServersPage({
   const run = async (
     id: string,
     action: (id: string) => Promise<RemoteServerView[]>,
-    options: { closeOnConnected?: boolean; notifyDisconnected?: boolean } = {}
+    options: {
+      closeOnConnected?: boolean;
+      notifyDisconnected?: boolean;
+      selectFallback?: boolean;
+    } = {}
   ) => {
     setBusyId(id);
     try {
@@ -150,7 +159,11 @@ export function RemoteServersPage({
       )?.runtimeId;
       const next = await action(id);
       updateServers(next);
-      setSelectedId(id);
+      setSelectedId(
+        options.selectFallback && !next.some((server) => server.id === id)
+          ? (next[0]?.id ?? null)
+          : id
+      );
       if (options.closeOnConnected) {
         const connected = next.find((server) => server.id === id);
         if (connected?.status === "connected") onConnected?.(connected.runtimeId);
@@ -332,7 +345,7 @@ export function RemoteServersPage({
               onEdit={() => startEdit(selected)}
               onRemove={() =>
                 void run(selected.id, removeRemoteServer, {
-                  notifyDisconnected: true,
+                  selectFallback: true,
                 })
               }
               onTrustHostKey={(request) => void trustHostKey(selected, request)}
@@ -404,11 +417,7 @@ function RemoteServerDetails({
         ) : (
           <Button
             size="sm"
-            disabled={
-              busy ||
-              server.status === "connecting" ||
-              server.status === "trust-required"
-            }
+            disabled={!canConnectRemoteServer(server, busy)}
             onClick={onConnect}
           >
             {server.status === "connecting" ? (
@@ -420,12 +429,17 @@ function RemoteServerDetails({
         <Button
           size="sm"
           variant="secondary"
-          disabled={server.status === "connected"}
+          disabled={!canEditRemoteServer(server, busy)}
           onClick={onEdit}
         >
           Edit
         </Button>
-        <Button size="sm" variant="ghost" disabled={busy} onClick={onRemove}>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={!canRemoveRemoteServer(server, busy)}
+          onClick={onRemove}
+        >
           <Trash2 className="size-4" />
           Remove
         </Button>


### PR DESCRIPTION
- 删除未连接的 remote server 时，不再关闭 Settings 窗口
- 删除 remote server 配置不再误触发 runtime disconnected 回调
- connected server 禁止 Edit / Remove，必须先 Disconnect
- disconnected / error server 允许 Connect / Edit / Remove
- connecting / trust-required server 禁止 Connect / Edit / Remove，避免打断连接状态机
- bun 侧 `RemoteServerManager.removeServer()` 不再隐式 disconnect connected server，而是在不可变更
状态下直接拒绝
- 断开非当前 remote runtime 时，不再关闭 Settings