### PR TITLE
fix(remote): terminate failed streams safely

### DIFF
--- a/apps/desktop/src/bun/remote/remote-runtime-client.test.ts
+++ b/apps/desktop/src/bun/remote/remote-runtime-client.test.ts
@@ -232,7 +232,86 @@ describe("RemoteRuntimeClient", () => {
 
     expect(events).toEqual([{ type: "agent_start" }]);
   });
+
+  test("does not complete after a remote stream error", async () => {
+    const messages: unknown[] = [];
+    await _withSseServer(
+      [
+        "data: [START]\n\n",
+        'data: {"type":"error","message":"Remote failed"}\n\n',
+        "data: [DONE]\n\n",
+      ],
+      async (baseUrl) => {
+        const client = new RemoteRuntimeClient({
+          id: "remote:test",
+          name: "Test Remote",
+          baseUrl,
+          token: "secret",
+        });
+        await client.streamThread(
+          { streamId: "s1", request: {} as AgentStreamRequest },
+          (message) => messages.push(message)
+        );
+      }
+    );
+
+    expect(messages).toEqual([
+      { streamId: "s1", type: "error", message: "Remote failed" },
+    ]);
+  });
+
+  test("rejects malformed SSE JSON", async () => {
+    await _withSseServer(
+      ["data: [START]\n\n", "data: {not valid JSON}\n\n"],
+      async (baseUrl) => {
+        const client = new RemoteRuntimeClient({
+          id: "remote:test",
+          name: "Test Remote",
+          baseUrl,
+          token: "secret",
+        });
+        let rejection: unknown;
+        try {
+          await client.streamThread(
+            { streamId: "s1", request: {} as AgentStreamRequest },
+            () => undefined
+          );
+        } catch (error) {
+          rejection = error;
+        }
+        expect(rejection).toBeInstanceOf(SyntaxError);
+      }
+    );
+  });
 });
+
+async function _withSseServer(
+  chunks: string[],
+  run: (baseUrl: string) => Promise<void>
+): Promise<void> {
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(encoder.encode(chunk));
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    },
+  });
+  try {
+    await run(`http://127.0.0.1:${server.port}`);
+  } finally {
+    await server.stop(true);
+  }
+}
 
 async function _withFetch(
   handler: (request: Request) => Response | Promise<Response>,

--- a/apps/desktop/src/bun/remote/remote-runtime-client.ts
+++ b/apps/desktop/src/bun/remote/remote-runtime-client.ts
@@ -201,7 +201,7 @@ export class RemoteRuntimeClient implements RuntimeClient {
           send({ streamId: payload.streamId, type: "event", event });
         }
       }
-      send({ streamId: payload.streamId, type: "done" });
+      throw new Error("Remote runtime stream ended before [DONE].");
     } finally {
       this._activeStreams.delete(payload.streamId);
     }

--- a/apps/desktop/src/bun/remote/remote-runtime-client.ts
+++ b/apps/desktop/src/bun/remote/remote-runtime-client.ts
@@ -196,6 +196,7 @@ export class RemoteRuntimeClient implements RuntimeClient {
             type: "error",
             message: event.message,
           });
+          return;
         } else {
           send({ streamId: payload.streamId, type: "event", event });
         }

--- a/apps/desktop/src/bun/rpc/index.ts
+++ b/apps/desktop/src/bun/rpc/index.ts
@@ -36,6 +36,7 @@ import type { UpdaterService } from "../updates";
 import { ensureRootDir } from "./ensure-root-dir";
 import { fsReveal } from "./fs-reveal";
 import { buildSharedThread } from "./share-thread";
