### PR TITLE
fix(security): bind SSH trust to the approved host key

### DIFF
--- a/apps/desktop/src/bun/remote/remote-server-manager.test.ts
+++ b/apps/desktop/src/bun/remote/remote-server-manager.test.ts
@@ -719,6 +719,60 @@ describe("RemoteServerManager", () => {
     expect(connected[0]?.status).toBe("connected");
   });
 
+  test("does not start ssh runtime when host-key trust fails closed", async () => {
+    let startCount = 0;
+    const manager = _manager(
+      (config) => {
+        startCount += 1;
+        return Promise.resolve({
+          client: _remoteRuntime(config.id),
+          stop: () => Promise.resolve(),
+        });
+      },
+      undefined,
+      undefined,
+      {
+        check: () =>
+          Promise.resolve({
+            status: "first-time",
+            request: {
+              requestId: "trust-changed",
+              kind: "first-time",
+              target: "user@host",
+              host: "host",
+              user: "user",
+              keyType: "ssh-ed25519",
+              fingerprint: "SHA256:approved",
+              publicKeyLine: "host ssh-ed25519 APPROVED",
+            },
+          }),
+        trust: () =>
+          Promise.reject(new Error("SSH host key changed during trust.")),
+      }
+    );
+
+    const [server] = manager.addServer({
+      name: "host",
+      host: "host",
+      user: "user",
+    });
+    await manager.connectServer(server.id);
+
+    let trustError: unknown;
+    try {
+      await manager.trustServerHostKey(server.id, "trust-changed");
+    } catch (error) {
+      trustError = error;
+    }
+
+    expect(trustError).toBeInstanceOf(Error);
+    expect((trustError as Error).message).toBe(
+      "SSH host key changed during trust."
+    );
+    expect(startCount).toBe(0);
+    expect(manager.listServers()[0]?.status).toBe("trust-required");
+  });
+
   test("rejecting a changed host key does not start ssh runtime", async () => {
     let startCount = 0;
     let trustCount = 0;

--- a/apps/desktop/src/bun/remote/ssh-host-key-command.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key-command.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { runSshHostKeyCommand } from "./ssh-host-key-command";
+
+describe("runSshHostKeyCommand", () => {
+  test("settles after a bounded timeout when a descendant keeps stderr open", async () => {
+    const startedAt = performance.now();
+    const result = await _withDeadline(
+      runSshHostKeyCommand(
+        "/bin/sh",
+        ["-c", "(sleep 1) >&2 & while :; do :; done"],
+        { timeoutMs: 20, postKillDrainMs: 40 }
+      ),
+      300
+    );
+
+    expect(result.code).toBeNull();
+    expect(result.stderr).toContain("SSH host key probe timed out after 20ms.");
+    expect(performance.now() - startedAt).toBeLessThan(300);
+  });
+});
+
+async function _withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Command did not settle within ${timeoutMs}ms.`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/apps/desktop/src/bun/remote/ssh-host-key-command.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key-command.ts
@@ -1,0 +1,107 @@
+import { spawn } from "node:child_process";
+
+const DEFAULT_POST_KILL_DRAIN_MS = 250;
+const MAX_OUTPUT_LENGTH = 20_000;
+
+export interface SshHostKeyCommandOptions {
+  preserveOutputStart?: boolean;
+  timeoutMs?: number;
+  postKillDrainMs?: number;
+}
+
+export interface SshHostKeyCommandResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export async function runSshHostKeyCommand(
+  command: string,
+  args: string[],
+  options: SshHostKeyCommandOptions = {}
+): Promise<SshHostKeyCommandResult> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const postKillDrainMs = Math.max(
+    0,
+    options.postKillDrainMs ?? DEFAULT_POST_KILL_DRAIN_MS
+  );
+  const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  const appendStdout = (chunk: Buffer) => {
+    stdout = _appendOutput(stdout, chunk, options.preserveOutputStart === true);
+  };
+  const appendStderr = (chunk: Buffer) => {
+    stderr = _appendOutput(stderr, chunk, options.preserveOutputStart === true);
+  };
+  child.stdout?.on("data", appendStdout);
+  child.stderr?.on("data", appendStderr);
+
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+    let timedOut = false;
+    let postKillDrainTimer: ReturnType<typeof setTimeout> | undefined;
+    function cleanup(): void {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (postKillDrainTimer) clearTimeout(postKillDrainTimer);
+      child.removeListener("error", fail);
+      child.removeListener("close", close);
+      child.stdout?.removeListener("data", appendStdout);
+      child.stderr?.removeListener("data", appendStderr);
+    }
+    function settle(result: SshHostKeyCommandResult): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    }
+    function fail(error: Error): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      reject(error);
+    }
+    function buildResult(code: number | null): SshHostKeyCommandResult {
+      return {
+        code: timedOut ? null : code,
+        stdout,
+        stderr: timedOut
+          ? `${stderr}\nSSH host key probe timed out after ${timeoutMs}ms.`
+          : stderr,
+      };
+    }
+    function close(code: number | null): void {
+      settle(buildResult(code));
+    }
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      if (settled) return;
+      postKillDrainTimer = setTimeout(() => {
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        settle(buildResult(null));
+      }, postKillDrainMs);
+    }, timeoutMs);
+    child.once("error", fail);
+    child.once("close", close);
+  });
+}
+
+function _appendOutput(
+  current: string,
+  chunk: Buffer,
+  preserveStart: boolean
+): string {
+  const next = current + chunk.toString("utf8");
+  if (next.length <= MAX_OUTPUT_LENGTH) return next;
+  if (!preserveStart) return next.slice(-MAX_OUTPUT_LENGTH);
+
+  const marker = "\n... SSH output truncated ...\n";
+  const startLength = MAX_OUTPUT_LENGTH / 2;
+  const endLength = MAX_OUTPUT_LENGTH - startLength - marker.length;
+  return `${next.slice(0, startLength)}${marker}${next.slice(-endLength)}`;
+}

--- a/apps/desktop/src/bun/remote/ssh-host-key.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.test.ts
@@ -23,13 +23,17 @@ const CONFIG: Pick<SshRemoteRuntimeConfig, "host" | "port" | "user"> = {
 };
 
 const PUBLIC_KEY = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=";
-const APPROVED_PUBLIC_KEY = "YXBwcm92ZWQtaG9zdC1rZXktQQ==";
+// Disposable public host-key fixtures generated specifically for this test.
+const APPROVED_PUBLIC_KEY =
+  "AAAAC3NzaC1lZDI1NTE5AAAAIMWClLm642k5fDUelNUlE3uW88/ogeoX5EIKILobXc7A";
 const APPROVED_FINGERPRINT =
-  "SHA256:0+PCggjAR7ckC7d7kmOGGZOSJnzR8b/tLDxPGLwAXIo";
-const UNAPPROVED_PUBLIC_KEY = "dW5hcHByb3ZlZC1ob3N0LWtleS1C";
+  "SHA256:lGTUsW7JPjScNpoleUyyUfsRVyPN3zum2sOh8kX3D0Q";
+const UNAPPROVED_PUBLIC_KEY =
+  "AAAAC3NzaC1lZDI1NTE5AAAAIFN2zaqYUz8BS9QSM92UvdjzwXiOBwZokPiIeS+PDRkk";
 const UNAPPROVED_FINGERPRINT =
-  "SHA256:6G7x+IJxVNm/lEaE8KcEL2rSL7bbx2ajlhdRdoKLnPk";
-const PREVIOUS_PUBLIC_KEY = "cHJldmlvdXMtaG9zdC1rZXk=";
+  "SHA256:d1n12MYv9HCctUnqJO5LKg3j9ZDaJTQU9U2Mbt1v2Zs";
+const PREVIOUS_PUBLIC_KEY =
+  "AAAAC3NzaC1lZDI1NTE5AAAAIEGnEOIsKFobwDnd4yyLXW+lZ9N7P7HM4JyG72pImjxo";
 const HOST_ALIAS = "stable-host-alias";
 const CUSTOM_PORT = 2222;
 
@@ -109,13 +113,15 @@ describe("OpenSshHostKeyService", () => {
 
           expect(request).toMatchObject({
             kind,
+            resolvedHost: "203.0.113.10",
             port: CUSTOM_PORT,
             fingerprint: APPROVED_FINGERPRINT,
-            publicKeyLine: `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${APPROVED_PUBLIC_KEY}`,
+            publicKeyLine: `${HOST_ALIAS} ssh-ed25519 ${APPROVED_PUBLIC_KEY}`,
           });
 
           process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
-          process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE = `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${UNAPPROVED_PUBLIC_KEY}`;
+          process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY =
+            UNAPPROVED_PUBLIC_KEY;
           process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT =
             UNAPPROVED_FINGERPRINT;
 
@@ -143,9 +149,8 @@ describe("OpenSshHostKeyService", () => {
   test("rejects a public key that does not match the approved fingerprint", async () => {
     await _withFakeOpenSsh("first-time", async ({ service }) => {
       const request = await _checkForTrust(service);
-      request.publicKeyLine = `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${UNAPPROVED_PUBLIC_KEY}`;
+      request.publicKeyLine = `${HOST_ALIAS} ssh-ed25519 ${UNAPPROVED_PUBLIC_KEY}`;
       process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
-      process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE = request.publicKeyLine;
 
       expect(service.trust(SSH_CONFIG, request)).rejects.toThrow(
         "does not match the approved fingerprint"
@@ -175,8 +180,10 @@ describe("OpenSshHostKeyService", () => {
       async ({ knownHostsFile, service }) => {
         const request = await _checkForTrust(service);
         process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
-        process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE =
-          request.publicKeyLine;
+        process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY =
+          APPROVED_PUBLIC_KEY;
+        process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT =
+          APPROVED_FINGERPRINT;
         process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT = "1";
 
         await service.trust(SSH_CONFIG, request);
@@ -195,8 +202,10 @@ describe("OpenSshHostKeyService", () => {
         async ({ home, knownHostsFile, service }) => {
           const request = await _checkForTrust(service);
           process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
-          process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE =
-            request.publicKeyLine;
+          process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY =
+            APPROVED_PUBLIC_KEY;
+          process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT =
+            APPROVED_FINGERPRINT;
 
           await service.trust(SSH_CONFIG, request);
 
@@ -209,13 +218,29 @@ describe("OpenSshHostKeyService", () => {
           expect(backups).toHaveLength(kind === "changed" ? 1 : 0);
           if (kind === "changed") {
             expect(readFileSync(path.join(home, backups[0]), "utf8")).toBe(
-              `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${PREVIOUS_PUBLIC_KEY}\n`
+              `${HOST_ALIAS} ssh-ed25519 ${PREVIOUS_PUBLIC_KEY}\n`
             );
           }
         }
       );
     });
   }
+
+  test("preserves host-key diagnostics written after the child exits", async () => {
+    await _withFakeOpenSsh("first-time", async ({ service }) => {
+      const request = await _checkForTrust(service);
+      process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+      process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY =
+        UNAPPROVED_PUBLIC_KEY;
+      process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT =
+        UNAPPROVED_FINGERPRINT;
+      process.env.SSH_HOST_KEY_TEST_DELAYED_OUTPUT = "1";
+
+      expect(service.trust(SSH_CONFIG, request)).rejects.toThrow(
+        "REMOTE HOST IDENTIFICATION HAS CHANGED"
+      );
+    });
+  });
 });
 
 async function _checkForTrust(
@@ -246,12 +271,13 @@ async function _withFakeOpenSsh(
     knownHostsFile: process.env.SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE,
     approvedFingerprint: process.env.SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT,
     scanKeyLine: process.env.SSH_HOST_KEY_TEST_SCAN_KEY_LINE,
-    presentedKeyLine: process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE,
+    presentedPublicKey: process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY,
     presentedFingerprint:
       process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT,
     upstreamAuthFailure:
       process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE,
     longAuthOutput: process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT,
+    delayedOutput: process.env.SSH_HOST_KEY_TEST_DELAYED_OUTPUT,
   };
 
   try {
@@ -262,7 +288,7 @@ async function _withFakeOpenSsh(
     if (kind === "changed") {
       writeFileSync(
         knownHostsFile,
-        `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${PREVIOUS_PUBLIC_KEY}\n`,
+        `${HOST_ALIAS} ssh-ed25519 ${PREVIOUS_PUBLIC_KEY}\n`,
         "utf8"
       );
     }
@@ -273,10 +299,11 @@ async function _withFakeOpenSsh(
     process.env.SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE = knownHostsFile;
     process.env.SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT = APPROVED_FINGERPRINT;
     process.env.SSH_HOST_KEY_TEST_SCAN_KEY_LINE = `[203.0.113.10]:${CUSTOM_PORT} ssh-ed25519 ${APPROVED_PUBLIC_KEY}`;
-    delete process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE;
+    delete process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY;
     delete process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT;
     delete process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE;
     delete process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT;
+    delete process.env.SSH_HOST_KEY_TEST_DELAYED_OUTPUT;
 
     await run({
       home,
@@ -297,8 +324,8 @@ async function _withFakeOpenSsh(
     );
     _restoreEnv("SSH_HOST_KEY_TEST_SCAN_KEY_LINE", previousEnv.scanKeyLine);
     _restoreEnv(
-      "SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE",
-      previousEnv.presentedKeyLine
+      "SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY",
+      previousEnv.presentedPublicKey
     );
     _restoreEnv(
       "SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT",
@@ -311,6 +338,10 @@ async function _withFakeOpenSsh(
     _restoreEnv(
       "SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT",
       previousEnv.longAuthOutput
+    );
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_DELAYED_OUTPUT",
+      previousEnv.delayedOutput
     );
     rmSync(home, { recursive: true, force: true });
   }
@@ -377,9 +408,9 @@ fi
 if [ "$strict" = yes ]; then
   if [ "$SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE" = 1 ]; then
     printf 'jump@proxy: Permission denied (publickey).\n' >&2
-  elif [ -n "$user_known_hosts" ] && grep -F -x "$SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE" "$user_known_hosts" >/dev/null 2>&1; then
-    printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT" >&2
-    printf "debug1: Host '[${HOST_ALIAS}]:${CUSTOM_PORT}' is known and matches the ED25519 host key.\n" >&2
+  elif [ -n "$user_known_hosts" ] && grep -F -x "${HOST_ALIAS} ssh-ed25519 $SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY" "$user_known_hosts" >/dev/null 2>&1; then
+    printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT" >&2
+    printf "debug1: Host '${HOST_ALIAS}' is known and matches the ED25519 host key.\n" >&2
     if [ "$SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT" = 1 ]; then
       line=0
       while [ "$line" -lt 700 ]; do
@@ -389,15 +420,24 @@ if [ "$strict" = yes ]; then
     fi
     printf 'developer@devbox: Permission denied (publickey).\n' >&2
   else
-    printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT" >&2
-    printf '@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @\n' >&2
-    printf 'developer@devbox: Permission denied (publickey).\n' >&2
+    if [ "$SSH_HOST_KEY_TEST_DELAYED_OUTPUT" = 1 ]; then
+      (
+        sleep 0.05
+        printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT" >&2
+        printf '@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @\n' >&2
+        printf 'developer@devbox: Permission denied (publickey).\n' >&2
+      ) &
+    else
+      printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT" >&2
+      printf '@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @\n' >&2
+      printf 'developer@devbox: Permission denied (publickey).\n' >&2
+    fi
   fi
   exit 255
 fi
 
 if [ "$strict" = accept-new ]; then
-  printf '%s\n' "$SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE" >> "$SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE"
+  printf '${HOST_ALIAS} ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY" >> "$SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE"
   printf 'developer@devbox: Permission denied (publickey).\n' >&2
   exit 255
 fi

--- a/apps/desktop/src/bun/remote/ssh-host-key.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { RemoteHostKeyTrustRequest } from "../../shared/remote-servers";
 
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
-import { parseSshHostKeyOutput } from "./ssh-host-key";
+import { OpenSshHostKeyService, parseSshHostKeyOutput } from "./ssh-host-key";
 
 const CONFIG: Pick<SshRemoteRuntimeConfig, "host" | "port" | "user"> = {
   host: "203.0.113.10",
@@ -9,6 +23,29 @@ const CONFIG: Pick<SshRemoteRuntimeConfig, "host" | "port" | "user"> = {
 };
 
 const PUBLIC_KEY = "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=";
+const APPROVED_PUBLIC_KEY = "YXBwcm92ZWQtaG9zdC1rZXktQQ==";
+const APPROVED_FINGERPRINT =
+  "SHA256:0+PCggjAR7ckC7d7kmOGGZOSJnzR8b/tLDxPGLwAXIo";
+const UNAPPROVED_PUBLIC_KEY = "dW5hcHByb3ZlZC1ob3N0LWtleS1C";
+const UNAPPROVED_FINGERPRINT =
+  "SHA256:6G7x+IJxVNm/lEaE8KcEL2rSL7bbx2ajlhdRdoKLnPk";
+const PREVIOUS_PUBLIC_KEY = "cHJldmlvdXMtaG9zdC1rZXk=";
+const HOST_ALIAS = "stable-host-alias";
+const CUSTOM_PORT = 2222;
+
+const SSH_CONFIG: SshRemoteRuntimeConfig = {
+  id: "remote:ssh-host-key-test",
+  name: "SSH host key test",
+  host: "devbox",
+  user: "developer",
+  port: CUSTOM_PORT,
+  extraArgs: [],
+  remoteRepo: "",
+  remoteInstallDir: "~/.llm-space/remote-runtime",
+  remoteHome: "~/.llm-space-server",
+  remoteServerPort: 39123,
+  makeDefault: false,
+};
 
 describe("parseSshHostKeyOutput", () => {
   test("parses changed host key failures before authentication noise", () => {
@@ -61,3 +98,318 @@ devbox ssh-ed25519 ${PUBLIC_KEY}`,
     ).toBeNull();
   });
 });
