### PR TITLE
fix(auth): make Device Flow cancellation authoritative

### DIFF
--- a/apps/desktop/src/bun/auth/github-auth-manager.test.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { GithubAuthState, GithubUser } from "../../shared/auth";
+
+class TestDeviceFlowError extends Error {}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+interface ProfileRequest {
+  accessToken: string;
+  signal: AbortSignal | undefined;
+  deferred: Deferred<GithubUser>;
+}
+
+const PROFILE_REQUESTS: ProfileRequest[] = [];
+
+const TOKENS = [
+  { accessToken: "cancelled-token", tokenType: "bearer", scope: "gist" },
+];
+
+function _deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+await mock.module("./github-device-flow", () => ({
+  DeviceFlowError: TestDeviceFlowError,
+  fetchGithubUser: (accessToken: string, signal?: AbortSignal) => {
+    const deferred = _deferred<GithubUser>();
+    PROFILE_REQUESTS.push({ accessToken, signal, deferred });
+    return deferred.promise;
+  },
+  pollForAccessToken: () => {
+    const token = TOKENS.shift();
+    if (!token) throw new Error("No token queued for Device Flow test.");
+    return Promise.resolve(token);
+  },
+  requestDeviceCode: () =>
+    Promise.resolve({
+      deviceCode: "device-code",
+      userCode: "USER-CODE",
+      verificationUri: "https://github.com/login/device",
+      verificationUriComplete: "https://github.com/login/device?user_code=USER-CODE",
+      expiresIn: 900,
+      interval: 1,
+    }),
+}));
+
+const { GitHubAuthManager } = await import("./github-auth-manager");
+
+const ORIGINAL_HOME = process.env.LLM_SPACE_HOME;
+const TEMP_DIRS: string[] = [];
+
+afterEach(async () => {
+  process.env.LLM_SPACE_HOME = ORIGINAL_HOME;
+  PROFILE_REQUESTS.length = 0;
+  TOKENS.splice(0, TOKENS.length, {
+    accessToken: "cancelled-token",
+    tokenType: "bearer",
+    scope: "gist",
+  });
+  await Promise.all(
+    TEMP_DIRS.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true })
+    )
+  );
+});
+
+async function _waitForProfileRequest(): Promise<ProfileRequest> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const request = PROFILE_REQUESTS.at(-1);
+    if (request) return request;
+    await Promise.resolve();
+  }
+  throw new Error("Device Flow did not start the profile request.");
+}
+
+describe("GitHubAuthManager", () => {
+  test("cancelling a delayed profile request keeps auth signed out and unpersisted", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "llm-space-auth-"));
+    TEMP_DIRS.push(home);
+    process.env.LLM_SPACE_HOME = home;
+    const states: GithubAuthState[] = [];
+    const manager = new GitHubAuthManager({
+      onChange: (state) => states.push(state),
+    });
+
+    const signIn = manager.signIn();
+    const profile = await _waitForProfileRequest();
+
+    manager.signOut();
+    expect(profile.signal?.aborted).toBe(true);
+
+    profile.deferred.resolve({
+      login: "late-user",
+      name: "Late User",
+      email: "late@example.com",
+      avatarUrl: "https://avatars.githubusercontent.com/u/1",
+      htmlUrl: "https://github.com/late-user",
+    });
+    await signIn;
+
+    expect(manager.getState()).toEqual({ status: "signedOut" });
+    expect(manager.getAccessToken()).toBeNull();
+    expect(existsSync(path.join(home, "settings", "auth.json"))).toBe(false);
+    expect(states.some((state) => state.status === "signedIn")).toBe(false);
+  });
+});

--- a/apps/desktop/src/bun/auth/github-auth-manager.test.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.test.ts
@@ -1,12 +1,23 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import type { GithubAuthState, GithubUser } from "../../shared/auth";
+import type {
+  AuthConfig,
+  GithubAuthState,
+  GithubUser,
+} from "../../shared/auth";
 