+import { forwardStreamThread } from "./stream-thread-request";
 
 /**
  * The stream handler references its RPC instance inside the initializer, so an
@@ -440,8 +441,10 @@ export function createMainWindowRPC({
         sendStreamThreadRequest: (payload) => {
           // Fire-and-forget: stream events back as `receiveStreamThreadResponse`
           // messages. `rpc` is initialized by the time this handler runs.
-          void getRuntime(payload.runtimeId).streamThread(payload, (message) =>
-            rpc.send.receiveStreamThreadResponse(message)
+          void forwardStreamThread(
+            getRuntime(payload.runtimeId),
+            payload,
+            (message) => rpc.send.receiveStreamThreadResponse(message)
           );
         },
         abortStreamThread: (payload) =>

--- a/apps/desktop/src/bun/rpc/index.ts
+++ b/apps/desktop/src/bun/rpc/index.ts
@@ -442,7 +442,7 @@ export function createMainWindowRPC({
           // Fire-and-forget: stream events back as `receiveStreamThreadResponse`
           // messages. `rpc` is initialized by the time this handler runs.
           void forwardStreamThread(
-            getRuntime(payload.runtimeId),
+            () => getRuntime(payload.runtimeId),
             payload,
             (message) => rpc.send.receiveStreamThreadResponse(message)
           );

--- a/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
+++ b/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
@@ -19,19 +19,69 @@ function _createRuntime(error: Error): Pick<RuntimeClient, "streamThread"> {
 }
 
 describe("forwardStreamThread", () => {
+  test("emits a terminal error when runtime lookup fails", async () => {
+    const responses: StreamThreadResponsePayload[] = [];
+    await forwardStreamThread(
+      () => {
+        throw new Error("Runtime not found: remote:stale");
+      },
+      { streamId: "stream-1", request: REQUEST },
+      (message) => responses.push(message)
+    );
+
+    expect(responses).toEqual([
+      {
+        streamId: "stream-1",
+        type: "error",
+        message: "Runtime not found: remote:stale",
+      },
+    ]);
+  });
+
   test.each([
     ["network rejection", new Error("fetch failed")],
     ["malformed SSE JSON", new SyntaxError("Unexpected token '<'")],
   ])("emits one terminal error for a %s", async (_kind, error) => {
     const responses: StreamThreadResponsePayload[] = [];
     await forwardStreamThread(
-      _createRuntime(error) as RuntimeClient,
+      () => _createRuntime(error) as RuntimeClient,
       { streamId: "stream-1", request: REQUEST },
       (message) => responses.push(message)
     );
 
     expect(responses).toEqual([
       { streamId: "stream-1", type: "error", message: error.message },
+    ]);
+  });
+
+  test("emits an error when a remote stream ends before done", async () => {
+    const responses: StreamThreadResponsePayload[] = [];
+    await _withLiveSseServer(
+      async ({ baseUrl, closeStream, streamStarted }) => {
+        const client = new RemoteRuntimeClient({
+          id: "remote:test",
+          name: "Test Remote",
+          baseUrl,
+          token: "secret",
+        });
+        const completion = forwardStreamThread(
+          () => client,
+          { streamId: "stream-1", request: REQUEST },
+          (message) => responses.push(message)
+        );
+        await streamStarted;
+
+        closeStream();
+        await completion;
+      }
+    );
+
+    expect(responses).toEqual([
+      {
+        streamId: "stream-1",
+        type: "error",
+        message: "Remote runtime stream ended before [DONE].",
+      },
     ]);
   });
 
@@ -46,7 +96,7 @@ describe("forwardStreamThread", () => {
           token: "secret",
         });
         const completion = forwardStreamThread(
-          client,
+          () => client,
           { streamId: "stream-1", request: REQUEST },
           (message) => responses.push(message)
         );

--- a/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
+++ b/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentStreamRequest } from "@llm-space/core";
+import type { RuntimeClient } from "@llm-space/runtime/runtime";
+
+import type {
+  StreamThreadResponsePayload,
+} from "@/shared/rpc";
+
+import { forwardStreamThread } from "./stream-thread-request";
+
+const REQUEST: AgentStreamRequest = {
+  model: { provider: "test", id: "test" },
+  context: { messages: [], tools: [] },
+};
+
+function _createRuntime(error: Error): Pick<RuntimeClient, "streamThread"> {
+  return { streamThread: () => Promise.reject(error) };
+}
+
+describe("forwardStreamThread", () => {
+  test.each([
+    ["network rejection", new Error("fetch failed")],
+    ["malformed SSE JSON", new SyntaxError("Unexpected token '<'")],
+  ])("emits one terminal error for a %s", async (_kind, error) => {
+    const responses: StreamThreadResponsePayload[] = [];
+    await forwardStreamThread(
+      _createRuntime(error) as RuntimeClient,
+      { streamId: "stream-1", request: REQUEST },
+      (message) => responses.push(message)
+    );
+
+    expect(responses).toEqual([
+      { streamId: "stream-1", type: "error", message: error.message },
+    ]);
+  });
+
+  test("does not emit an error for an explicit abort", async () => {
+    const responses: StreamThreadResponsePayload[] = [];
+    await forwardStreamThread(
+      _createRuntime(new DOMException("Aborted", "AbortError")) as RuntimeClient,
+      { streamId: "stream-1", request: REQUEST },
+      (message) => responses.push(message)
+    );
+
+    expect(responses).toEqual([]);
+  });
+});

--- a/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
+++ b/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, test } from "bun:test";
 import type { AgentStreamRequest } from "@llm-space/core";
 import type { RuntimeClient } from "@llm-space/runtime/runtime";
 
-import type {
-  StreamThreadResponsePayload,
-} from "@/shared/rpc";
+import type { StreamThreadResponsePayload } from "@/shared/rpc";
+
+import { RemoteRuntimeClient } from "../remote/remote-runtime-client";
 
 import { forwardStreamThread } from "./stream-thread-request";
 
@@ -35,14 +35,100 @@ describe("forwardStreamThread", () => {
     ]);
   });
 
-  test("does not emit an error for an explicit abort", async () => {
+  test("aborts a live remote stream without emitting a response", async () => {
     const responses: StreamThreadResponsePayload[] = [];
-    await forwardStreamThread(
-      _createRuntime(new DOMException("Aborted", "AbortError")) as RuntimeClient,
-      { streamId: "stream-1", request: REQUEST },
-      (message) => responses.push(message)
+    await _withLiveSseServer(
+      async ({ baseUrl, closeStream, streamStarted }) => {
+        const client = new RemoteRuntimeClient({
+          id: "remote:test",
+          name: "Test Remote",
+          baseUrl,
+          token: "secret",
+        });
+        const completion = forwardStreamThread(
+          client,
+          { streamId: "stream-1", request: REQUEST },
+          (message) => responses.push(message)
+        );
+        await streamStarted;
+
+        client.abortStream({ streamId: "stream-1" });
+        try {
+          await _withTimeout(completion, 500);
+        } finally {
+          closeStream();
+          await completion;
+        }
+      }
     );
 
     expect(responses).toEqual([]);
   });
 });
+
+interface LiveSseServer {
+  baseUrl: string;
+  closeStream: () => void;
+  streamStarted: Promise<void>;
+}
+
+async function _withLiveSseServer(
+  run: (server: LiveSseServer) => Promise<void>
+): Promise<void> {
+  let closeStream = () => undefined;
+  let markStreamStarted = () => undefined;
+  const streamStarted = new Promise<void>((resolve) => {
+    markStreamStarted = resolve;
+  });
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: [START]\n\n"));
+          closeStream = () => {
+            try {
+              controller.close();
+            } catch {
+              // The client abort can close the server-side body first.
+            }
+          };
+          markStreamStarted();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    },
+  });
+  try {
+    await run({
+      baseUrl: `http://127.0.0.1:${server.port}`,
+      closeStream: () => closeStream(),
+      streamStarted,
+    });
+  } finally {
+    closeStream();
+    await server.stop(true);
+  }
+}
+
+async function _withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Timed out waiting for live stream abort")),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
+++ b/apps/desktop/src/bun/rpc/stream-thread-request.test.ts
@@ -76,7 +76,7 @@ async function _withLiveSseServer(
   run: (server: LiveSseServer) => Promise<void>
 ): Promise<void> {
   let closeStream = () => undefined;
-  let markStreamStarted = () => undefined;
+  let markStreamStarted: () => void = () => undefined;
   const streamStarted = new Promise<void>((resolve) => {
     markStreamStarted = resolve;
   });

--- a/apps/desktop/src/bun/rpc/stream-thread-request.ts
+++ b/apps/desktop/src/bun/rpc/stream-thread-request.ts
@@ -1,0 +1,29 @@
+import type { RuntimeClient } from "@llm-space/runtime/runtime";
+
+import type {
+  StreamThreadRequestPayload,
+  StreamThreadResponsePayload,
+} from "../../shared/rpc";
+
+export async function forwardStreamThread(
+  runtime: RuntimeClient,
+  payload: StreamThreadRequestPayload,
+  send: (message: StreamThreadResponsePayload) => void
+): Promise<void> {
+  try {
+    await runtime.streamThread(payload, send);
+  } catch (error) {
+    if (_isAbortError(error)) {
+      return;
+    }
+    send({
+      streamId: payload.streamId,
+      type: "error",
+      message: error instanceof Error ? error.message : "Internal error",
+    });
+  }
+}
+
+function _isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/apps/desktop/src/bun/rpc/stream-thread-request.ts
+++ b/apps/desktop/src/bun/rpc/stream-thread-request.ts
@@ -6,11 +6,12 @@ import type {
 } from "../../shared/rpc";
 
 export async function forwardStreamThread(
-  runtime: RuntimeClient,
+  getRuntime: () => RuntimeClient,
   payload: StreamThreadRequestPayload,
   send: (message: StreamThreadResponsePayload) => void
 ): Promise<void> {
   try {
+    const runtime = getRuntime();
     await runtime.streamThread(payload, send);
   } catch (error) {
     if (_isAbortError(error)) {


### PR DESCRIPTION
## Root cause

The desktop Bun RPC handler started RuntimeClient.streamThread() as fire-and-forget. Remote network, HTTP, and SSE parsing failures could reject without a terminal renderer response, leaving the renderer waiting and risking an unhandled rejection. Remote SSE error payloads also fell through to a subsequent done message.

## Changes

- Forward failed runtime stream rejections as exactly one terminal RPC error, while treating AbortError as an expected silent stop.
- Stop RemoteRuntimeClient immediately after an SSE error payload so it cannot emit done afterward.
- Add regression coverage for network rejection, malformed SSE JSON, explicit abort, and server-sent stream errors using a real local SSE server.

## Impact

Failed remote streams now terminate in the renderer with their error instead of hanging. Intentional cancellations remain silent.

## Validation

- /Users/minimax/.bun/bin/bun test apps/desktop/src/bun/rpc/stream-thread-request.test.ts apps/desktop/src/bun/remote/remote-runtime-client.test.ts apps/desktop/src/client/rpc-transport.test.ts — 18 passed
- /Users/minimax/.bun/bin/bun test — 391 passed, 0 failed
- /Users/minimax/.bun/bin/bun run lint — passed with zero warnings
- /Users/minimax/.bun/bin/bun run typecheck — passed
- git diff --check origin/main...HEAD — passed

Closes #105