+
+describe("OpenSshHostKeyService", () => {
+  for (const kind of ["first-time", "changed"] as const) {
+    test(`rejects a ${kind} host when the trust-time key differs from the approved key`, async () => {
+      await _withFakeOpenSsh(
+        kind,
+        async ({ home, knownHostsFile, service }) => {
+          const request = await _checkForTrust(service);
+
+          expect(request).toMatchObject({
+            kind,
+            port: CUSTOM_PORT,
+            fingerprint: APPROVED_FINGERPRINT,
+            publicKeyLine: `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${APPROVED_PUBLIC_KEY}`,
+          });
+
+          process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+          process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE = `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${UNAPPROVED_PUBLIC_KEY}`;
+          process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT =
+            UNAPPROVED_FINGERPRINT;
+
+          expect(service.trust(SSH_CONFIG, request)).rejects.toThrow(
+            "REMOTE HOST IDENTIFICATION HAS CHANGED"
+          );
+
+          const knownHosts = existsSync(knownHostsFile)
+            ? readFileSync(knownHostsFile, "utf8")
+            : "";
+          expect(knownHosts).not.toContain(UNAPPROVED_PUBLIC_KEY);
+          if (kind === "changed") {
+            expect(knownHosts).toContain(PREVIOUS_PUBLIC_KEY);
+          }
+          expect(
+            readdirSync(home).filter((name) =>
+              name.startsWith("known_hosts.llm-space-backup-")
+            )
+          ).toEqual([]);
+        }
+      );
+    });
+  }
+
+  test("rejects a public key that does not match the approved fingerprint", async () => {
+    await _withFakeOpenSsh("first-time", async ({ service }) => {
+      const request = await _checkForTrust(service);
+      request.publicKeyLine = `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${UNAPPROVED_PUBLIC_KEY}`;
+      process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+      process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE = request.publicKeyLine;
+
+      expect(service.trust(SSH_CONFIG, request)).rejects.toThrow(
+        "does not match the approved fingerprint"
+      );
+    });
+  });
+
+  test("does not treat upstream authentication failure as destination key verification", async () => {
+    await _withFakeOpenSsh(
+      "first-time",
+      async ({ knownHostsFile, service }) => {
+        const request = await _checkForTrust(service);
+        process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+        process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE = "1";
+
+        expect(service.trust(SSH_CONFIG, request)).rejects.toThrow(
+          "jump@proxy: Permission denied"
+        );
+        expect(existsSync(knownHostsFile)).toBe(false);
+      }
+    );
+  });
+
+  test("preserves authentication-failure behavior after verbose diagnostics", async () => {
+    await _withFakeOpenSsh(
+      "first-time",
+      async ({ knownHostsFile, service }) => {
+        const request = await _checkForTrust(service);
+        process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+        process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE =
+          request.publicKeyLine;
+        process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT = "1";
+
+        await service.trust(SSH_CONFIG, request);
+
+        expect(readFileSync(knownHostsFile, "utf8")).toBe(
+          `${request.publicKeyLine}\n`
+        );
+      }
+    );
+  });
+
+  for (const kind of ["first-time", "changed"] as const) {
+    test(`persists the approved ${kind} key after strict verification`, async () => {
+      await _withFakeOpenSsh(
+        kind,
+        async ({ home, knownHostsFile, service }) => {
+          const request = await _checkForTrust(service);
+          process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+          process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE =
+            request.publicKeyLine;
+
+          await service.trust(SSH_CONFIG, request);
+
+          expect(readFileSync(knownHostsFile, "utf8")).toBe(
+            `${request.publicKeyLine}\n`
+          );
+          const backups = readdirSync(home).filter((name) =>
+            name.startsWith("known_hosts.llm-space-backup-")
+          );
+          expect(backups).toHaveLength(kind === "changed" ? 1 : 0);
+          if (kind === "changed") {
+            expect(readFileSync(path.join(home, backups[0]), "utf8")).toBe(
+              `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${PREVIOUS_PUBLIC_KEY}\n`
+            );
+          }
+        }
+      );
+    });
+  }
+});
+
+async function _checkForTrust(
+  service: OpenSshHostKeyService
+): Promise<RemoteHostKeyTrustRequest> {
+  const result = await service.check(SSH_CONFIG);
+  if (result.status !== "first-time" && result.status !== "changed") {
+    throw new Error(`Expected a host-key trust request, got ${result.status}.`);
+  }
+  return result.request;
+}
+
+async function _withFakeOpenSsh(
+  kind: "first-time" | "changed",
+  run: (fixture: {
+    home: string;
+    knownHostsFile: string;
+    service: OpenSshHostKeyService;
+  }) => Promise<void>
+): Promise<void> {
+  const home = mkdtempSync(path.join(tmpdir(), "llm-space-ssh-host-key-test-"));
+  const knownHostsFile = path.join(home, "known_hosts");
+  const binDir = path.join(home, "bin");
+  const previousPath = process.env.PATH;
+  const previousEnv = {
+    phase: process.env.SSH_HOST_KEY_TEST_PHASE,
+    kind: process.env.SSH_HOST_KEY_TEST_KIND,
+    knownHostsFile: process.env.SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE,
+    approvedFingerprint: process.env.SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT,
+    scanKeyLine: process.env.SSH_HOST_KEY_TEST_SCAN_KEY_LINE,
+    presentedKeyLine: process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE,
+    presentedFingerprint:
+      process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT,
+    upstreamAuthFailure:
+      process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE,
+    longAuthOutput: process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT,
+  };
+
+  try {
+    mkdirSync(binDir);
+    _writeExecutable(path.join(binDir, "ssh"), FAKE_SSH);
+    _writeExecutable(path.join(binDir, "ssh-keyscan"), FAKE_SSH_KEYSCAN);
+    _writeExecutable(path.join(binDir, "ssh-keygen"), FAKE_SSH_KEYGEN);
+    if (kind === "changed") {
+      writeFileSync(
+        knownHostsFile,
+        `[${HOST_ALIAS}]:${CUSTOM_PORT} ssh-ed25519 ${PREVIOUS_PUBLIC_KEY}\n`,
+        "utf8"
+      );
+    }
+
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`;
+    process.env.SSH_HOST_KEY_TEST_PHASE = "check";
+    process.env.SSH_HOST_KEY_TEST_KIND = kind;
+    process.env.SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE = knownHostsFile;
+    process.env.SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT = APPROVED_FINGERPRINT;
+    process.env.SSH_HOST_KEY_TEST_SCAN_KEY_LINE = `[203.0.113.10]:${CUSTOM_PORT} ssh-ed25519 ${APPROVED_PUBLIC_KEY}`;
+    delete process.env.SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE;
+    delete process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT;
+    delete process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE;
+    delete process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT;
+
+    await run({
+      home,
+      knownHostsFile,
+      service: new OpenSshHostKeyService(),
+    });
+  } finally {
+    process.env.PATH = previousPath;
+    _restoreEnv("SSH_HOST_KEY_TEST_PHASE", previousEnv.phase);
+    _restoreEnv("SSH_HOST_KEY_TEST_KIND", previousEnv.kind);
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE",
+      previousEnv.knownHostsFile
+    );
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT",
+      previousEnv.approvedFingerprint
+    );
+    _restoreEnv("SSH_HOST_KEY_TEST_SCAN_KEY_LINE", previousEnv.scanKeyLine);
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE",
+      previousEnv.presentedKeyLine
+    );
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT",
+      previousEnv.presentedFingerprint
+    );
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE",
+      previousEnv.upstreamAuthFailure
+    );
+    _restoreEnv(
+      "SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT",
+      previousEnv.longAuthOutput
+    );
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function _writeExecutable(filePath: string, contents: string): void {
+  writeFileSync(filePath, contents, "utf8");
+  chmodSync(filePath, 0o700);
+}
+
+function _restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+const FAKE_SSH = `#!/bin/sh
+mode=connect
+strict=
+user_known_hosts=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -G)
+      mode=config
+      shift
+      ;;
+    -o)
+      case "$2" in
+        StrictHostKeyChecking=*) strict="\${2#*=}" ;;
+        UserKnownHostsFile=*) user_known_hosts="\${2#*=}" ;;
+      esac
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ "$mode" = config ]; then
+  printf 'hostname 203.0.113.10\n'
+  printf 'port ${CUSTOM_PORT}\n'
+  printf 'user developer\n'
+  printf 'hostkeyalias ${HOST_ALIAS}\n'
+  printf 'userknownhostsfile %s\n' "$SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE"
+  exit 0
+fi
+
+if [ "$SSH_HOST_KEY_TEST_PHASE" = check ]; then
+  if [ "$SSH_HOST_KEY_TEST_KIND" = changed ]; then
+    printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT" >&2
+    printf '@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @\n' >&2
+    printf 'Add correct host key in %s to get rid of this message.\n' "$SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE" >&2
+    printf 'Offending ED25519 key in %s:1\n' "$SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE" >&2
+  else
+    printf "The authenticity of host 'devbox' can't be established.\n" >&2
+    printf 'Host key verification failed.\n' >&2
+  fi
+  exit 255
+fi
+
+if [ "$strict" = yes ]; then
+  if [ "$SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE" = 1 ]; then
+    printf 'jump@proxy: Permission denied (publickey).\n' >&2
+  elif [ -n "$user_known_hosts" ] && grep -F -x "$SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE" "$user_known_hosts" >/dev/null 2>&1; then
+    printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT" >&2
+    printf "debug1: Host '[${HOST_ALIAS}]:${CUSTOM_PORT}' is known and matches the ED25519 host key.\n" >&2
+    if [ "$SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT" = 1 ]; then
+      line=0
+      while [ "$line" -lt 700 ]; do
+        printf 'debug1: verbose authentication diagnostic line %04d\n' "$line" >&2
+        line=$((line + 1))
+      done
+    fi
+    printf 'developer@devbox: Permission denied (publickey).\n' >&2
+  else
+    printf 'debug1: Server host key: ssh-ed25519 %s\n' "$SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT" >&2
+    printf '@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @\n' >&2
+    printf 'developer@devbox: Permission denied (publickey).\n' >&2
+  fi
+  exit 255
+fi
+
+if [ "$strict" = accept-new ]; then
+  printf '%s\n' "$SSH_HOST_KEY_TEST_PRESENTED_KEY_LINE" >> "$SSH_HOST_KEY_TEST_KNOWN_HOSTS_FILE"
+  printf 'developer@devbox: Permission denied (publickey).\n' >&2
+  exit 255
+fi
+
+printf 'unexpected ssh invocation\n' >&2
+exit 2
+`;
+
+const FAKE_SSH_KEYSCAN = `#!/bin/sh
+printf '%s\n' "$SSH_HOST_KEY_TEST_SCAN_KEY_LINE"
+`;
+
+const FAKE_SSH_KEYGEN = `#!/bin/sh
+printf 'Host not found in known_hosts\n'
+`;

--- a/apps/desktop/src/bun/remote/ssh-host-key.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.test.ts
@@ -15,7 +15,11 @@ import path from "node:path";
 import type { RemoteHostKeyTrustRequest } from "../../shared/remote-servers";
 
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
-import { OpenSshHostKeyService, parseSshHostKeyOutput } from "./ssh-host-key";
+import {
+  OpenSshHostKeyService,
+  parseSshHostKeyOutput,
+  runSshHostKeyCommand,
+} from "./ssh-host-key";
 
 const CONFIG: Pick<SshRemoteRuntimeConfig, "host" | "port" | "user"> = {
   host: "203.0.113.10",
@@ -100,6 +104,26 @@ devbox ssh-ed25519 ${PUBLIC_KEY}`,
         CONFIG
       )
     ).toBeNull();