-class TestDeviceFlowError extends Error {}
+import {
+  GitHubAuthManager,
+  type GitHubDeviceFlow,
+} from "./github-auth-manager";
+import type {
+  AccessTokenResponse,
+  DeviceCodeResponse,
+} from "./github-device-flow";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -15,27 +26,16 @@ interface Deferred<T> {
 
 interface ProfileRequest {
   accessToken: string;
-  signal: AbortSignal | undefined;
+  signal: AbortSignal;
   deferred: Deferred<GithubUser>;
 }
 
+const DEVICE_CODES: DeviceCodeResponse[] = [];
 const PROFILE_REQUESTS: ProfileRequest[] = [];
+const TOKENS: AccessTokenResponse[] = [];
 
-const TOKENS = [
-  { accessToken: "cancelled-token", tokenType: "bearer", scope: "gist" },
-];
-
-function _deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
-await mock.module("./github-device-flow", () => ({
-  DeviceFlowError: TestDeviceFlowError,
-  fetchGithubUser: (accessToken: string, signal?: AbortSignal) => {
+const DEVICE_FLOW: GitHubDeviceFlow = {
+  fetchGithubUser: (accessToken, signal) => {
     const deferred = _deferred<GithubUser>();
     PROFILE_REQUESTS.push({ accessToken, signal, deferred });
     return deferred.promise;
@@ -45,30 +45,24 @@ await mock.module("./github-device-flow", () => ({
     if (!token) throw new Error("No token queued for Device Flow test.");
     return Promise.resolve(token);
   },
-  requestDeviceCode: () =>
-    Promise.resolve({
-      deviceCode: "device-code",
-      userCode: "USER-CODE",
-      verificationUri: "https://github.com/login/device",
-      verificationUriComplete: "https://github.com/login/device?user_code=USER-CODE",
-      expiresIn: 900,
-      interval: 1,
-    }),
-}));
-
-const { GitHubAuthManager } = await import("./github-auth-manager");
+  requestDeviceCode: () => {
+    const device = DEVICE_CODES.shift();
+    if (!device) throw new Error("No device code queued for Device Flow test.");
+    return Promise.resolve(device);
+  },
+};
 
 const ORIGINAL_HOME = process.env.LLM_SPACE_HOME;
 const TEMP_DIRS: string[] = [];
 
+beforeEach(() => {
+  DEVICE_CODES.splice(0, DEVICE_CODES.length, _deviceCode("FIRST"));
+  PROFILE_REQUESTS.length = 0;
+  TOKENS.splice(0, TOKENS.length, _token("first-token"));
+});
+
 afterEach(async () => {
   process.env.LLM_SPACE_HOME = ORIGINAL_HOME;
-  PROFILE_REQUESTS.length = 0;
-  TOKENS.splice(0, TOKENS.length, {
-    accessToken: "cancelled-token",
-    tokenType: "bearer",
-    scope: "gist",
-  });
   await Promise.all(
     TEMP_DIRS.splice(0).map((directory) =>
       rm(directory, { recursive: true, force: true })
@@ -76,9 +70,76 @@ afterEach(async () => {
   );
 });
 
-async function _waitForProfileRequest(): Promise<ProfileRequest> {
+function _deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function _deviceCode(userCode: string): DeviceCodeResponse {
+  return {
+    deviceCode: `${userCode.toLowerCase()}-device-code`,
+    userCode,
+    verificationUri: "https://github.com/login/device",
+    verificationUriComplete: `https://github.com/login/device?user_code=${userCode}`,
+    expiresIn: 900,
+    interval: 1,
+  };
+}
+
+function _token(accessToken: string): AccessTokenResponse {
+  return { accessToken, tokenType: "bearer", scope: "gist" };
+}
+
+function _queueTwoFlows(): void {
+  DEVICE_CODES.splice(
+    0,
+    DEVICE_CODES.length,
+    _deviceCode("FIRST"),
+    _deviceCode("SECOND")
+  );
+  TOKENS.splice(
+    0,
+    TOKENS.length,
+    _token("first-token"),
+    _token("second-token")
+  );
+}
+
+function _user(login: string): GithubUser {
+  return {
+    login,
+    name: `${login} name`,
+    email: `${login}@example.com`,
+    avatarUrl: `https://avatars.githubusercontent.com/${login}`,
+    htmlUrl: `https://github.com/${login}`,
+  };
+}
+
+async function _createManager(): Promise<{
+  authPath: string;
+  manager: GitHubAuthManager;
+  states: GithubAuthState[];
+}> {
+  const home = await mkdtemp(path.join(os.tmpdir(), "llm-space-auth-"));
+  TEMP_DIRS.push(home);
+  process.env.LLM_SPACE_HOME = home;
+  const states: GithubAuthState[] = [];
+  return {
+    authPath: path.join(home, "settings", "auth.json"),
+    manager: new GitHubAuthManager({
+      deviceFlow: DEVICE_FLOW,
+      onChange: (state) => states.push(state),
+    }),
+    states,
+  };
+}
+
+async function _waitForProfileRequest(index = 0): Promise<ProfileRequest> {
   for (let attempt = 0; attempt < 10; attempt += 1) {
-    const request = PROFILE_REQUESTS.at(-1);
+    const request = PROFILE_REQUESTS[index];
     if (request) return request;
     await Promise.resolve();
   }
@@ -87,32 +148,83 @@ async function _waitForProfileRequest(): Promise<ProfileRequest> {
 
 describe("GitHubAuthManager", () => {
   test("cancelling a delayed profile request keeps auth signed out and unpersisted", async () => {
-    const home = await mkdtemp(path.join(os.tmpdir(), "llm-space-auth-"));
-    TEMP_DIRS.push(home);
-    process.env.LLM_SPACE_HOME = home;
-    const states: GithubAuthState[] = [];
-    const manager = new GitHubAuthManager({
-      onChange: (state) => states.push(state),
-    });
+    const { authPath, manager, states } = await _createManager();
 
     const signIn = manager.signIn();
     const profile = await _waitForProfileRequest();
 
     manager.signOut();
-    expect(profile.signal?.aborted).toBe(true);
+    expect(profile.signal.aborted).toBe(true);
 
-    profile.deferred.resolve({
-      login: "late-user",
-      name: "Late User",
-      email: "late@example.com",
-      avatarUrl: "https://avatars.githubusercontent.com/u/1",
-      htmlUrl: "https://github.com/late-user",
-    });
+    profile.deferred.resolve(_user("late-user"));
     await signIn;
 
     expect(manager.getState()).toEqual({ status: "signedOut" });
     expect(manager.getAccessToken()).toBeNull();
-    expect(existsSync(path.join(home, "settings", "auth.json"))).toBe(false);
+    expect(existsSync(authPath)).toBe(false);
     expect(states.some((state) => state.status === "signedIn")).toBe(false);
+  });
+
+  test("a stale flow cannot clear its replacement's pending state", async () => {
+    _queueTwoFlows();
+    const { authPath, manager } = await _createManager();
+
+    const firstSignIn = manager.signIn();
+    const firstProfile = await _waitForProfileRequest(0);
+    manager.signOut();
+
+    const secondSignIn = manager.signIn();
+    const secondProfile = await _waitForProfileRequest(1);
+
+    firstProfile.deferred.resolve(_user("stale-user"));
+    await firstSignIn;
+
+    expect(manager.getState()).toEqual({
+      status: "signingIn",
+      userCode: "SECOND",
+      verificationUri: "https://github.com/login/device",
+    });
+    expect(manager.getAccessToken()).toBeNull();
+    expect(existsSync(authPath)).toBe(false);
+
+    const currentUser = _user("current-user");
+    secondProfile.deferred.resolve(currentUser);
+    await secondSignIn;
+
+    expect(manager.getState()).toEqual({ status: "signedIn", user: currentUser });
+    expect(manager.getAccessToken()).toBe("second-token");
+    expect(JSON.parse(await readFile(authPath, "utf8")) as AuthConfig).toEqual({
+      accessToken: "second-token",
+      tokenType: "bearer",
+      scope: "gist",
+      user: currentUser,
+    });
+  });
+
+  test("a stale flow cannot overwrite its replacement's credentials", async () => {
+    _queueTwoFlows();
+    const { authPath, manager } = await _createManager();
+
+    const firstSignIn = manager.signIn();
+    const firstProfile = await _waitForProfileRequest(0);
+    manager.signOut();
+
+    const secondSignIn = manager.signIn();
+    const secondProfile = await _waitForProfileRequest(1);
+    const currentUser = _user("current-user");
+    secondProfile.deferred.resolve(currentUser);
+    await secondSignIn;
+
+    firstProfile.deferred.resolve(_user("stale-user"));
+    await firstSignIn;
+
+    expect(manager.getState()).toEqual({ status: "signedIn", user: currentUser });
+    expect(manager.getAccessToken()).toBe("second-token");
+    expect(JSON.parse(await readFile(authPath, "utf8")) as AuthConfig).toEqual({
+      accessToken: "second-token",
+      tokenType: "bearer",
+      scope: "gist",
+      user: currentUser,
+    });
   });
 });

--- a/apps/desktop/src/bun/auth/github-auth-manager.test.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.test.ts
@@ -13,7 +13,6 @@ import type {
 import {
   GitHubAuthManager,
   type GitHubDeviceFlow,
-  type GitHubAuthManagerOptions,
 } from "./github-auth-manager";
 import type {
   AccessTokenResponse,
@@ -29,12 +28,6 @@ interface ProfileRequest {
   accessToken: string;
   signal: AbortSignal;
   deferred: Deferred<GithubUser>;
-}
-
-class NonAbortingAbortController extends AbortController {
-  override abort(reason?: unknown): void {
-    void reason;
-  }
 }
 
 const DEVICE_CODES: DeviceCodeResponse[] = [];
@@ -125,9 +118,7 @@ function _user(login: string): GithubUser {
   };
 }
 
-async function _createManager(
-  options: Pick<GitHubAuthManagerOptions, "createAbortController"> = {}
-): Promise<{
+async function _createManager(): Promise<{
   authPath: string;
   manager: GitHubAuthManager;
   states: GithubAuthState[];
@@ -139,7 +130,6 @@ async function _createManager(
   return {
     authPath: path.join(home, "settings", "auth.json"),
     manager: new GitHubAuthManager({
-      ...options,
       deviceFlow: DEVICE_FLOW,
       onChange: (state) => states.push(state),
     }),
@@ -175,13 +165,14 @@ describe("GitHubAuthManager", () => {
     expect(states.some((state) => state.status === "signedIn")).toBe(false);
   });
 
-  test("a stale flow cannot clear its replacement's pending state", async () => {
+  test("an aborted stale flow cannot clear its replacement's pending state", async () => {
     _queueTwoFlows();
     const { authPath, manager } = await _createManager();
 
     const firstSignIn = manager.signIn();
     const firstProfile = await _waitForProfileRequest(0);
     manager.signOut();
+    expect(firstProfile.signal.aborted).toBe(true);
 
     const secondSignIn = manager.signIn();
     const secondProfile = await _waitForProfileRequest(1);
@@ -211,13 +202,14 @@ describe("GitHubAuthManager", () => {
     });
   });
 
-  test("a stale flow cannot overwrite its replacement's credentials", async () => {
+  test("an aborted stale flow cannot overwrite replacement credentials", async () => {
     _queueTwoFlows();
     const { authPath, manager } = await _createManager();
 
     const firstSignIn = manager.signIn();
     const firstProfile = await _waitForProfileRequest(0);
     manager.signOut();
+    expect(firstProfile.signal.aborted).toBe(true);
 
     const secondSignIn = manager.signIn();
     const secondProfile = await _waitForProfileRequest(1);
@@ -236,46 +228,5 @@ describe("GitHubAuthManager", () => {
       scope: "gist",
       user: currentUser,
     });
-  });
-
-  test("controller identity rejects a non-current flow with an active signal", async () => {
-    _queueTwoFlows();
-    const controllers: AbortController[] = [
-      new NonAbortingAbortController(),
-      new AbortController(),
-    ];
-    const { authPath, manager } = await _createManager({
-      createAbortController: () => {
-        const controller = controllers.shift();
-        if (!controller) {
-          throw new Error("No AbortController queued for Device Flow test.");
-        }
-        return controller;
-      },
-    });
-
-    const firstSignIn = manager.signIn();
-    const firstProfile = await _waitForProfileRequest(0);
-    manager.cancelSignIn();
-    expect(firstProfile.signal.aborted).toBe(false);
-
-    const secondSignIn = manager.signIn();
-    const secondProfile = await _waitForProfileRequest(1);
-    firstProfile.deferred.resolve(_user("stale-user"));
-    await firstSignIn;
-
-    expect(manager.getState()).toEqual({
-      status: "signingIn",
-      userCode: "SECOND",
-      verificationUri: "https://github.com/login/device",
-    });
-    expect(manager.getAccessToken()).toBeNull();
-    expect(existsSync(authPath)).toBe(false);
-
-    const currentUser = _user("current-user");
-    secondProfile.deferred.resolve(currentUser);
-    await secondSignIn;
-    expect(manager.getState()).toEqual({ status: "signedIn", user: currentUser });
-    expect(manager.getAccessToken()).toBe("second-token");
   });
 });

--- a/apps/desktop/src/bun/auth/github-auth-manager.test.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.test.ts
@@ -13,6 +13,7 @@ import type {
 import {
   GitHubAuthManager,
   type GitHubDeviceFlow,
+  type GitHubAuthManagerOptions,
 } from "./github-auth-manager";
 import type {
   AccessTokenResponse,
@@ -28,6 +29,12 @@ interface ProfileRequest {
   accessToken: string;
   signal: AbortSignal;
   deferred: Deferred<GithubUser>;
+}
+
+class NonAbortingAbortController extends AbortController {
+  override abort(reason?: unknown): void {
+    void reason;
+  }
 }
 
 const DEVICE_CODES: DeviceCodeResponse[] = [];
@@ -118,7 +125,9 @@ function _user(login: string): GithubUser {
   };
 }
 
-async function _createManager(): Promise<{
+async function _createManager(
+  options: Pick<GitHubAuthManagerOptions, "createAbortController"> = {}
+): Promise<{
   authPath: string;
   manager: GitHubAuthManager;
   states: GithubAuthState[];
@@ -130,6 +139,7 @@ async function _createManager(): Promise<{
   return {
     authPath: path.join(home, "settings", "auth.json"),
     manager: new GitHubAuthManager({
+      ...options,
       deviceFlow: DEVICE_FLOW,
       onChange: (state) => states.push(state),
     }),
@@ -226,5 +236,46 @@ describe("GitHubAuthManager", () => {
       scope: "gist",
       user: currentUser,
     });
+  });
+
+  test("controller identity rejects a non-current flow with an active signal", async () => {
+    _queueTwoFlows();
+    const controllers: AbortController[] = [
+      new NonAbortingAbortController(),
+      new AbortController(),
+    ];
+    const { authPath, manager } = await _createManager({
+      createAbortController: () => {
+        const controller = controllers.shift();
+        if (!controller) {
+          throw new Error("No AbortController queued for Device Flow test.");
+        }
+        return controller;
+      },
+    });
+
+    const firstSignIn = manager.signIn();
+    const firstProfile = await _waitForProfileRequest(0);
+    manager.cancelSignIn();
+    expect(firstProfile.signal.aborted).toBe(false);
+
+    const secondSignIn = manager.signIn();
+    const secondProfile = await _waitForProfileRequest(1);
+    firstProfile.deferred.resolve(_user("stale-user"));
+    await firstSignIn;
+
+    expect(manager.getState()).toEqual({
+      status: "signingIn",
+      userCode: "SECOND",
+      verificationUri: "https://github.com/login/device",
+    });
+    expect(manager.getAccessToken()).toBeNull();
+    expect(existsSync(authPath)).toBe(false);
+
+    const currentUser = _user("current-user");
+    secondProfile.deferred.resolve(currentUser);
+    await secondSignIn;
+    expect(manager.getState()).toEqual({ status: "signedIn", user: currentUser });
+    expect(manager.getAccessToken()).toBe("second-token");
   });
 });

--- a/apps/desktop/src/bun/auth/github-auth-manager.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.ts
@@ -41,6 +41,8 @@ export interface GitHubAuthManagerOptions {
   onChange: (state: GithubAuthState) => void;
   /** Device Flow request implementation; defaults to the GitHub HTTP helpers. */
   deviceFlow?: GitHubDeviceFlow;
+  /** Creates per-flow cancellation controllers; defaults to AbortController. */
+  createAbortController?: () => AbortController;
 }
 
 export interface GitHubDeviceFlow {
@@ -64,6 +66,7 @@ const GITHUB_DEVICE_FLOW: GitHubDeviceFlow = {
  */
 export class GitHubAuthManager {
   private _config: AuthConfig | null;
+  private readonly _createAbortController: () => AbortController;
   private readonly _deviceFlow: GitHubDeviceFlow;
   private readonly _onChange: (state: GithubAuthState) => void;
   /** Non-null while a Device Flow is in progress; aborts the token poll. */
@@ -72,6 +75,8 @@ export class GitHubAuthManager {
   private _pending: { userCode: string; verificationUri: string } | null = null;
 
   constructor(options: GitHubAuthManagerOptions) {
+    this._createAbortController =
+      options.createAbortController ?? (() => new AbortController());
     this._deviceFlow = options.deviceFlow ?? GITHUB_DEVICE_FLOW;
     this._onChange = options.onChange;
     this._config = this._loadConfig();
@@ -110,7 +115,7 @@ export class GitHubAuthManager {
       return;
     }
 
-    const controller = new AbortController();
+    const controller = this._createAbortController();
     this._signInController = controller;
     this._emit();
 

--- a/apps/desktop/src/bun/auth/github-auth-manager.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.ts
@@ -39,7 +39,21 @@ const AuthConfigSchema: z.ZodType<AuthConfig | null> = z
 export interface GitHubAuthManagerOptions {
   /** Pushed on every auth-state transition (→ renderer over RPC). */
   onChange: (state: GithubAuthState) => void;
+  /** Device Flow request implementation; defaults to the GitHub HTTP helpers. */
+  deviceFlow?: GitHubDeviceFlow;
 }
+
+export interface GitHubDeviceFlow {
+  fetchGithubUser: typeof fetchGithubUser;
+  pollForAccessToken: typeof pollForAccessToken;
+  requestDeviceCode: typeof requestDeviceCode;
+}
+
+const GITHUB_DEVICE_FLOW: GitHubDeviceFlow = {
+  fetchGithubUser,
+  pollForAccessToken,
+  requestDeviceCode,
+};
 
 /**
  * Owns GitHub authentication: the persisted access token (`settings/auth.json`,
@@ -50,6 +64,7 @@ export interface GitHubAuthManagerOptions {
  */
 export class GitHubAuthManager {
   private _config: AuthConfig | null;
+  private readonly _deviceFlow: GitHubDeviceFlow;
   private readonly _onChange: (state: GithubAuthState) => void;
   /** Non-null while a Device Flow is in progress; aborts the token poll. */
   private _signInController: AbortController | null = null;
@@ -57,6 +72,7 @@ export class GitHubAuthManager {
   private _pending: { userCode: string; verificationUri: string } | null = null;
 
   constructor(options: GitHubAuthManagerOptions) {
+    this._deviceFlow = options.deviceFlow ?? GITHUB_DEVICE_FLOW;
     this._onChange = options.onChange;
     this._config = this._loadConfig();
   }
@@ -99,7 +115,9 @@ export class GitHubAuthManager {
     this._emit();
 
     try {
-      const device = await requestDeviceCode(GITHUB_OAUTH_CLIENT_ID);
+      const device = await this._deviceFlow.requestDeviceCode(
+        GITHUB_OAUTH_CLIENT_ID
+      );
       if (controller.signal.aborted) {
         return;
       }
@@ -110,13 +128,16 @@ export class GitHubAuthManager {
         verificationUri: device.verificationUri,
       };
       this._emit();
-      const token = await pollForAccessToken(
+      const token = await this._deviceFlow.pollForAccessToken(
         GITHUB_OAUTH_CLIENT_ID,
         device.deviceCode,
         device.interval,
         controller.signal
       );
-      const user = await fetchGithubUser(token.accessToken, controller.signal);
+      const user = await this._deviceFlow.fetchGithubUser(
+        token.accessToken,
+        controller.signal
+      );
       if (
         controller.signal.aborted ||
         this._signInController !== controller

--- a/apps/desktop/src/bun/auth/github-auth-manager.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.ts
@@ -41,8 +41,6 @@ export interface GitHubAuthManagerOptions {
   onChange: (state: GithubAuthState) => void;
   /** Device Flow request implementation; defaults to the GitHub HTTP helpers. */
   deviceFlow?: GitHubDeviceFlow;
-  /** Creates per-flow cancellation controllers; defaults to AbortController. */
-  createAbortController?: () => AbortController;
 }
 
 export interface GitHubDeviceFlow {
@@ -66,7 +64,6 @@ const GITHUB_DEVICE_FLOW: GitHubDeviceFlow = {
  */
 export class GitHubAuthManager {
   private _config: AuthConfig | null;
-  private readonly _createAbortController: () => AbortController;
   private readonly _deviceFlow: GitHubDeviceFlow;
   private readonly _onChange: (state: GithubAuthState) => void;
   /** Non-null while a Device Flow is in progress; aborts the token poll. */
@@ -75,8 +72,6 @@ export class GitHubAuthManager {
   private _pending: { userCode: string; verificationUri: string } | null = null;
 
   constructor(options: GitHubAuthManagerOptions) {
-    this._createAbortController =
-      options.createAbortController ?? (() => new AbortController());
     this._deviceFlow = options.deviceFlow ?? GITHUB_DEVICE_FLOW;
     this._onChange = options.onChange;
     this._config = this._loadConfig();
@@ -115,7 +110,7 @@ export class GitHubAuthManager {
       return;
     }
 
-    const controller = this._createAbortController();
+    const controller = new AbortController();
     this._signInController = controller;
     this._emit();
 

--- a/apps/desktop/src/bun/auth/github-auth-manager.ts
+++ b/apps/desktop/src/bun/auth/github-auth-manager.ts
@@ -116,7 +116,13 @@ export class GitHubAuthManager {
         device.interval,
         controller.signal
       );
-      const user = await fetchGithubUser(token.accessToken);
+      const user = await fetchGithubUser(token.accessToken, controller.signal);
+      if (
+        controller.signal.aborted ||
+        this._signInController !== controller
+      ) {
+        return;
+      }
       this._config = {
         accessToken: token.accessToken,
         tokenType: token.tokenType,
@@ -130,8 +136,8 @@ export class GitHubAuthManager {
       }
       return;
     } finally {
-      this._pending = null;
       if (this._signInController === controller) {
+        this._pending = null;
         this._signInController = null;
       }
     }
@@ -145,6 +151,7 @@ export class GitHubAuthManager {
     }
     this._signInController.abort();
     this._signInController = null;
+    this._pending = null;
     this._emit();
   }
 

--- a/apps/desktop/src/bun/auth/github-device-flow.test.ts
+++ b/apps/desktop/src/bun/auth/github-device-flow.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { fetchGithubUser } from "./github-device-flow";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -25,9 +31,66 @@ async function _captureRejection(promise: Promise<unknown>): Promise<unknown> {
 }
 
 describe("fetchGithubUser", () => {
+  test("always uses the proxy-routed global fetch", async () => {
+    globalThis.fetch = ((
+      input: string | URL | Request,
+      init?: RequestInit
+    ) => {
+      void input;
+      void init;
+      return Promise.resolve(
+        Response.json({
+          login: "global-user",
+          name: "Global User",
+          email: "global-user@example.com",
+          avatar_url: "https://avatars.githubusercontent.com/global-user",
+          html_url: "https://github.com/global-user",
+        })
+      );
+    }) as typeof fetch;
+    const bypassAttempt = ((
+      input: string | URL | Request,
+      init?: RequestInit
+    ) => {
+      void input;
+      void init;
+      return Promise.resolve(
+        Response.json({
+          login: "bypass-user",
+          name: "Bypass User",
+          email: "bypass-user@example.com",
+          avatar_url: "https://avatars.githubusercontent.com/bypass-user",
+          html_url: "https://github.com/bypass-user",
+        })
+      );
+    }) as typeof fetch;
+    const callFromUntypedRuntime = fetchGithubUser as unknown as (
+      accessToken: string,
+      signal: AbortSignal,
+      extraArgument: typeof fetch
+    ) => ReturnType<typeof fetchGithubUser>;
+
+    const user = await callFromUntypedRuntime(
+      "test-token",
+      new AbortController().signal,
+      bypassAttempt
+    );
+
+    expect(user).toEqual({
+      login: "global-user",
+      name: "Global User",
+      email: "global-user@example.com",
+      avatarUrl: "https://avatars.githubusercontent.com/global-user",
+      htmlUrl: "https://github.com/global-user",
+    });
+  });
+
   test("preserves AbortError when fallback email lookup is cancelled", async () => {
     const emailRequestStarted = _deferred<void>();
-    const fetchImpl = ((input: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = ((
+      input: string | URL | Request,
+      init?: RequestInit
+    ) => {
       const url =
         typeof input === "string"
           ? input
@@ -65,7 +128,7 @@ describe("fetchGithubUser", () => {
     }) as typeof fetch;
     const controller = new AbortController();
     const rejection = _captureRejection(
-      fetchGithubUser("test-token", controller.signal, fetchImpl)
+      fetchGithubUser("test-token", controller.signal)
     );
 
     await emailRequestStarted.promise;

--- a/apps/desktop/src/bun/auth/github-device-flow.test.ts
+++ b/apps/desktop/src/bun/auth/github-device-flow.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import { fetchGithubUser } from "./github-device-flow";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function _deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function _captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    throw new Error("Expected promise to reject");
+  } catch (error) {
+    return error;
+  }
+}
+
+describe("fetchGithubUser", () => {
+  test("preserves AbortError when fallback email lookup is cancelled", async () => {
+    const emailRequestStarted = _deferred<void>();
+    const fetchImpl = ((input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (url === "https://api.github.com/user") {
+        return Promise.resolve(
+          Response.json({
+            login: "octocat",
+            name: "The Octocat",
+            email: null,
+            avatar_url: "https://avatars.githubusercontent.com/u/583231",
+            html_url: "https://github.com/octocat",
+          })
+        );
+      }
+      if (url === "https://api.github.com/user/emails") {
+        emailRequestStarted.resolve(undefined);
+        const signal = init?.signal;
+        if (!signal) {
+          return Promise.reject(new Error("Fallback email request has no signal"));
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          const rejectAbort = () =>
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          if (signal.aborted) {
+            rejectAbort();
+          } else {
+            signal.addEventListener("abort", rejectAbort, { once: true });
+          }
+        });
+      }
+      return Promise.reject(new Error(`Unexpected GitHub URL: ${url}`));
+    }) as typeof fetch;
+    const controller = new AbortController();
+    const rejection = _captureRejection(
+      fetchGithubUser("test-token", controller.signal, fetchImpl)
+    );
+
+    await emailRequestStarted.promise;
+    controller.abort();
+
+    expect(await rejection).toMatchObject({ name: "AbortError" });
+  });
+});

--- a/apps/desktop/src/bun/auth/github-device-flow.ts
+++ b/apps/desktop/src/bun/auth/github-device-flow.ts
@@ -157,7 +157,8 @@ export async function pollForAccessToken(
 
 /** Fetch the authenticated user's public profile with a bearer token. */
 export async function fetchGithubUser(
-  accessToken: string
+  accessToken: string,
+  signal: AbortSignal
 ): Promise<GithubUser> {
   const response = await fetch(USER_URL, {
     headers: {
@@ -166,6 +167,7 @@ export async function fetchGithubUser(
       "User-Agent": USER_AGENT,
       "X-GitHub-Api-Version": "2022-11-28",
     },
+    signal,
   });
   if (!response.ok) {
     throw new DeviceFlowError(
@@ -180,7 +182,7 @@ export async function fetchGithubUser(
   const email =
     typeof data.email === "string" && data.email
       ? data.email
-      : await _fetchPrimaryEmail(accessToken);
+      : await _fetchPrimaryEmail(accessToken, signal);
   return {
     login,
     name: typeof data.name === "string" ? data.name : null,
@@ -191,7 +193,10 @@ export async function fetchGithubUser(
 }
 
 /** The user's primary (or first verified) email, best-effort; null on failure. */
-async function _fetchPrimaryEmail(accessToken: string): Promise<string | null> {
+async function _fetchPrimaryEmail(
+  accessToken: string,
+  signal: AbortSignal
+): Promise<string | null> {
   try {
     const response = await fetch(USER_EMAILS_URL, {
       headers: {
@@ -200,6 +205,7 @@ async function _fetchPrimaryEmail(accessToken: string): Promise<string | null> {
         "User-Agent": USER_AGENT,
         "X-GitHub-Api-Version": "2022-11-28",
       },
+      signal,
     });
     if (!response.ok) {
       return null;
@@ -214,7 +220,10 @@ async function _fetchPrimaryEmail(accessToken: string): Promise<string | null> {
       emails.find((e) => e.verified) ??
       emails[0];
     return typeof chosen?.email === "string" ? chosen.email : null;
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw error;
+    }
     return null;
   }
 }

--- a/apps/desktop/src/bun/auth/github-device-flow.ts
+++ b/apps/desktop/src/bun/auth/github-device-flow.ts
@@ -158,10 +158,9 @@ export async function pollForAccessToken(
 /** Fetch the authenticated user's public profile with a bearer token. */
 export async function fetchGithubUser(
   accessToken: string,
-  signal: AbortSignal,
-  fetchImpl: typeof fetch = fetch
+  signal: AbortSignal
 ): Promise<GithubUser> {
-  const response = await fetchImpl(USER_URL, {
+  const response = await fetch(USER_URL, {
     headers: {
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${accessToken}`,
@@ -183,7 +182,7 @@ export async function fetchGithubUser(
   const email =
     typeof data.email === "string" && data.email
       ? data.email
-      : await _fetchPrimaryEmail(accessToken, signal, fetchImpl);
+      : await _fetchPrimaryEmail(accessToken, signal);
   return {
     login,
     name: typeof data.name === "string" ? data.name : null,
@@ -196,11 +195,10 @@ export async function fetchGithubUser(
 /** The user's primary (or first verified) email, best-effort; null on failure. */
 async function _fetchPrimaryEmail(
   accessToken: string,
-  signal: AbortSignal,
-  fetchImpl: typeof fetch
+  signal: AbortSignal
 ): Promise<string | null> {
   try {
-    const response = await fetchImpl(USER_EMAILS_URL, {
+    const response = await fetch(USER_EMAILS_URL, {
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${accessToken}`,

--- a/apps/desktop/src/bun/auth/github-device-flow.ts
+++ b/apps/desktop/src/bun/auth/github-device-flow.ts
@@ -158,9 +158,10 @@ export async function pollForAccessToken(
 /** Fetch the authenticated user's public profile with a bearer token. */
 export async function fetchGithubUser(
   accessToken: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  fetchImpl: typeof fetch = fetch
 ): Promise<GithubUser> {
-  const response = await fetch(USER_URL, {
+  const response = await fetchImpl(USER_URL, {
     headers: {
       Accept: "application/vnd.github+json",
       Authorization: `Bearer ${accessToken}`,
@@ -182,7 +183,7 @@ export async function fetchGithubUser(
   const email =
     typeof data.email === "string" && data.email
       ? data.email
-      : await _fetchPrimaryEmail(accessToken, signal);
+      : await _fetchPrimaryEmail(accessToken, signal, fetchImpl);
   return {
     login,
     name: typeof data.name === "string" ? data.name : null,
@@ -195,10 +196,11 @@ export async function fetchGithubUser(
 /** The user's primary (or first verified) email, best-effort; null on failure. */
 async function _fetchPrimaryEmail(
   accessToken: string,
-  signal: AbortSignal
+  signal: AbortSignal,
+  fetchImpl: typeof fetch
 ): Promise<string | null> {
   try {
-    const response = await fetch(USER_EMAILS_URL, {
+    const response = await fetchImpl(USER_EMAILS_URL, {
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Root cause
Profile and fallback email requests outlived Device Flow cancellation. A stale profile completion could persist credentials and emit `signedIn` after cancellation.

## Changes
- Propagate the active Device Flow abort signal through profile and fallback-email requests.
- Preserve fallback-email `AbortError`s as cancellation.
- Commit credentials only when the originating controller remains current and active.
- Keep stale flows from clearing a newer flow's pending state.

## User impact
Cancelling or signing out during GitHub authentication now remains signed out and cannot create or restore stale credentials.

## Validation
- `/Users/minimax/.bun/bin/bun test apps/desktop/src/bun/auth/github-auth-manager.test.ts` (RED then GREEN)
- `/Users/minimax/.bun/bin/bun test` (387 pass)
- `/Users/minimax/.bun/bin/bun run lint`
- `/Users/minimax/.bun/bin/bun run typecheck`
- `git diff --check origin/main...HEAD`

Closes #110