### PR TITLE
fix(security): remove runtime bearer tokens from argv

### DIFF
--- a/apps/desktop/src/bun/remote/process-utils.test.ts
+++ b/apps/desktop/src/bun/remote/process-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+
+import { spawnManagedProcess } from "./process-utils";
+
+const SENTINEL_TOKEN = "sentinel-runtime-token-do-not-leak";
+
+describe("spawnManagedProcess", () => {
+  test("delivers sensitive stdin without adding it to child argv and closes the pipe", async () => {
+    const process = spawnManagedProcess(
+      "stdin reader",
+      "/bin/sh",
+      ["-c", 'IFS= read -r value; printf %s "$value"; sleep 5'],
+      { stdinInput: `${SENTINEL_TOKEN}\n` }
+    );
+
+    if (!process.output()) {
+      await once(process.child.stdout!, "data");
+    }
+
+    expect(process.child.spawnargs.join("\0")).not.toContain(SENTINEL_TOKEN);
+    expect(process.output()).toBe(SENTINEL_TOKEN);
+    expect(process.child.stdin?.writableEnded).toBe(true);
+    expect(process.child.stdin?.destroyed).toBe(true);
+    expect(process.child.exitCode).toBeNull();
+
+    await process.stop();
+  });
+
+  test("closes sensitive stdin when the child exits before reading it", async () => {
+    const process = spawnManagedProcess(
+      "early exit",
+      "/bin/sh",
+      ["-c", "exit 7"],
+      { stdinInput: `${SENTINEL_TOKEN.repeat(4096)}\n` }
+    );
+
+    await once(process.child, "exit");
+
+    expect(process.child.stdin?.writableEnded).toBe(true);
+    expect(process.child.stdin?.destroyed).toBe(true);
+    expect(process.output()).not.toContain(SENTINEL_TOKEN);
+  });
+});

--- a/apps/desktop/src/bun/remote/process-utils.ts
+++ b/apps/desktop/src/bun/remote/process-utils.ts
@@ -7,14 +7,23 @@ export interface ManagedProcess {
   stop(): Promise<void>;
 }
 