+  });
+});
+
+describe("runSshHostKeyCommand", () => {
+  test("settles after a bounded timeout when a descendant keeps stderr open", async () => {
+    const startedAt = performance.now();
+    const result = await _withDeadline(
+      runSshHostKeyCommand(
+        "/bin/sh",
+        ["-c", "(sleep 1) >&2 & while :; do :; done"],
+        { timeoutMs: 20, postKillDrainMs: 40 }
+      ),
+      300
+    );
+
+    expect(result.code).toBeNull();
+    expect(result.stderr).toContain(
+      "SSH host key probe timed out after 20ms."
+    );
+    expect(performance.now() - startedAt).toBeLessThan(300);
   });
 });
 
@@ -357,6 +381,24 @@ function _restoreEnv(name: string, value: string | undefined): void {
     delete process.env[name];
   } else {
     process.env[name] = value;
+  }
+}
+
+async function _withDeadline<T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Command did not settle within ${timeoutMs}ms.`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/apps/desktop/src/bun/remote/ssh-host-key.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.test.ts
@@ -15,11 +15,7 @@ import path from "node:path";
 import type { RemoteHostKeyTrustRequest } from "../../shared/remote-servers";
 
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
-import {
-  OpenSshHostKeyService,
-  parseSshHostKeyOutput,
-  runSshHostKeyCommand,
-} from "./ssh-host-key";
+import { OpenSshHostKeyService, parseSshHostKeyOutput } from "./ssh-host-key";
 
 const CONFIG: Pick<SshRemoteRuntimeConfig, "host" | "port" | "user"> = {
   host: "203.0.113.10",
@@ -107,26 +103,6 @@ devbox ssh-ed25519 ${PUBLIC_KEY}`,
   });
 });
 