+export interface ManagedProcessOptions {
+  collectOutput?: boolean;
+  stdinInput?: string;
+}
+
 export function spawnManagedProcess(
   label: string,
   command: string,
   args: string[],
-  options: { collectOutput?: boolean } = {}
+  options: ManagedProcessOptions = {}
 ): ManagedProcess {
   const child = spawn(command, args, {
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: [
+      options.stdinInput === undefined ? "ignore" : "pipe",
+      "pipe",
+      "pipe",
+    ],
   });
   let output = "";
   const append = (chunk: Buffer) => {
@@ -27,6 +36,13 @@ export function spawnManagedProcess(
     child.stdout?.on("data", append);
   }
   child.stderr?.on("data", append);
+  if (options.stdinInput !== undefined) {
+    child.stdin?.on("error", () => {
+      // The child exit/output path reports startup failures. Handling EPIPE
+      // here prevents a closed remote stdin from becoming an uncaught error.
+    });
+    child.stdin?.end(options.stdinInput);
+  }
 
   return {
     label,

--- a/apps/desktop/src/bun/remote/ssh-command.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-command.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
 import {
   buildRemoteServerCommand,
+  buildRemoteServerArgs,
   buildSourceRemoteServerCommand,
   buildSshBaseArgs,
   buildSshTarget,
@@ -26,6 +39,8 @@ const CONFIG: SshRemoteRuntimeConfig = {
   remoteServerPort: 39123,
   makeDefault: true,
 };
+
+const SENTINEL_TOKEN = "sentinel-runtime-token-do-not-leak";
 
 describe("ssh command builders", () => {
   test("builds target and base args", () => {
@@ -80,19 +95,19 @@ describe("ssh command builders", () => {
     );
   });
 
-  test("shell quotes remote server command", () => {
+  test("keeps the packaged runtime token out of local and remote argv", () => {
     expect(shellQuote("a'b$c")).toBe("'a'\\''b$c'");
-    const command = buildRemoteServerCommand({
+    const sshArgs = buildRemoteServerArgs({
+      config: CONFIG,
       entrypoint: "/opt/llm space/server/bin/llm-space-server",
-      host: "127.0.0.1",
-      port: 39123,
-      token: "tok'en$;",
-      home: "/tmp/home path",
     });
+    const command = sshArgs.at(-1) ?? "";
+
+    expect(command).not.toContain("--token ");
+    expect(command).toContain("--token-stdin");
     expect(command).toContain(
       "exec '/opt/llm space/server/bin/llm-space-server'"
     );
-    expect(command).toContain("--token 'tok'\\''en$;'");
     expect(command).toContain("--home '/tmp/home path'");
   });
 
@@ -107,7 +122,6 @@ describe("ssh command builders", () => {
         "~/.llm-space/remote-runtime/versions/4.4.4/bin/llm-space-server",
       host: "127.0.0.1",
       port: 39123,
-      token: "token",
       home: "~/.llm-space-server",
     });
 
@@ -136,24 +150,37 @@ describe("ssh command builders", () => {
     );
   });
 
-  test("keeps source mode as legacy fallback", () => {
+  test("keeps the source runtime token out of remote argv", () => {
     const command = buildSourceRemoteServerCommand({
       remoteRepo: "/repo path/llm-space",
       host: "127.0.0.1",
       port: 39123,
-      token: "token",
       home: "/tmp/home path",
     });
+    expect(command).not.toContain("--token ");
+    expect(command).toContain("--token-stdin");
     expect(command).toContain("cd '/repo path/llm-space'");
-    expect(command).toContain("exec bun --filter @llm-space/server dev --");
+    expect(command).toContain("exec bun apps/server/src/index.ts");
+    expect(command).not.toContain("--filter");
   });
+
+  test.each(["installed", "source"] as const)(
+    "keeps the protected token out of the executed %s runtime argv",
+    async (mode) => {
+      const result = await _captureExecutedRuntime(mode);
+
+      expect(result.localShellArgv.join("\0")).not.toContain(SENTINEL_TOKEN);
+      expect(result.remoteArgv.join("\0")).not.toContain(SENTINEL_TOKEN);
+      expect(result.remoteArgv).toContain("--token-stdin");
+      expect(result.receivedToken).toBe(SENTINEL_TOKEN);
+    }
+  );
 
   test("expands source mode tilde paths", () => {
     const command = buildSourceRemoteServerCommand({
       remoteRepo: "~/repo/llm-space",
       host: "127.0.0.1",
       port: 39123,
-      token: "token",
       home: "~/.llm-space-server",
     });
 
@@ -161,3 +188,65 @@ describe("ssh command builders", () => {
     expect(command).toContain('--home "$HOME"/'.concat("'.llm-space-server'"));
   });
 });
+
+async function _captureExecutedRuntime(mode: "installed" | "source"): Promise<{
+  localShellArgv: string[];
+  remoteArgv: string[];
+  receivedToken: string;
+}> {
+  const directory = await mkdtemp(
+    path.join(tmpdir(), "llm-space-runtime-argv-")
+  );
+  const argvPath = path.join(directory, "argv");
+  const tokenPath = path.join(directory, "token");
+  const executablePath = path.join(
+    directory,
+    mode === "source" ? "bun" : "server"
+  );
+  const script = `#!/bin/sh\numask 077\nprintf '%s\\n' "$@" > "$ARGV_CAPTURE"\nIFS= read -r token\nprintf '%s' "$token" > "$TOKEN_CAPTURE"\n`;
+
+  try {
+    await writeFile(executablePath, script, { encoding: "utf8", mode: 0o700 });
+    await chmod(executablePath, 0o700);
+    const repositoryPath = path.join(directory, "repo");
+    await mkdir(repositoryPath, { mode: 0o700 });
+    const command =
+      mode === "source"
+        ? buildSourceRemoteServerCommand({
+            remoteRepo: repositoryPath,
+            host: "127.0.0.1",
+            port: 39123,
+            home: path.join(directory, "home"),
+          })
+        : buildRemoteServerCommand({
+            entrypoint: executablePath,
+            host: "127.0.0.1",
+            port: 39123,
+            home: path.join(directory, "home"),
+          });
+    const child = spawn("/bin/sh", ["-c", command], {
+      env: {
+        ...process.env,
+        ARGV_CAPTURE: argvPath,
+        TOKEN_CAPTURE: tokenPath,
+        PATH: `${directory}:${process.env.PATH ?? ""}`,
+      },
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.stdin?.end(`${SENTINEL_TOKEN}\n`);
+    const [exitCode] = (await once(child, "exit")) as [number | null];
+    expect(exitCode, stderr).toBe(0);
+
+    return {
+      localShellArgv: child.spawnargs,
+      remoteArgv: (await readFile(argvPath, "utf8")).trimEnd().split("\n"),
+      receivedToken: await readFile(tokenPath, "utf8"),
+    };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/apps/desktop/src/bun/remote/ssh-command.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import {
   chmod,
@@ -16,6 +16,7 @@ import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
 import {
   buildRemoteServerCommand,
   buildRemoteServerArgs,
+  buildSourceRemoteServerArgs,
   buildSourceRemoteServerCommand,
   buildSshBaseArgs,
   buildSshTarget,
@@ -41,6 +42,14 @@ const CONFIG: SshRemoteRuntimeConfig = {
 };
 
 const SENTINEL_TOKEN = "sentinel-runtime-token-do-not-leak";
+const SERVER_TTY_CONFIG: SshRemoteRuntimeConfig = {
+  ...CONFIG,
+  host: "tty-probe",
+  user: undefined,
+  port: undefined,
+  identityFile: undefined,
+  extraArgs: ["-tt"],
+};
 
 describe("ssh command builders", () => {
   test("builds target and base args", () => {
@@ -58,6 +67,7 @@ describe("ssh command builders", () => {
       "jump",
       "user@host",
     ]);
+    expect(buildSshBaseArgs(CONFIG)).not.toContain("-T");
   });
 
   test("does not override OpenSSH config by default", () => {
@@ -93,6 +103,12 @@ describe("ssh command builders", () => {
     expect(buildTunnelArgs({ config: CONFIG, localPort: 40000 })).toContain(
       "127.0.0.1:40000:127.0.0.1:39123"
     );
+    const forcedTtyArgs = buildTunnelArgs({
+      config: SERVER_TTY_CONFIG,
+      localPort: 40000,
+    });
+    expect(forcedTtyArgs).toContain("-tt");
+    expect(forcedTtyArgs).not.toContain("-T");
   });
 
   test("keeps the packaged runtime token out of local and remote argv", () => {
@@ -110,6 +126,49 @@ describe("ssh command builders", () => {
     );
     expect(command).toContain("--home '/tmp/home path'");
   });
+
+  test("disables TTY after user options and before the packaged server target", () => {
+    const sshArgs = buildRemoteServerArgs({
+      config: SERVER_TTY_CONFIG,
+      entrypoint: "/opt/llm-space-server",
+    });
+    const userTtyIndex = sshArgs.indexOf("-tt");
+    const disableTtyIndex = sshArgs.indexOf("-T");
+    const targetIndex = sshArgs.indexOf("tty-probe");
+
+    expect(disableTtyIndex).toBeGreaterThan(userTtyIndex);
+    expect(disableTtyIndex).toBeLessThan(targetIndex);
+  });
+
+  test.each(["installed", "source"] as const)(
+    "OpenSSH resolves the %s server session to requesttty false",
+    async (mode) => {
+      const directory = await mkdtemp(path.join(tmpdir(), "llm-space-ssh-g-"));
+      try {
+        const configPath = path.join(directory, "config");
+        await writeFile(
+          configPath,
+          "Host tty-probe\n  HostName 127.0.0.1\n  RequestTTY force\n",
+          { encoding: "utf8", mode: 0o600 }
+        );
+        const sshArgs =
+          mode === "source"
+            ? buildSourceRemoteServerArgs({ config: SERVER_TTY_CONFIG })
+            : buildRemoteServerArgs({
+                config: SERVER_TTY_CONFIG,
+                entrypoint: "/opt/llm-space-server",
+              });
+        const result = spawnSync("ssh", ["-F", configPath, "-G", ...sshArgs], {
+          encoding: "utf8",
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(/^requesttty false$/m.test(result.stdout)).toBe(true);
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    }
+  );
 
   test("expands current-user tilde paths on the remote shell", () => {
     expect(shellPath("~")).toBe('"$HOME"');

--- a/apps/desktop/src/bun/remote/ssh-command.ts
+++ b/apps/desktop/src/bun/remote/ssh-command.ts
@@ -34,7 +34,6 @@ export function buildTunnelArgs(input: {
 
 export function buildRemoteServerArgs(input: {
   config: SshRemoteRuntimeConfig;
-  token: string;
   entrypoint: string;
 }): string[] {
   return [
@@ -43,7 +42,6 @@ export function buildRemoteServerArgs(input: {
       entrypoint: input.entrypoint,
       host: "127.0.0.1",
       port: input.config.remoteServerPort,
-      token: input.token,
       home: input.config.remoteHome,
     }),
   ];
@@ -53,7 +51,6 @@ export function buildRemoteServerCommand(input: {
   entrypoint: string;
   host: string;
   port: number;
-  token: string;
   home: string;
 }): string {
   return [
@@ -63,8 +60,7 @@ export function buildRemoteServerCommand(input: {
     shellQuote(input.host),
     "--port",
     String(input.port),
-    "--token",
-    shellQuote(input.token),
+    "--token-stdin",
     "--home",
     shellPath(input.home),
   ].join(" ");
@@ -74,20 +70,18 @@ export function buildSourceRemoteServerCommand(input: {
   remoteRepo: string;
   host: string;
   port: number;
-  token: string;
   home: string;
 }): string {
   return [
     "cd",
     shellPath(input.remoteRepo),
     "&&",
-    "exec bun --filter @llm-space/server dev --",
+    "exec bun apps/server/src/index.ts",
     "--host",
     shellQuote(input.host),
     "--port",
     String(input.port),
-    "--token",
-    shellQuote(input.token),
+    "--token-stdin",
     "--home",
     shellPath(input.home),
   ].join(" ");

--- a/apps/desktop/src/bun/remote/ssh-command.ts
+++ b/apps/desktop/src/bun/remote/ssh-command.ts
@@ -36,15 +36,29 @@ export function buildRemoteServerArgs(input: {
   config: SshRemoteRuntimeConfig;
   entrypoint: string;
 }): string[] {
-  return [
-    ...buildSshBaseArgs(input.config),
+  return _buildRemoteServerSessionArgs(
+    input.config,
     buildRemoteServerCommand({
       entrypoint: input.entrypoint,
       host: "127.0.0.1",
       port: input.config.remoteServerPort,
       home: input.config.remoteHome,
-    }),
-  ];
+    })
+  );
+}
+
+export function buildSourceRemoteServerArgs(input: {
+  config: SshRemoteRuntimeConfig;
+}): string[] {
+  return _buildRemoteServerSessionArgs(
+    input.config,
+    buildSourceRemoteServerCommand({
+      remoteRepo: input.config.remoteRepo,
+      host: "127.0.0.1",
+      port: input.config.remoteServerPort,
+      home: input.config.remoteHome,
+    })
+  );
 }
 
 export function buildRemoteServerCommand(input: {
@@ -114,4 +128,16 @@ export function shellQuote(value: unknown): string {
     throw new Error(`Cannot shell-quote non-string value: ${String(value)}`);
   }
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function _buildRemoteServerSessionArgs(
+  config: SshRemoteRuntimeConfig,
+  command: string
+): string[] {
+  return [
+    ...buildSshBaseArgs(config).slice(0, -1),
+    "-T",
+    buildSshTarget(config),
+    command,
+  ];
 }

--- a/apps/desktop/src/bun/remote/ssh-remote-runtime.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-remote-runtime.test.ts
@@ -30,7 +30,7 @@ const CONFIG: SshRemoteRuntimeConfig = {
   id: "remote:test",
   name: "test",
   host: "host",
-  extraArgs: [],
+  extraArgs: ["-tt"],
   remoteRepo: "",
   remoteInstallDir: "~/.llm-space/remote-runtime",
   remoteHome: "~/.llm-space-server",
@@ -165,6 +165,11 @@ describe("startSshRemoteRuntime", () => {
       expect(serverSpawn).toBeDefined();
       expect(serverSpawn?.command).toBe("ssh");
       expect(serverSpawn?.args.join("\0")).not.toContain(SENTINEL_TOKEN);
+      const userTtyIndex = serverSpawn?.args.indexOf("-tt") ?? -1;
+      const disableTtyIndex = serverSpawn?.args.indexOf("-T") ?? -1;
+      const targetIndex = serverSpawn?.args.indexOf(CONFIG.host) ?? -1;
+      expect(disableTtyIndex).toBeGreaterThan(userTtyIndex);
+      expect(disableTtyIndex).toBeLessThan(targetIndex);
       expect(serverSpawn?.args.at(-1)).not.toContain("--token ");
       expect(serverSpawn?.args.at(-1)).toContain("--token-stdin");
       expect(serverSpawn?.options?.stdinInput).toBe(`${SENTINEL_TOKEN}\n`);

--- a/apps/desktop/src/bun/remote/ssh-remote-runtime.test.ts
+++ b/apps/desktop/src/bun/remote/ssh-remote-runtime.test.ts
@@ -17,6 +17,14 @@ let serverSpawnCalls = 0;
 let stopCalls = 0;
 let diagnosticCalls = 0;
 let remoteExecCalls: string[] = [];
+let spawnCalls: {
+  label: string;
+  command: string;
+  args: string[];
+  options?: { collectOutput?: boolean; stdinInput?: string };
+}[] = [];
+
+const SENTINEL_TOKEN = "sentinel-runtime-token-do-not-leak";
 
 const CONFIG: SshRemoteRuntimeConfig = {
   id: "remote:test",
@@ -31,6 +39,7 @@ const CONFIG: SshRemoteRuntimeConfig = {
 };
 
 const TEST_DEPENDENCIES = {
+  generateToken: () => SENTINEL_TOKEN,
   findFreePort: () => Promise.resolve(40000),
   installRemoteServerPackage: () => {
     installCalls += 1;
@@ -66,7 +75,13 @@ const TEST_DEPENDENCIES = {
       stderr: "",
     });
   },
-  spawnManagedProcess: (label: string) => {
+  spawnManagedProcess: (
+    label: string,
+    command: string,
+    args: string[],
+    options?: { collectOutput?: boolean; stdinInput?: string }
+  ) => {
+    spawnCalls.push({ label, command, args, options });
     const attempt = installCalls;
     if (label === "remote server") {
       serverSpawnCalls += 1;
@@ -114,16 +129,58 @@ beforeEach(() => {
   stopCalls = 0;
   diagnosticCalls = 0;
   remoteExecCalls = [];
+  spawnCalls = [];
 });
 
 describe("startSshRemoteRuntime", () => {
+  test.each(["installed", "source"] as const)(
+    "passes the %s runtime token only through a closed stdin payload",
+    async (mode) => {
+      scenario = "success";
+      const originalMode = process.env.LLM_SPACE_REMOTE_SERVER_MODE;
+      if (mode === "source") {
+        process.env.LLM_SPACE_REMOTE_SERVER_MODE = "source";
+      } else {
+        delete process.env.LLM_SPACE_REMOTE_SERVER_MODE;
+      }
+
+      try {
+        await _withFetch(async () => {
+          const handle = await startSshRemoteRuntime(CONFIG, {
+            dependencies: TEST_DEPENDENCIES,
+          });
+          await handle.stop();
+        });
+      } finally {
+        if (originalMode === undefined) {
+          delete process.env.LLM_SPACE_REMOTE_SERVER_MODE;
+        } else {
+          process.env.LLM_SPACE_REMOTE_SERVER_MODE = originalMode;
+        }
+      }
+
+      const serverSpawn = spawnCalls.find(
+        (call) => call.label === "remote server"
+      );
+      expect(serverSpawn).toBeDefined();
+      expect(serverSpawn?.command).toBe("ssh");
+      expect(serverSpawn?.args.join("\0")).not.toContain(SENTINEL_TOKEN);
+      expect(serverSpawn?.args.at(-1)).not.toContain("--token ");
+      expect(serverSpawn?.args.at(-1)).toContain("--token-stdin");
+      expect(serverSpawn?.options?.stdinInput).toBe(`${SENTINEL_TOKEN}\n`);
+    }
+  );
+
   test("does not reinstall when the runtime binary is missing", async () => {
-    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
+    await startSshRemoteRuntime(CONFIG, {
+      dependencies: TEST_DEPENDENCIES,
+    }).then(
       () => {
         throw new Error("connect should fail");
       },
       (error) => {
         expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).not.toContain(SENTINEL_TOKEN);
         expect((error as Error).message).toContain(
           "Remote runtime binary is missing"
         );
@@ -141,7 +198,9 @@ describe("startSshRemoteRuntime", () => {
   test("does not reinstall for non-runtime startup failures", async () => {
     scenario = "non-runtime-failure";
 
-    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
+    await startSshRemoteRuntime(CONFIG, {
+      dependencies: TEST_DEPENDENCIES,
+    }).then(
       () => {
         throw new Error("connect should fail");
       },
@@ -169,6 +228,14 @@ describe("startSshRemoteRuntime", () => {
 
     expect(installCalls).toBe(1);
     expect(serverSpawnCalls).toBe(2);
+    const serverSpawns = spawnCalls.filter(
+      (call) => call.label === "remote server"
+    );
+    expect(serverSpawns).toHaveLength(2);
+    for (const spawn of serverSpawns) {
+      expect(spawn.args.join("\0")).not.toContain(SENTINEL_TOKEN);
+      expect(spawn.options?.stdinInput).toBe(`${SENTINEL_TOKEN}\n`);
+    }
     expect(remoteExecCalls.some((command) => command.includes("PIDS"))).toBe(
       true
     );
@@ -181,7 +248,9 @@ describe("startSshRemoteRuntime", () => {
   test("does not stop unknown remote port owners", async () => {
     scenario = "port-in-use-unknown-owner";
 
-    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
+    await startSshRemoteRuntime(CONFIG, {
+      dependencies: TEST_DEPENDENCIES,
+    }).then(
       () => {
         throw new Error("connect should fail");
       },
@@ -204,7 +273,9 @@ describe("startSshRemoteRuntime", () => {
   test("retries remote port recovery only once", async () => {
     scenario = "port-in-use-retry-fails";
 
-    await startSshRemoteRuntime(CONFIG, { dependencies: TEST_DEPENDENCIES }).then(
+    await startSshRemoteRuntime(CONFIG, {
+      dependencies: TEST_DEPENDENCIES,
+    }).then(
       () => {
         throw new Error("connect should fail");
       },

--- a/apps/desktop/src/bun/remote/ssh-remote-runtime.ts
+++ b/apps/desktop/src/bun/remote/ssh-remote-runtime.ts
@@ -56,6 +56,7 @@ export interface SshRemoteRuntimeOptions {
 }
 
 interface SshRemoteRuntimeDependencies {
+  generateToken: typeof _generateToken;
   findFreePort: typeof findFreePort;
   installRemoteServerPackage: typeof installRemoteServerPackage;
   getOrDownloadServerPackage: typeof getOrDownloadServerPackage;
@@ -65,6 +66,7 @@ interface SshRemoteRuntimeDependencies {
 }
 
 const DEFAULT_DEPENDENCIES: SshRemoteRuntimeDependencies = {
+  generateToken: _generateToken,
   findFreePort,
   installRemoteServerPackage,
   getOrDownloadServerPackage,
@@ -77,8 +79,8 @@ export async function startSshRemoteRuntime(
   config: SshRemoteRuntimeConfig,
   options: SshRemoteRuntimeOptions = {}
 ): Promise<SshRemoteRuntimeHandle> {
-  const token = _generateToken();
   const dependencies = { ...DEFAULT_DEPENDENCIES, ...options.dependencies };
+  const token = dependencies.generateToken();
   const localPort = config.localPort ?? (await dependencies.findFreePort());
   const allProcesses: ManagedProcess[] = [];
 
@@ -202,16 +204,14 @@ async function _startInstalledRuntimeOnce(input: {
               remoteRepo: input.config.remoteRepo,
               host: "127.0.0.1",
               port: input.config.remoteServerPort,
-              token: input.token,
               home: input.config.remoteHome,
             }),
           ]
         : buildRemoteServerArgs({
             config: input.config,
-            token: input.token,
             entrypoint: input.install.entrypoint,
           }),
-      { collectOutput: false }
+      { collectOutput: false, stdinInput: `${input.token}\n` }
     );
     processes.push(serverProcess);
     await _waitForProcessAlive(serverProcess, "server-start", input.config);

--- a/apps/desktop/src/bun/remote/ssh-remote-runtime.ts
+++ b/apps/desktop/src/bun/remote/ssh-remote-runtime.ts
@@ -21,8 +21,7 @@ import { getOrDownloadServerPackage } from "./server-package-cache";
 import type { SshRemoteRuntimeConfig } from "./ssh-bootstrap-config";
 import {
   buildRemoteServerArgs,
-  buildSourceRemoteServerCommand,
-  buildSshBaseArgs,
+  buildSourceRemoteServerArgs,
   buildTunnelArgs,
   joinRemotePath,
   shellPath,
@@ -198,15 +197,7 @@ async function _startInstalledRuntimeOnce(input: {
       "remote server",
       "ssh",
       process.env.LLM_SPACE_REMOTE_SERVER_MODE === "source"
-        ? [
-            ...buildSshBaseArgs(input.config),
-            buildSourceRemoteServerCommand({
-              remoteRepo: input.config.remoteRepo,
-              host: "127.0.0.1",
-              port: input.config.remoteServerPort,
-              home: input.config.remoteHome,
-            }),
-          ]
+        ? buildSourceRemoteServerArgs({ config: input.config })
         : buildRemoteServerArgs({
             config: input.config,
             entrypoint: input.install.entrypoint,

--- a/apps/server/src/args.test.ts
+++ b/apps/server/src/args.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseArgs } from "./args";
+import { parseArgs, resolveServerToken } from "./args";
+
+const SENTINEL_TOKEN = "sentinel-runtime-token-do-not-leak";
 
 describe("parseArgs", () => {
   test("parses explicit server arguments", () => {
@@ -27,6 +29,29 @@ describe("parseArgs", () => {
   test("requires token unless help is requested", () => {
     expect(() => parseArgs([])).toThrow("--token is required.");
     expect(parseArgs(["--help"]).help).toBe(true);
+  });
+
+  test("accepts a mutually exclusive protected stdin token source", async () => {
+    const args = parseArgs(["--token-stdin"]);
+
+    expect(args.token).toBeUndefined();
+    expect(args.tokenStdin).toBe(true);
+    expect(() =>
+      parseArgs(["--token", SENTINEL_TOKEN, "--token-stdin"])
+    ).toThrow("Choose exactly one token source");
+    expect(
+      await resolveServerToken(args, () =>
+        Promise.resolve(`${SENTINEL_TOKEN}\n`)
+      )
+    ).toBe(SENTINEL_TOKEN);
+  });
+
+  test("rejects empty protected stdin without echoing its contents", () => {
+    const args = parseArgs(["--token-stdin"]);
+
+    expect(
+      resolveServerToken(args, () => Promise.resolve("\n"))
+    ).rejects.toThrow("standard input is empty");
   });
 
   test("rejects invalid ports", () => {

--- a/apps/server/src/args.ts
+++ b/apps/server/src/args.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 export interface ServerArgs {
   host: string;
   port: number;
-  token: string;
+  token?: string;
+  tokenStdin: boolean;
   home: string;
   help: boolean;
 }
@@ -18,6 +19,7 @@ export function parseArgs(argv: string[]): ServerArgs {
     port: DEFAULT_PORT,
     home: path.join(os.homedir(), ".llm-space-server"),
     help: false,
+    tokenStdin: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -38,6 +40,10 @@ export function parseArgs(argv: string[]): ServerArgs {
       parsed.token = _requireValue(argv, ++index, arg);
       continue;
     }
+    if (arg === "--token-stdin") {
+      parsed.tokenStdin = true;
+      continue;
+    }
     if (arg === "--home") {
       parsed.home = _resolveHome(_requireValue(argv, ++index, arg));
       continue;
@@ -49,15 +55,34 @@ export function parseArgs(argv: string[]): ServerArgs {
     parsed.home ?? path.join(os.homedir(), ".llm-space-server")
   );
 
-  if (!parsed.help && !parsed.token) {
+  if (!parsed.help && !parsed.token && !parsed.tokenStdin) {
     throw new Error("--token is required.");
+  }
+  if (!parsed.help && parsed.token && parsed.tokenStdin) {
+    throw new Error(
+      "Choose exactly one token source: --token or --token-stdin."
+    );
   }
 
   return parsed as ServerArgs;
 }
 
+export async function resolveServerToken(
+  args: ServerArgs,
+  readStdin: () => Promise<string> = () => Bun.stdin.text()
+): Promise<string> {
+  if (args.token !== undefined) return args.token;
+  const input = await readStdin();
+  const token = input.endsWith("\n") ? input.slice(0, -1) : input;
+  const normalized = token.endsWith("\r") ? token.slice(0, -1) : token;
+  if (!normalized) {
+    throw new Error("Bearer token from standard input is empty.");
+  }
+  return normalized;
+}
+
 export function helpText(): string {
-  return `Usage: llm-space-server --token <token> [options]\n\nOptions:\n  --host <host>    Host to bind. Defaults to 127.0.0.1.\n  --port <port>    Port to bind. Defaults to 39123.\n  --token <token>  Bearer token required by every endpoint.\n  --home <path>    Server home. Defaults to ~/.llm-space-server.\n  --help           Show this help.\n`;
+  return `Usage: llm-space-server (--token <token> | --token-stdin) [options]\n\nOptions:\n  --host <host>    Host to bind. Defaults to 127.0.0.1.\n  --port <port>    Port to bind. Defaults to 39123.\n  --token <token>  Bearer token required by every endpoint.\n  --token-stdin    Read the bearer token from standard input.\n  --home <path>    Server home. Defaults to ~/.llm-space-server.\n  --help           Show this help.\n`;
 }
 
 function _requireValue(argv: string[], index: number, flag: string): string {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,6 +1,6 @@
 import desktopPackageJson from "../../desktop/package.json";
 
-import { helpText, parseArgs } from "./args";
+import { helpText, parseArgs, resolveServerToken } from "./args";
 import { startHttpServer } from "./http-server";
 import { createServerRuntime } from "./runtime-factory";
 
@@ -19,6 +19,8 @@ async function main(): Promise<void> {
     return;
   }
 
+  const token = await resolveServerToken(args);
+
   const runtime = await createServerRuntime(args.home);
   let stopping = false;
   const stop = async () => {
@@ -32,7 +34,7 @@ async function main(): Promise<void> {
   const server = startHttpServer({
     host: args.host,
     port: args.port,
-    token: args.token,
+    token,
     runtime,
     version: desktopPackageJson.version,
     onShutdown: () => void stop(),


### PR DESCRIPTION
## Root cause

The generated remote-runtime bearer token was interpolated into the remote shell command. That made it visible in the long-lived local `ssh` argv and in the remote server's `--token <secret>` argv.

An SSH configuration that forced PTY allocation could also echo a stdin-delivered secret or break EOF-based token reading unless the protected server session explicitly disabled TTY allocation.

## Changes

- Pass the token through an EOF-terminated SSH stdin pipe.
- Add `--token-stdin` parsing while preserving the existing manual `--token` CLI behavior.
- Launch source-development mode directly with `bun apps/server/src/index.ts` so stdin reaches the server process.
- Force `-T` after all user SSH arguments and before the target for installed and source server sessions, overriding `RequestTTY force` and `-t`/`-tt`.
- Keep tunnel, file-transfer, and ordinary SSH semantics unchanged.
- Handle early pipe closure without exposing the payload in diagnostics.
- Cover installed/source argv, stdin delivery and closure, PTY precedence, retry, startup failure, and bearer-auth semantics.

## Security impact

The bearer token is absent from local SSH and remote server process arguments, environment variables, remote shell variables, logs, and temporary files. The local stdin writer is ended immediately. Token-bearing server sessions cannot allocate a PTY, preventing echo into a long-lived output pipe.

## Verification

- Focused SSH/process/runtime/server/auth/HTTP suite: 31 pass, 0 fail.
- Full suite: 397 pass, 0 fail.
- Real no-network `ssh -G` probes resolve `requesttty false` for installed and source builders even with `RequestTTY force` and user `-tt`.
- Live source-mode and compiled-server probes: valid token 200, invalid token 401, sentinel absent from inspected argv.
- Lint and all six TypeScript project typechecks: clean.
- `git diff --check origin/main...HEAD`: clean.
- Independent security review: approved after one fix round.

Closes #106