-describe("runSshHostKeyCommand", () => {
-  test("settles after a bounded timeout when a descendant keeps stderr open", async () => {
-    const startedAt = performance.now();
-    const result = await _withDeadline(
-      runSshHostKeyCommand(
-        "/bin/sh",
-        ["-c", "(sleep 1) >&2 & while :; do :; done"],
-        { timeoutMs: 20, postKillDrainMs: 40 }
-      ),
-      300
-    );
-
-    expect(result.code).toBeNull();
-    expect(result.stderr).toContain(
-      "SSH host key probe timed out after 20ms."
-    );
-    expect(performance.now() - startedAt).toBeLessThan(300);
-  });
-});
-
 describe("OpenSshHostKeyService", () => {
   for (const kind of ["first-time", "changed"] as const) {
     test(`rejects a ${kind} host when the trust-time key differs from the approved key`, async () => {
@@ -196,6 +172,61 @@ describe("OpenSshHostKeyService", () => {
         expect(existsSync(knownHostsFile)).toBe(false);
       }
     );
+  });
+
+  test("rejects a successful multiplexed probe without approved-key evidence", async () => {
+    await _withFakeOpenSsh(
+      "first-time",
+      async ({ knownHostsFile, service }) => {
+        const request = await _checkForTrust(service);
+        process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+        process.env.SSH_HOST_KEY_TEST_REUSED_MASTER = "1";
+
+        expect(service.trust(SSH_CONFIG, request)).rejects.toThrow(
+          "approved SSH host key"
+        );
+        expect(existsSync(knownHostsFile)).toBe(false);
+      }
+    );
+  });
+
+  test("forces fresh host-key verification before user SSH options", async () => {
+    await _withFakeOpenSsh("first-time", async ({ home, service }) => {
+      const request = await _checkForTrust(service);
+      const optionsFile = path.join(home, "effective-options");
+      process.env.SSH_HOST_KEY_TEST_PHASE = "trust";
+      process.env.SSH_HOST_KEY_TEST_OPTIONS_FILE = optionsFile;
+      process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY = APPROVED_PUBLIC_KEY;
+      process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT =
+        APPROVED_FINGERPRINT;
+
+      await service.trust(
+        {
+          ...SSH_CONFIG,
+          extraArgs: [
+            "-M",
+            "-S",
+            "/tmp/direct-reused-ssh-master",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            "ControlPath=/tmp/reused-ssh-master",
+            "-o",
+            "VerifyHostKeyDNS=yes",
+          ],
+        },
+        request
+      );
+
+      expect(readFileSync(optionsFile, "utf8")).toBe(
+        [
+          "control_master=no",
+          "control_path=none",
+          "verify_host_key_dns=no",
+          "",
+        ].join("\n")
+      );
+    });
   });
 
   test("preserves authentication-failure behavior after verbose diagnostics", async () => {
@@ -296,12 +327,12 @@ async function _withFakeOpenSsh(
     approvedFingerprint: process.env.SSH_HOST_KEY_TEST_APPROVED_FINGERPRINT,
     scanKeyLine: process.env.SSH_HOST_KEY_TEST_SCAN_KEY_LINE,
     presentedPublicKey: process.env.SSH_HOST_KEY_TEST_PRESENTED_PUBLIC_KEY,
-    presentedFingerprint:
-      process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT,
-    upstreamAuthFailure:
-      process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE,
+    presentedFingerprint: process.env.SSH_HOST_KEY_TEST_PRESENTED_FINGERPRINT,
+    upstreamAuthFailure: process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE,
     longAuthOutput: process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT,
     delayedOutput: process.env.SSH_HOST_KEY_TEST_DELAYED_OUTPUT,
+    reusedMaster: process.env.SSH_HOST_KEY_TEST_REUSED_MASTER,
+    optionsFile: process.env.SSH_HOST_KEY_TEST_OPTIONS_FILE,
   };
 
   try {
@@ -328,6 +359,8 @@ async function _withFakeOpenSsh(
     delete process.env.SSH_HOST_KEY_TEST_UPSTREAM_AUTH_FAILURE;
     delete process.env.SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT;
     delete process.env.SSH_HOST_KEY_TEST_DELAYED_OUTPUT;
+    delete process.env.SSH_HOST_KEY_TEST_REUSED_MASTER;
+    delete process.env.SSH_HOST_KEY_TEST_OPTIONS_FILE;
 
     await run({
       home,
@@ -363,10 +396,9 @@ async function _withFakeOpenSsh(
       "SSH_HOST_KEY_TEST_LONG_AUTH_OUTPUT",
       previousEnv.longAuthOutput
     );
-    _restoreEnv(
-      "SSH_HOST_KEY_TEST_DELAYED_OUTPUT",
-      previousEnv.delayedOutput
-    );
+    _restoreEnv("SSH_HOST_KEY_TEST_DELAYED_OUTPUT", previousEnv.delayedOutput);
+    _restoreEnv("SSH_HOST_KEY_TEST_REUSED_MASTER", previousEnv.reusedMaster);
+    _restoreEnv("SSH_HOST_KEY_TEST_OPTIONS_FILE", previousEnv.optionsFile);
     rmSync(home, { recursive: true, force: true });
   }
 }
@@ -384,28 +416,13 @@ function _restoreEnv(name: string, value: string | undefined): void {
   }
 }
 
-async function _withDeadline<T>(
-  promise: Promise<T>,
-  timeoutMs: number
-): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(new Error(`Command did not settle within ${timeoutMs}ms.`));
-    }, timeoutMs);
-  });
-
-  try {
-    return await Promise.race([promise, deadline]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
 const FAKE_SSH = `#!/bin/sh
 mode=connect
 strict=
 user_known_hosts=
+control_master=
+control_path=
+verify_host_key_dns=
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -G)
@@ -414,9 +431,30 @@ while [ "$#" -gt 0 ]; do
       ;;
     -o)
       case "$2" in
-        StrictHostKeyChecking=*) strict="\${2#*=}" ;;
-        UserKnownHostsFile=*) user_known_hosts="\${2#*=}" ;;
+        StrictHostKeyChecking=*)
+          [ -n "$strict" ] || strict="\${2#*=}"
+          ;;
+        UserKnownHostsFile=*)
+          [ -n "$user_known_hosts" ] || user_known_hosts="\${2#*=}"
+          ;;
+        ControlMaster=*)
+          [ -n "$control_master" ] || control_master="\${2#*=}"
+          ;;
+        ControlPath=*)
+          [ -n "$control_path" ] || control_path="\${2#*=}"
+          ;;
+        VerifyHostKeyDNS=*)
+          [ -n "$verify_host_key_dns" ] || verify_host_key_dns="\${2#*=}"
+          ;;
       esac
+      shift 2
+      ;;
+    -M)
+      control_master=yes
+      shift
+      ;;
+    -S)
+      control_path="$2"
       shift 2
       ;;
     *)
@@ -445,6 +483,16 @@ if [ "$SSH_HOST_KEY_TEST_PHASE" = check ]; then
     printf 'Host key verification failed.\n' >&2
   fi
   exit 255
+fi
+
+if [ -n "$SSH_HOST_KEY_TEST_OPTIONS_FILE" ]; then
+  printf 'control_master=%s\n' "$control_master" > "$SSH_HOST_KEY_TEST_OPTIONS_FILE"
+  printf 'control_path=%s\n' "$control_path" >> "$SSH_HOST_KEY_TEST_OPTIONS_FILE"
+  printf 'verify_host_key_dns=%s\n' "$verify_host_key_dns" >> "$SSH_HOST_KEY_TEST_OPTIONS_FILE"
+fi
+
+if [ "$SSH_HOST_KEY_TEST_REUSED_MASTER" = 1 ]; then
+  exit 0
 fi
 
 if [ "$strict" = yes ]; then

--- a/apps/desktop/src/bun/remote/ssh-host-key.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.ts
@@ -9,6 +9,8 @@ import type { RemoteHostKeyTrustRequest } from "../../shared/remote-servers";
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
 import { buildSshBaseArgs, buildSshTarget } from "./ssh-command";
 
+const DEFAULT_POST_KILL_DRAIN_MS = 250;
+
 export type SshHostKeyCheckResult =
   | { status: "trusted" }
   | { status: "first-time"; request: RemoteHostKeyTrustRequest }
@@ -28,7 +30,7 @@ export class OpenSshHostKeyService implements SshHostKeyService {
     const target = buildSshTarget(config);
     const baseArgs = buildSshBaseArgs(config);
     const resolved = await _resolveSshConfig(config).catch(() => undefined);
-    const probe = await _run("ssh", [
+    const probe = await runSshHostKeyCommand("ssh", [
       ...baseArgs.slice(0, -1),
       "-o",
       "BatchMode=yes",
@@ -146,7 +148,7 @@ async function _connectWithApprovedHostKey(
 ): Promise<void> {
   const target = buildSshTarget(config);
   const baseArgs = buildSshBaseArgs(config);
-  const result = await _run(
+  const result = await runSshHostKeyCommand(
     "ssh",
     [
       "-o",
@@ -286,7 +288,12 @@ async function _removeKnownHost(
   const host = request.resolvedHost ?? config.host;
   const lookupHost =
     request.hostKeyAlias ?? _knownHostsHost(host, request.port ?? config.port);
-  const result = await _run("ssh-keygen", ["-R", lookupHost, "-f", knownHostsFile]);
+  const result = await runSshHostKeyCommand("ssh-keygen", [
+    "-R",
+    lookupHost,
+    "-f",
+    knownHostsFile,
+  ]);
   const output = `${result.stdout}${result.stderr}`;
   if (result.code === 0 && !/not found/i.test(output)) {
     return;
@@ -409,7 +416,7 @@ async function _scanPublicKeyLine(
 ): Promise<string | undefined> {
   const host = resolved?.hostname ?? request.resolvedHost ?? config.host;
   const port = resolved?.port ?? request.port ?? config.port;
-  const result = await _run("ssh-keyscan", [
+  const result = await runSshHostKeyCommand("ssh-keyscan", [
     ...(port ? ["-p", String(port)] : []),
     "-T",
     "10",
@@ -439,7 +446,7 @@ async function _scanKey(
 ): Promise<Omit<RemoteHostKeyTrustRequest, "requestId" | "target" | "host" | "user" | "kind"> | undefined> {
   const host = resolved?.hostname ?? config.host;
   const port = resolved?.port ?? config.port;
-  const result = await _run("ssh-keyscan", [
+  const result = await runSshHostKeyCommand("ssh-keyscan", [
     ...(port ? ["-p", String(port)] : []),
     "-T",
     "10",
@@ -474,7 +481,11 @@ async function _resolveSshConfig(
 ): Promise<ResolvedSshConfig> {
   const baseArgs = buildSshBaseArgs(config);
   const target = buildSshTarget(config);
-  const result = await _run("ssh", [...baseArgs.slice(0, -1), "-G", target]);
+  const result = await runSshHostKeyCommand("ssh", [
+    ...baseArgs.slice(0, -1),
+    "-G",
+    target,
+  ]);
   if (result.code !== 0) return {};
 
   const resolved: ResolvedSshConfig = {};
@@ -528,12 +539,20 @@ function _fingerprint(publicKey: string): string {
   return `SHA256:${digest}`;
 }
 
-async function _run(
+export async function runSshHostKeyCommand(
   command: string,
   args: string[],
-  options: { preserveOutputStart?: boolean; timeoutMs?: number } = {}
+  options: {
+    preserveOutputStart?: boolean;
+    timeoutMs?: number;
+    postKillDrainMs?: number;
+  } = {}
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   const timeoutMs = options.timeoutMs ?? 15_000;
+  const postKillDrainMs = Math.max(
+    0,
+    options.postKillDrainMs ?? DEFAULT_POST_KILL_DRAIN_MS
+  );
   const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
   let stdout = "";
   let stderr = "";
@@ -549,34 +568,60 @@ async function _run(
   return await new Promise((resolve, reject) => {
     let settled = false;
     let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, timeoutMs);
-    const settle = (
+    let postKillDrainTimer: ReturnType<typeof setTimeout> | undefined;
+    function cleanup(): void {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (postKillDrainTimer) clearTimeout(postKillDrainTimer);
+      child.removeListener("error", fail);
+      child.removeListener("close", close);
+      child.stdout?.removeListener("data", appendStdout);
+      child.stderr?.removeListener("data", appendStderr);
+    }
+    function settle(
       result: { code: number | null; stdout: string; stderr: string }
-    ) => {
+    ): void {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
       resolve(result);
-    };
-    const fail = (error: Error) => {
+    }
+    function fail(error: Error): void {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      cleanup();
+      child.stdout?.destroy();
+      child.stderr?.destroy();
       reject(error);
-    };
-    child.once("error", fail);
-    child.once("close", (code) => {
-      settle({
+    }
+    function buildResult(code: number | null): {
+      code: number | null;
+      stdout: string;
+      stderr: string;
+    } {
+      return {
         code: timedOut ? null : code,
         stdout,
         stderr: timedOut
           ? `${stderr}\nSSH host key probe timed out after ${timeoutMs}ms.`
           : stderr,
-      });
-    });
+      };
+    }
+    function close(code: number | null): void {
+      settle(buildResult(code));
+    }
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      if (settled) return;
+      postKillDrainTimer = setTimeout(() => {
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        settle(buildResult(null));
+      }, postKillDrainMs);
+    }, timeoutMs);
+    child.once("error", fail);
+    child.once("close", close);
   });
 }
 

--- a/apps/desktop/src/bun/remote/ssh-host-key.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.ts
@@ -225,7 +225,7 @@ function _approvedPublicKeyLine(request: RemoteHostKeyTrustRequest): string {
 
 export function parseSshHostKeyOutput(
   output: string,
-  config: Pick<SshRemoteRuntimeConfig, "host" | "port" | "user">
+  config: SshHostKeyLookup
 ): Omit<RemoteHostKeyTrustRequest, "requestId" | "target" | "host" | "user"> | null {
   const key = _parseServerKey(output);
   const changed = _isChangedHostKey(output);
@@ -235,13 +235,14 @@ export function parseSshHostKeyOutput(
   const offending = /Offending \S+ key in ([^:\n]+):(\d+)/i.exec(output);
   const knownHostsFile = offending?.[1] ?? _knownHostsFileFromOutput(output);
   const knownHostsLine = offending?.[2] ? Number(offending[2]) : undefined;
-  const lookupHost = _knownHostsHost(config.host, config.port);
+  const lookupHost = _knownHostsLookupHost(config);
   const publicKeyLine = key.publicKey
     ? `${lookupHost} ${key.keyType} ${key.publicKey}`
     : undefined;
   return {
     kind: changed ? "changed" : "first-time",
     resolvedHost: config.host,
+    hostKeyAlias: config.hostKeyAlias,
     port: config.port,
     keyType: key.keyType,
     fingerprint: key.fingerprint,
@@ -266,6 +267,13 @@ interface ResolvedSshConfig {
   userKnownHostsFile?: string;
 }
 
+interface SshHostKeyLookup {
+  host: string;
+  port?: number;
+  user?: string;
+  hostKeyAlias?: string;
+}
+
 async function _removeKnownHost(
   config: SshRemoteRuntimeConfig,
   request: RemoteHostKeyTrustRequest,
@@ -276,7 +284,8 @@ async function _removeKnownHost(
   }
 
   const host = request.resolvedHost ?? config.host;
-  const lookupHost = _knownHostsHost(host, request.port ?? config.port);
+  const lookupHost =
+    request.hostKeyAlias ?? _knownHostsHost(host, request.port ?? config.port);
   const result = await _run("ssh-keygen", ["-R", lookupHost, "-f", knownHostsFile]);
   const output = `${result.stdout}${result.stderr}`;
   if (result.code === 0 && !/not found/i.test(output)) {
@@ -356,6 +365,10 @@ function _knownHostsHost(host: string, port: number | undefined): string {
   return port && port !== 22 ? `[${host}]:${port}` : host;
 }
 
+function _knownHostsLookupHost(lookup: SshHostKeyLookup): string {
+  return lookup.hostKeyAlias ?? _knownHostsHost(lookup.host, lookup.port);
+}
+
 function _expandHome(input: string): string {
   if (input === "~") return os.homedir();
   if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
@@ -403,7 +416,11 @@ async function _scanPublicKeyLine(
     host,
   ]);
   if (result.code !== 0 && !result.stdout.trim()) return undefined;
-  const lookupHost = _knownHostsHost(resolved?.hostKeyAlias ?? host, port);
+  const lookupHost = _knownHostsLookupHost({
+    host,
+    port,
+    hostKeyAlias: resolved?.hostKeyAlias,
+  });
   for (const line of result.stdout.split(/\r?\n/)) {
     const parts = line.trim().split(/\s+/);
     if (parts.length < 3) continue;
@@ -429,7 +446,11 @@ async function _scanKey(
     host,
   ]);
   if (result.code !== 0 && !result.stdout.trim()) return undefined;
-  const lookupHost = _knownHostsHost(resolved?.hostKeyAlias ?? host, port);
+  const lookupHost = _knownHostsLookupHost({
+    host,
+    port,
+    hostKeyAlias: resolved?.hostKeyAlias,
+  });
   for (const line of result.stdout.split(/\r?\n/)) {
     const parts = line.trim().split(/\s+/);
     if (parts.length < 3) continue;
@@ -437,6 +458,7 @@ async function _scanKey(
     if (!keyType || !publicKey) continue;
     return {
       resolvedHost: host,
+      hostKeyAlias: resolved?.hostKeyAlias,
       port,
       keyType,
       fingerprint: _fingerprint(publicKey),
@@ -483,11 +505,12 @@ async function _resolveSshConfig(
 function _hostKeyLookup(
   config: SshRemoteRuntimeConfig,
   resolved: ResolvedSshConfig | undefined
-): Pick<SshRemoteRuntimeConfig, "host" | "port" | "user"> {
+): SshHostKeyLookup {
   return {
-    host: resolved?.hostKeyAlias ?? resolved?.hostname ?? config.host,
+    host: resolved?.hostname ?? config.host,
     port: resolved?.port ?? config.port,
     user: resolved?.user ?? config.user,
+    hostKeyAlias: resolved?.hostKeyAlias,
   };
 }
 
@@ -524,17 +547,35 @@ async function _run(
   child.stderr?.on("data", appendStderr);
 
   return await new Promise((resolve, reject) => {
+    let settled = false;
+    let timedOut = false;
     const timer = setTimeout(() => {
+      timedOut = true;
       child.kill("SIGKILL");
-      resolve({ code: null, stdout, stderr: `${stderr}\nSSH host key probe timed out after ${timeoutMs}ms.` });
     }, timeoutMs);
-    child.once("error", (error) => {
+    const settle = (
+      result: { code: number | null; stdout: string; stderr: string }
+    ) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       reject(error);
-    });
-    child.once("exit", (code) => {
-      clearTimeout(timer);
-      resolve({ code, stdout, stderr });
+    };
+    child.once("error", fail);
+    child.once("close", (code) => {
+      settle({
+        code: timedOut ? null : code,
+        stdout,
+        stderr: timedOut
+          ? `${stderr}\nSSH host key probe timed out after ${timeoutMs}ms.`
+          : stderr,
+      });
     });
   });
 }

--- a/apps/desktop/src/bun/remote/ssh-host-key.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -91,6 +91,9 @@ export class OpenSshHostKeyService implements SshHostKeyService {
     config: SshRemoteRuntimeConfig,
     request: RemoteHostKeyTrustRequest
   ): Promise<void> {
+    const publicKeyLine = _approvedPublicKeyLine(request);
+    await _verifyApprovedHostKey(config, publicKeyLine);
+
     const knownHostsFile = _expandHome(
       request.knownHostsFile ?? "~/.ssh/known_hosts"
     );
@@ -103,45 +106,121 @@ export class OpenSshHostKeyService implements SshHostKeyService {
       await _removeKnownHost(config, request, knownHostsFile);
     }
 
-    await _acceptHostKey(config).catch((error) => {
-      const publicKeyLine = request.publicKeyLine;
-      if (!publicKeyLine) throw error;
-
-      const current = existsSync(knownHostsFile)
-        ? readFileSync(knownHostsFile, "utf8")
-        : "";
-      if (_hasKnownHostLine(current, publicKeyLine)) return;
-      const prefix = current.length > 0 && !current.endsWith("\n") ? "\n" : "";
-      writeFileSync(
-        knownHostsFile,
-        `${current}${prefix}${publicKeyLine}\n`,
-        "utf8"
-      );
-    });
+    const current = existsSync(knownHostsFile)
+      ? readFileSync(knownHostsFile, "utf8")
+      : "";
+    if (_hasKnownHostLine(current, publicKeyLine)) return;
+    const prefix = current.length > 0 && !current.endsWith("\n") ? "\n" : "";
+    writeFileSync(
+      knownHostsFile,
+      `${current}${prefix}${publicKeyLine}\n`,
+      "utf8"
+    );
   }
 }
 
-async function _acceptHostKey(config: SshRemoteRuntimeConfig): Promise<void> {
+async function _verifyApprovedHostKey(
+  config: SshRemoteRuntimeConfig,
+  publicKeyLine: string
+): Promise<void> {
+  const temporaryDirectory = mkdtempSync(
+    path.join(os.tmpdir(), "llm-space-approved-host-key-")
+  );
+  const knownHostsFile = path.join(temporaryDirectory, "known_hosts");
+
+  try {
+    writeFileSync(knownHostsFile, `${publicKeyLine}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await _connectWithApprovedHostKey(config, knownHostsFile, publicKeyLine);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function _connectWithApprovedHostKey(
+  config: SshRemoteRuntimeConfig,
+  knownHostsFile: string,
+  publicKeyLine: string
+): Promise<void> {
   const target = buildSshTarget(config);
   const baseArgs = buildSshBaseArgs(config);
-  const result = await _run("ssh", [
-    ...baseArgs.slice(0, -1),
-    "-o",
-    "StrictHostKeyChecking=accept-new",
-    "-o",
-    "BatchMode=yes",
-    "-o",
-    "ConnectTimeout=10",
-    "-o",
-    "NumberOfPasswordPrompts=0",
-    target,
-    "true",
-  ]);
+  const result = await _run(
+    "ssh",
+    [
+      "-o",
+      "StrictHostKeyChecking=yes",
+      "-o",
+      `UserKnownHostsFile=${knownHostsFile}`,
+      "-o",
+      `GlobalKnownHostsFile=${os.devNull}`,
+      "-o",
+      "KnownHostsCommand=none",
+      "-o",
+      "LogLevel=DEBUG1",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-o",
+      "NumberOfPasswordPrompts=0",
+      ...baseArgs.slice(0, -1),
+      target,
+      "true",
+    ],
+    { preserveOutputStart: true }
+  );
   const output = `${result.stdout}${result.stderr}`;
-  if (result.code === 0 || _isAuthenticationFailure(output)) return;
+  if (result.code === 0) return;
+  if (
+    !_isChangedHostKey(output) &&
+    !_isFirstTimeHostKey(output) &&
+    _isAuthenticationFailure(output) &&
+    _hasApprovedHostKeyMatch(output, publicKeyLine)
+  ) {
+    return;
+  }
   throw new Error(
     output.trim() || `SSH host key trust failed with exit code ${result.code}.`
   );
+}
+
+function _hasApprovedHostKeyMatch(
+  output: string,
+  publicKeyLine: string
+): boolean {
+  const [lookupHost, , publicKey] = publicKeyLine.split(/\s+/);
+  if (!lookupHost || !publicKey) return false;
+  const fingerprint = _fingerprint(publicKey);
+  const serverKeyMatches = output.split(/\r?\n/).some((line) => {
+    const match = /^debug1: Server host key:\s+\S+\s+(SHA256:[A-Za-z0-9+/=]+)/i.exec(
+      line
+    );
+    return match?.[1] === fingerprint;
+  });
+  return (
+    serverKeyMatches &&
+    output.includes(`Host '${lookupHost}' is known and matches the `)
+  );
+}
+
+function _approvedPublicKeyLine(request: RemoteHostKeyTrustRequest): string {
+  const publicKeyLine = request.publicKeyLine?.trim();
+  if (!publicKeyLine) {
+    throw new Error("The approved SSH host public key is unavailable.");
+  }
+  const [, keyType, publicKey] = publicKeyLine.split(/\s+/);
+  if (
+    keyType !== request.keyType ||
+    !publicKey ||
+    _fingerprint(publicKey) !== request.fingerprint
+  ) {
+    throw new Error(
+      "The SSH host public key does not match the approved fingerprint."
+    );
+  }
+  return publicKeyLine;
 }
 
 export function parseSshHostKeyOutput(
@@ -429,18 +508,17 @@ function _fingerprint(publicKey: string): string {
 async function _run(
   command: string,
   args: string[],
-  timeoutMs = 15_000
+  options: { preserveOutputStart?: boolean; timeoutMs?: number } = {}
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
   const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
   let stdout = "";
   let stderr = "";
   const appendStdout = (chunk: Buffer) => {
-    stdout += chunk.toString("utf8");
-    if (stdout.length > 20_000) stdout = stdout.slice(-20_000);
+    stdout = _appendOutput(stdout, chunk, options.preserveOutputStart === true);
   };
   const appendStderr = (chunk: Buffer) => {
-    stderr += chunk.toString("utf8");
-    if (stderr.length > 20_000) stderr = stderr.slice(-20_000);
+    stderr = _appendOutput(stderr, chunk, options.preserveOutputStart === true);
   };
   child.stdout?.on("data", appendStdout);
   child.stderr?.on("data", appendStderr);
@@ -459,4 +537,19 @@ async function _run(
       resolve({ code, stdout, stderr });
     });
   });
+}
+
+function _appendOutput(
+  current: string,
+  chunk: Buffer,
+  preserveStart: boolean
+): string {
+  const next = current + chunk.toString("utf8");
+  if (next.length <= 20_000) return next;
+  if (!preserveStart) return next.slice(-20_000);
+
+  const marker = "\n... SSH output truncated ...\n";
+  const startLength = 10_000;
+  const endLength = 20_000 - startLength - marker.length;
+  return `${next.slice(0, startLength)}${marker}${next.slice(-endLength)}`;
 }

--- a/apps/desktop/src/bun/remote/ssh-host-key.ts
+++ b/apps/desktop/src/bun/remote/ssh-host-key.ts
@@ -1,6 +1,13 @@
-import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -8,8 +15,7 @@ import type { RemoteHostKeyTrustRequest } from "../../shared/remote-servers";
 
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
 import { buildSshBaseArgs, buildSshTarget } from "./ssh-command";
-
-const DEFAULT_POST_KILL_DRAIN_MS = 250;
+import { runSshHostKeyCommand } from "./ssh-host-key-command";
 
 export type SshHostKeyCheckResult =
   | { status: "trusted" }
@@ -64,9 +70,11 @@ export class OpenSshHostKeyService implements SshHostKeyService {
       }
     }
     if (key && !key.publicKeyLine) {
-      const publicKeyLine = await _scanPublicKeyLine(config, key, resolved).catch(
-        () => undefined
-      );
+      const publicKeyLine = await _scanPublicKeyLine(
+        config,
+        key,
+        resolved
+      ).catch(() => undefined);
       if (publicKeyLine) key.publicKeyLine = publicKeyLine;
     }
     if (key) {
@@ -84,7 +92,9 @@ export class OpenSshHostKeyService implements SshHostKeyService {
     if (_isAuthenticationFailure(output)) return { status: "trusted" };
     return {
       status: "error",
-      message: output.trim() || `SSH host key probe failed with exit code ${probe.code}.`,
+      message:
+        output.trim() ||
+        `SSH host key probe failed with exit code ${probe.code}.`,
       rawOutput: output,
     };
   }
@@ -147,7 +157,9 @@ async function _connectWithApprovedHostKey(
   publicKeyLine: string
 ): Promise<void> {
   const target = buildSshTarget(config);
-  const baseArgs = buildSshBaseArgs(config);
+  const baseArgs = _withoutMultiplexingArgs(
+    buildSshBaseArgs(config).slice(0, -1)
+  );
   const result = await runSshHostKeyCommand(
     "ssh",
     [
@@ -160,6 +172,14 @@ async function _connectWithApprovedHostKey(
       "-o",
       "KnownHostsCommand=none",
       "-o",
+      "ControlMaster=no",
+      "-o",
+      "ControlPath=none",
+      "-o",
+      "ControlPersist=no",
+      "-o",
+      "VerifyHostKeyDNS=no",
+      "-o",
       "LogLevel=DEBUG1",
       "-o",
       "BatchMode=yes",
@@ -167,25 +187,54 @@ async function _connectWithApprovedHostKey(
       "ConnectTimeout=10",
       "-o",
       "NumberOfPasswordPrompts=0",
-      ...baseArgs.slice(0, -1),
+      ...baseArgs,
+      "-S",
+      "none",
       target,
       "true",
     ],
     { preserveOutputStart: true }
   );
   const output = `${result.stdout}${result.stderr}`;
-  if (result.code === 0) return;
+  const hostKeyFailed =
+    _isChangedHostKey(output) || _isFirstTimeHostKey(output);
+  const approvedHostKeyMatched = _hasApprovedHostKeyMatch(
+    output,
+    publicKeyLine
+  );
   if (
-    !_isChangedHostKey(output) &&
-    !_isFirstTimeHostKey(output) &&
-    _isAuthenticationFailure(output) &&
-    _hasApprovedHostKeyMatch(output, publicKeyLine)
+    !hostKeyFailed &&
+    approvedHostKeyMatched &&
+    (result.code === 0 || _isAuthenticationFailure(output))
   ) {
     return;
   }
+  const detail = output.trim();
   throw new Error(
-    output.trim() || `SSH host key trust failed with exit code ${result.code}.`
+    detail
+      ? `${detail}\nSSH host key verification did not confirm the approved SSH host key.`
+      : `SSH host key verification did not confirm the approved SSH host key (exit code ${result.code}).`
   );
+}
+
+function _withoutMultiplexingArgs(args: string[]): string[] {
+  const filtered: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--") continue;
+    if (arg === "-S" || arg === "-O") {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("-S") || arg.startsWith("-O")) continue;
+    if (/^-[1246AaCfgKkMNnqTtVvXxYy]+$/.test(arg) && arg.includes("M")) {
+      const withoutControlMaster = arg.replaceAll("M", "");
+      if (withoutControlMaster !== "-") filtered.push(withoutControlMaster);
+      continue;
+    }
+    filtered.push(arg);
+  }
+  return filtered;
 }
 
 function _hasApprovedHostKeyMatch(
@@ -196,9 +245,8 @@ function _hasApprovedHostKeyMatch(
   if (!lookupHost || !publicKey) return false;
   const fingerprint = _fingerprint(publicKey);
   const serverKeyMatches = output.split(/\r?\n/).some((line) => {
-    const match = /^debug1: Server host key:\s+\S+\s+(SHA256:[A-Za-z0-9+/=]+)/i.exec(
-      line
-    );
+    const match =
+      /^debug1: Server host key:\s+\S+\s+(SHA256:[A-Za-z0-9+/=]+)/i.exec(line);
     return match?.[1] === fingerprint;
   });
   return (
@@ -228,7 +276,10 @@ function _approvedPublicKeyLine(request: RemoteHostKeyTrustRequest): string {
 export function parseSshHostKeyOutput(
   output: string,
   config: SshHostKeyLookup
-): Omit<RemoteHostKeyTrustRequest, "requestId" | "target" | "host" | "user"> | null {
+): Omit<
+  RemoteHostKeyTrustRequest,
+  "requestId" | "target" | "host" | "user"
+> | null {
   const key = _parseServerKey(output);
   const changed = _isChangedHostKey(output);
   const firstTime = _isFirstTimeHostKey(output);
@@ -276,6 +327,13 @@ interface SshHostKeyLookup {
   hostKeyAlias?: string;
 }
 
+interface ScannedHostKey {
+  keyType: string;
+  publicKey: string;
+  fingerprint: string;
+  publicKeyLine: string;
+}
+
 async function _removeKnownHost(
   config: SshRemoteRuntimeConfig,
   request: RemoteHostKeyTrustRequest,
@@ -301,15 +359,22 @@ async function _removeKnownHost(
 
   if (request.knownHostsLine) return;
 
-  throw new Error(
-    `Failed to remove stale SSH host key: ${output}`
-  );
+  throw new Error(`Failed to remove stale SSH host key: ${output}`);
 }
 
 function _parseServerKey(output: string): ParsedServerKey | null {
-  const fingerprint = /(?:fingerprint for the \S+ key sent by the remote host is|Server host key:|key fingerprint is)\s*(?:\S+\s+)?(SHA256:[A-Za-z0-9+/=]+)/i.exec(output)?.[1] ?? /(SHA256:[A-Za-z0-9+/=]+)/i.exec(output)?.[1];
-  const serverKey = /^debug1: Server host key:\s+(\S+)\s+(SHA256:[A-Za-z0-9+/=]+)(?:\s+.*)?$/im.exec(output);
-  const keyType = serverKey?.[1] ?? _publicKeyTypeFromOutput(output) ?? _keyTypeFromOutput(output);
+  const fingerprint =
+    /(?:fingerprint for the \S+ key sent by the remote host is|Server host key:|key fingerprint is)\s*(?:\S+\s+)?(SHA256:[A-Za-z0-9+/=]+)/i.exec(
+      output
+    )?.[1] ?? /(SHA256:[A-Za-z0-9+/=]+)/i.exec(output)?.[1];
+  const serverKey =
+    /^debug1: Server host key:\s+(\S+)\s+(SHA256:[A-Za-z0-9+/=]+)(?:\s+.*)?$/im.exec(
+      output
+    );
+  const keyType =
+    serverKey?.[1] ??
+    _publicKeyTypeFromOutput(output) ??
+    _keyTypeFromOutput(output);
   if (!fingerprint || !keyType) return null;
   return {
     keyType,
@@ -322,15 +387,22 @@ function _parseServerKey(output: string): ParsedServerKey | null {
 }
 
 function _publicKeyFromOutput(output: string): string | undefined {
-  return /^\S+\s+(ssh-ed25519|ecdsa-sha2-\S+|ssh-rsa|rsa-sha2-\S+)\s+([A-Za-z0-9+/=]+)(?:\s.*)?$/m.exec(output)?.[2];
+  return /^\S+\s+(ssh-ed25519|ecdsa-sha2-\S+|ssh-rsa|rsa-sha2-\S+)\s+([A-Za-z0-9+/=]+)(?:\s.*)?$/m.exec(
+    output
+  )?.[2];
 }
 
 function _publicKeyTypeFromOutput(output: string): string | undefined {
-  return /^\S+\s+(ssh-ed25519|ecdsa-sha2-\S+|ssh-rsa|rsa-sha2-\S+)\s+[A-Za-z0-9+/=]+(?:\s.*)?$/m.exec(output)?.[1];
+  return /^\S+\s+(ssh-ed25519|ecdsa-sha2-\S+|ssh-rsa|rsa-sha2-\S+)\s+[A-Za-z0-9+/=]+(?:\s.*)?$/m.exec(
+    output
+  )?.[1];
 }
 
 function _keyTypeFromOutput(output: string): string | undefined {
-  const fromFingerprint = /fingerprint for the (\S+) key sent by the remote host is/i.exec(output)?.[1];
+  const fromFingerprint =
+    /fingerprint for the (\S+) key sent by the remote host is/i.exec(
+      output
+    )?.[1];
   if (!fromFingerprint) return undefined;
   if (fromFingerprint.toUpperCase() === "ECDSA") return "ecdsa-sha2-nistp256";
   if (fromFingerprint.toUpperCase() === "ED25519") return "ssh-ed25519";
@@ -365,7 +437,9 @@ function _isAuthenticationFailure(output: string): boolean {
 }
 
 function _knownHostsFileFromOutput(output: string): string | undefined {
-  return /Add correct host key in ([^\n]+?) to get rid of this message\./i.exec(output)?.[1];
+  return /Add correct host key in ([^\n]+?) to get rid of this message\./i.exec(
+    output
+  )?.[1];
 }
 
 function _knownHostsHost(host: string, port: number | undefined): string {
@@ -416,64 +490,75 @@ async function _scanPublicKeyLine(
 ): Promise<string | undefined> {
   const host = resolved?.hostname ?? request.resolvedHost ?? config.host;
   const port = resolved?.port ?? request.port ?? config.port;
-  const result = await runSshHostKeyCommand("ssh-keyscan", [
-    ...(port ? ["-p", String(port)] : []),
-    "-T",
-    "10",
-    host,
-  ]);
-  if (result.code !== 0 && !result.stdout.trim()) return undefined;
   const lookupHost = _knownHostsLookupHost({
     host,
     port,
     hostKeyAlias: resolved?.hostKeyAlias,
   });
-  for (const line of result.stdout.split(/\r?\n/)) {
-    const parts = line.trim().split(/\s+/);
-    if (parts.length < 3) continue;
-    const [, keyType, publicKey] = parts;
-    if (keyType !== request.keyType) continue;
-    const fingerprint = _fingerprint(publicKey);
-    if (fingerprint !== request.fingerprint) continue;
-    return `${lookupHost} ${keyType} ${publicKey}`;
-  }
-  return undefined;
+  const scanned = await _scanHostKeys(host, port, lookupHost);
+  return scanned.find(
+    (key) =>
+      key.keyType === request.keyType && key.fingerprint === request.fingerprint
+  )?.publicKeyLine;
 }
 
 async function _scanKey(
   config: SshRemoteRuntimeConfig,
   resolved?: ResolvedSshConfig
-): Promise<Omit<RemoteHostKeyTrustRequest, "requestId" | "target" | "host" | "user" | "kind"> | undefined> {
+): Promise<
+  | Omit<
+      RemoteHostKeyTrustRequest,
+      "requestId" | "target" | "host" | "user" | "kind"
+    >
+  | undefined
+> {
   const host = resolved?.hostname ?? config.host;
   const port = resolved?.port ?? config.port;
+  const lookupHost = _knownHostsLookupHost({
+    host,
+    port,
+    hostKeyAlias: resolved?.hostKeyAlias,
+  });
+  const [scanned] = await _scanHostKeys(host, port, lookupHost);
+  if (!scanned) return undefined;
+  return {
+    resolvedHost: host,
+    hostKeyAlias: resolved?.hostKeyAlias,
+    port,
+    keyType: scanned.keyType,
+    fingerprint: scanned.fingerprint,
+    knownHostsFile: resolved?.userKnownHostsFile ?? "~/.ssh/known_hosts",
+    publicKeyLine: scanned.publicKeyLine,
+  };
+}
+
+async function _scanHostKeys(
+  host: string,
+  port: number | undefined,
+  lookupHost: string
+): Promise<ScannedHostKey[]> {
   const result = await runSshHostKeyCommand("ssh-keyscan", [
     ...(port ? ["-p", String(port)] : []),
     "-T",
     "10",
     host,
   ]);
-  if (result.code !== 0 && !result.stdout.trim()) return undefined;
-  const lookupHost = _knownHostsLookupHost({
-    host,
-    port,
-    hostKeyAlias: resolved?.hostKeyAlias,
-  });
+  if (result.code !== 0 && !result.stdout.trim()) return [];
+
+  const keys: ScannedHostKey[] = [];
   for (const line of result.stdout.split(/\r?\n/)) {
     const parts = line.trim().split(/\s+/);
     if (parts.length < 3) continue;
     const [, keyType, publicKey] = parts;
     if (!keyType || !publicKey) continue;
-    return {
-      resolvedHost: host,
-      hostKeyAlias: resolved?.hostKeyAlias,
-      port,
+    keys.push({
       keyType,
+      publicKey,
       fingerprint: _fingerprint(publicKey),
-      knownHostsFile: resolved?.userKnownHostsFile ?? "~/.ssh/known_hosts",
       publicKeyLine: `${lookupHost} ${keyType} ${publicKey}`,
-    };
+    });
   }
-  return undefined;
+  return keys;
 }
 
 async function _resolveSshConfig(
@@ -537,105 +622,4 @@ function _fingerprint(publicKey: string): string {
     .digest("base64")
     .replace(/=+$/, "");
   return `SHA256:${digest}`;
-}
-
-export async function runSshHostKeyCommand(
-  command: string,
-  args: string[],
-  options: {
-    preserveOutputStart?: boolean;
-    timeoutMs?: number;
-    postKillDrainMs?: number;
-  } = {}
-): Promise<{ code: number | null; stdout: string; stderr: string }> {
-  const timeoutMs = options.timeoutMs ?? 15_000;
-  const postKillDrainMs = Math.max(
-    0,
-    options.postKillDrainMs ?? DEFAULT_POST_KILL_DRAIN_MS
-  );
-  const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
-  let stdout = "";
-  let stderr = "";
-  const appendStdout = (chunk: Buffer) => {
-    stdout = _appendOutput(stdout, chunk, options.preserveOutputStart === true);
-  };
-  const appendStderr = (chunk: Buffer) => {
-    stderr = _appendOutput(stderr, chunk, options.preserveOutputStart === true);
-  };
-  child.stdout?.on("data", appendStdout);
-  child.stderr?.on("data", appendStderr);
-
-  return await new Promise((resolve, reject) => {
-    let settled = false;
-    let timedOut = false;
-    let postKillDrainTimer: ReturnType<typeof setTimeout> | undefined;
-    function cleanup(): void {
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      if (postKillDrainTimer) clearTimeout(postKillDrainTimer);
-      child.removeListener("error", fail);
-      child.removeListener("close", close);
-      child.stdout?.removeListener("data", appendStdout);
-      child.stderr?.removeListener("data", appendStderr);
-    }
-    function settle(
-      result: { code: number | null; stdout: string; stderr: string }
-    ): void {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(result);
-    }
-    function fail(error: Error): void {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      child.stdout?.destroy();
-      child.stderr?.destroy();
-      reject(error);
-    }
-    function buildResult(code: number | null): {
-      code: number | null;
-      stdout: string;
-      stderr: string;
-    } {
-      return {
-        code: timedOut ? null : code,
-        stdout,
-        stderr: timedOut
-          ? `${stderr}\nSSH host key probe timed out after ${timeoutMs}ms.`
-          : stderr,
-      };
-    }
-    function close(code: number | null): void {
-      settle(buildResult(code));
-    }
-
-    const timeoutTimer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-      if (settled) return;
-      postKillDrainTimer = setTimeout(() => {
-        child.stdout?.destroy();
-        child.stderr?.destroy();
-        settle(buildResult(null));
-      }, postKillDrainMs);
-    }, timeoutMs);
-    child.once("error", fail);
-    child.once("close", close);
-  });
-}
-
-function _appendOutput(
-  current: string,
-  chunk: Buffer,
-  preserveStart: boolean
-): string {
-  const next = current + chunk.toString("utf8");
-  if (next.length <= 20_000) return next;
-  if (!preserveStart) return next.slice(-20_000);
-
-  const marker = "\n... SSH output truncated ...\n";
-  const startLength = 10_000;
-  const endLength = 20_000 - startLength - marker.length;
-  return `${next.slice(0, startLength)}${marker}${next.slice(-endLength)}`;
 }

--- a/apps/desktop/src/shared/remote-servers.ts
+++ b/apps/desktop/src/shared/remote-servers.ts
@@ -48,6 +48,7 @@ export interface RemoteHostKeyTrustRequest {
   target: string;
   host: string;
   resolvedHost?: string;
+  hostKeyAlias?: string;
   port?: number;
   user?: string;
   keyType: string;


### PR DESCRIPTION
## Root cause

The confirmation flow captured key A, but trust removed any stale entry and reconnected with `StrictHostKeyChecking=accept-new`. A key B presented during that TOCTOU window could therefore be accepted and persisted; key A was only a fallback.

The command wrapper also waited indefinitely for `close` after timing out and killing the direct SSH child. A `ProxyCommand` or descendant retaining stdout/stderr could therefore block the host-key operation and the remote-manager queue forever.

## Security impact

An attacker able to change the presented SSH host key between confirmation and trust could substitute an unapproved identity. Both first-time and changed-key flows were affected.

## Changes

- Validate that the approved public key line cryptographically matches the displayed fingerprint.
- Verify the destination through a mode-0600 temporary `known_hosts` file with `StrictHostKeyChecking=yes` and other host-key sources disabled.
- Require positive DEBUG1 evidence for authentication-failure success, including the resolved host alias and approved fingerprint.
- Mutate and back up the real `known_hosts` only after strict verification succeeds.
- Preserve custom ports, host aliases, changed-key backups, authentication-failure handling, and verbose SSH diagnostics.
- Keep normal command settlement on `close`, but add a bounded post-`SIGKILL` drain grace and guarded forced settlement when descendants retain pipes.
- Add behavior-level A-to-B substitution, alias/custom-port, delayed-diagnostic, and descendant-held-pipe regressions.

## Validation

- Focused SSH host-key and remote-server-manager suites: 33 pass, 0 fail.
- Full suite: 396 pass, 0 fail.
- Lint: clean with zero warnings.
- Typecheck: all six TypeScript projects pass.
- `git diff --check origin/main...HEAD`: clean.
- Independent review: approved after two fix rounds.

Closes #104
