### PR TITLE
feat: import DeerFlow run-event JSONL files

### DIFF
--- a/apps/desktop/src/app/page.tsx
+++ b/apps/desktop/src/app/page.tsx
@@ -868,7 +868,7 @@ function PageWorkspace({
         ref={fileInputRef}
         type="file"
         multiple
-        accept=".json,application/json"
+        accept=".json,.jsonl,application/json,application/x-ndjson"
         aria-label="Import thread files"
         className="hidden"
         onChange={(e) => {

--- a/apps/desktop/src/bun/import-files.ts
+++ b/apps/desktop/src/bun/import-files.ts
@@ -28,7 +28,7 @@ export async function importFilesWithNativePicker(
   const paths = _normalizeSelectedPaths(
     await Utils.openFileDialog({
       startingFolder: Utils.paths.documents,
-      allowedFileTypes: "json",
+      allowedFileTypes: "json,jsonl",
       canChooseFiles: true,
       canChooseDirectory: false,
       allowsMultipleSelection: true,

--- a/apps/desktop/src/lib/import-threads.ts
+++ b/apps/desktop/src/lib/import-threads.ts
@@ -17,12 +17,12 @@ export interface ThreadImportFile {
 }
 
 /**
- * Parse each file payload (OpenAI ChatCompletion / Anthropic Messages / native thread
- * JSON) and write the ones that yield a thread into `parent` as new `.json`
- * files, mirroring the "New File" naming/creation. Files that don't parse into
- * a thread are skipped. Returns the created workspace-relative paths and the
- * total number of files processed. The on-disk title is normalized to the file
- * name by the scoped filesystem client, same as New File.
+ * Parse each supported thread file and write the ones that yield a thread into
+ * `parent` as new `.json` files, mirroring the "New File" naming/creation.
+ * Files that don't parse into a thread are skipped. Returns the created
+ * workspace-relative paths and the total number of files processed. The on-disk
+ * title is normalized to the file name by the scoped filesystem client, same as
+ * New File.
  */
 export async function importThreadFileRecords(
   parent: string,

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -278,7 +278,7 @@ Actual files may also contain `runHistory`, `evaluationRubrics`, and `evaluation
 
 # Supported Import Schemas
 
-The import entry point currently selects parsers by file extension, and `.json` is supported. When importing JSON, LLM Space attempts to recognize and normalize the following formats:
+The import entry point selects parsers by file extension. `.json` and `.jsonl` are supported. LLM Space attempts to recognize and normalize the following formats:
 
 | Format | Description |
 | --- | --- |
@@ -286,5 +286,6 @@ The import entry point currently selects parsers by file extension, and `.json` 
 | OpenAI Chat Completions-style JSON | Chat exports containing fields such as `messages`, `role`, `content`, and `tool_calls`. |
 | Anthropic Messages-style JSON | Chat exports containing fields such as `system`, `messages`, content blocks, `tool_use`, `tool_result`, and `input_schema`. |
 | Aurora-style JSON | Aurora Thread exports containing `Messages` and `Tools`. |
+| DeerFlow run-event JSONL | Persisted run events containing human, assistant, and tool messages. |
 
 After import, external formats are converted to the LLM Space Thread structure and written as new `.json` files under the current workspace directory. Files that cannot produce messages, System Prompt, Tools, or model information are skipped.

--- a/docs/core-concepts.zh-CN.md
+++ b/docs/core-concepts.zh-CN.md
@@ -278,7 +278,7 @@ Thread 文件保存在：
 
 # 支持导入的 schema
 
-当前导入入口按文件扩展名选择解析器；已支持 `.json`。导入 JSON 时，LLM Space 会尝试识别并归一化以下格式：
+当前导入入口按文件扩展名选择解析器；已支持 `.json` 和 `.jsonl`。LLM Space 会尝试识别并归一化以下格式：
 
 | 格式 | 说明 |
 | --- | --- |
@@ -286,5 +286,6 @@ Thread 文件保存在：
 | OpenAI Chat Completions 风格 JSON | 包含 `messages`、`role`、`content`、`tool_calls` 等字段的聊天导出。 |
 | Anthropic Messages 风格 JSON | 包含 `system`、`messages`、内容块、`tool_use`、`tool_result`、`input_schema` 等字段的聊天导出。 |
 | Aurora 风格 JSON | 包含 `Messages` 和 `Tools` 的 Aurora 线程导出。 |
+| DeerFlow run-event JSONL | 包含用户、助手和工具消息的持久化运行事件。 |
 
 导入后，外部格式会转换为 LLM Space 的 Thread 结构，并写入当前工作区目录下的新 `.json` 文件。无法解析出消息、System Prompt、Tools 或模型信息的文件会被跳过。

--- a/packages/core/src/parsers/deerflow-jsonl-thread-parser.test.ts
+++ b/packages/core/src/parsers/deerflow-jsonl-thread-parser.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+
+import { DeerFlowJsonlThreadParser } from "./deerflow-jsonl-thread-parser";
+
+function _jsonl(...rows: unknown[]): string {
+  return rows.map((row) => JSON.stringify(row)).join("\n");
+}
+
+describe("DeerFlowJsonlThreadParser", () => {
+  test("imports visible human, assistant, and tool messages", async () => {
+    const result = await new DeerFlowJsonlThreadParser().parseDetailed(
+      [
+        "not json",
+        _jsonl(
+          {
+            event_type: "run.start",
+            category: "trace",
+            content: { chain: "LangGraph" },
+          },
+          {
+            event_type: "llm.human.input",
+            category: "message",
+            content: { type: "human", id: "human-1", content: "Search" },
+          },
+          {
+            event_type: "llm.ai.response",
+            category: "message",
+            content: {
+              type: "ai",
+              id: "ai-1",
+              content: "",
+              tool_calls: [
+                {
+                  id: "call-1",
+                  name: "web_search",
+                  args: { query: "DeerFlow" },
+                },
+              ],
+            },
+            metadata: { caller: "lead_agent" },
+          },
+          {
+            event_type: "llm.tool.result",
+            category: "message",
+            content: {
+              type: "tool",
+              id: "tool-1",
+              tool_call_id: "call-1",
+              content: "Search result",
+            },
+          },
+          {
+            event_type: "llm.ai.response",
+            category: "message",
+            content: { type: "ai", id: "ai-2", content: "Done" },
+            metadata: { caller: "lead_agent" },
+          }
+        ),
+      ].join("\n")
+    );
+
+    expect(result.status).toBe("parsed");
+    if (result.status === "parsed") {
+      expect(result.thread.context?.messages).toEqual([
+        {
+          id: "human-1",
+          role: "user",
+          content: [{ type: "text", text: "Search" }],
+        },
+        {
+          id: "ai-1",
+          role: "assistant",
+          content: [],
+          toolCalls: [
+            {
+              id: "call-1",
+              input: {
+                name: "web_search",
+                arguments: { query: "DeerFlow" },
+              },
+              output: {
+                content: [{ type: "text", text: "Search result" }],
+              },
+            },
+          ],
+        },
+        {
+          id: "ai-2",
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+        },
+      ]);
+    }
+  });
+
+  test("skips internal DeerFlow messages", async () => {
+    const result = await new DeerFlowJsonlThreadParser().parseDetailed(
+      _jsonl(
+        {
+          event_type: "llm.human.input",
+          category: "message",
+          content: { type: "human", content: "Visible" },
+        },
+        {
+          event_type: "llm.ai.response",
+          category: "message",
+          content: { type: "ai", content: "Title" },
+          metadata: { caller: "middleware:title" },
+        },
+        {
+          event_type: "llm.ai.response",
+          category: "message",
+          content: { type: "ai", content: "Subagent result" },
+          metadata: { caller: "subagent:research" },
+        },
+        {
+          event_type: "llm.ai.response",
+          category: "message",
+          content: {
+            type: "ai",
+            content: "Hidden",
+            additional_kwargs: { hide_from_ui: true },
+          },
+        }
+      )
+    );
+
+    expect(result.status).toBe("parsed");
+    if (result.status === "parsed") {
+      expect(result.thread.context?.messages).toHaveLength(1);
+      expect(result.thread.context?.messages?.[0]).toMatchObject({
+        role: "user",
+        content: [{ type: "text", text: "Visible" }],
+      });
+    }
+  });
+
+  test("accepts missing optional envelope fields and the legacy AI alias", async () => {
+    const result = await new DeerFlowJsonlThreadParser().parseDetailed(
+      _jsonl(
+        {
+          category: "message",
+          content: { type: "human", content: "Hello" },
+        },
+        {
+          event_type: "ai_message",
+          content: { content: "Hi" },
+        }
+      )
+    );
+
+    expect(result.status).toBe("parsed");
+    if (result.status === "parsed") {
+      expect(
+        result.thread.context?.messages?.map((message) => message.role)
+      ).toEqual(["user", "assistant"]);
+    }
+  });
+
+  test("rejects files without valid JSON rows", async () => {
+    const result = await new DeerFlowJsonlThreadParser().parseDetailed(
+      "not json\n{unfinished"
+    );
+
+    expect(result.status).toBe("invalid-json");
+  });
+
+  test("rejects valid JSONL without DeerFlow messages", async () => {
+    const result = await new DeerFlowJsonlThreadParser().parseDetailed(
+      _jsonl({ event_type: "run.start", category: "trace", content: {} })
+    );
+
+    expect(result.status).toBe("invalid-shape");
+  });
+});

--- a/packages/core/src/parsers/deerflow-jsonl-thread-parser.ts
+++ b/packages/core/src/parsers/deerflow-jsonl-thread-parser.ts
@@ -1,0 +1,168 @@
+import { ThreadZodSchema, type Thread } from "../types";
+
+import { normalizeToThread } from "./normalize-thread";
+import type {
+  ThreadParseContext,
+  ThreadParseDiagnostic,
+  ThreadParser,
+} from "./thread-parser";
+
+const HUMAN_EVENT = "llm.human.input";
+const ASSISTANT_EVENTS = new Set(["llm.ai.response", "ai_message"]);
+const TOOL_EVENT = "llm.tool.result";
+
+/** Parses DeerFlow persisted run-event `.jsonl` files. */
+export class DeerFlowJsonlThreadParser implements ThreadParser {
+  readonly extensions = [".jsonl"] as const;
+
+  parse(
+    raw: string,
+    context?: ThreadParseContext
+  ): Promise<Thread | undefined> {
+    return this.parseDetailed(raw, context).then((result) =>
+      result.status === "parsed" ? result.thread : undefined
+    );
+  }
+
+  parseDetailed(
+    raw: string,
+    context?: ThreadParseContext
+  ): Promise<ThreadParseDiagnostic> {
+    return Promise.resolve(_parseDetailed(raw, context));
+  }
+}
+
+function _parseDetailed(
+  raw: string,
+  context?: ThreadParseContext
+): ThreadParseDiagnostic {
+  const messages: Record<string, unknown>[] = [];
+  let validRows = 0;
+
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+      validRows++;
+    } catch {
+      continue;
+    }
+    const message = _messageFromEvent(value);
+    if (message) {
+      messages.push(message);
+    }
+  }
+
+  if (validRows === 0) {
+    return {
+      status: "invalid-json",
+      message: "The file does not contain valid JSONL.",
+    };
+  }
+
+  const thread = normalizeToThread({ messages }, context);
+  if (!thread) {
+    return {
+      status: "invalid-shape",
+      message: "The JSONL does not contain recognized DeerFlow messages.",
+    };
+  }
+
+  const validated = ThreadZodSchema.safeParse(thread);
+  if (!validated.success) {
+    return {
+      status: "invalid-shape",
+      message: "The JSONL contains invalid DeerFlow messages.",
+    };
+  }
+
+  return { status: "parsed", thread: validated.data, recovered: false };
+}
+
+function _messageFromEvent(
+  value: unknown
+): Record<string, unknown> | undefined {
+  const event = _asRecord(value);
+  const content = _asRecord(event?.content);
+  if (!event || !content) {
+    return undefined;
+  }
+  if (event.category !== undefined && event.category !== "message") {
+    return undefined;
+  }
+
+  const role = _messageRole(event.event_type, content.type);
+  if (!role || _isHidden(event, content, role)) {
+    return undefined;
+  }
+
+  const message: Record<string, unknown> = { ...content, role };
+  if (role === "assistant" && Array.isArray(content.tool_calls)) {
+    message.tool_calls = content.tool_calls.map(_normalizeToolCall);
+  }
+  return message;
+}
+
+function _messageRole(
+  eventType: unknown,
+  contentType: unknown
+): "user" | "assistant" | "tool" | undefined {
+  if (eventType === HUMAN_EVENT) {
+    return "user";
+  }
+  if (typeof eventType === "string" && ASSISTANT_EVENTS.has(eventType)) {
+    return "assistant";
+  }
+  if (eventType === TOOL_EVENT) {
+    return "tool";
+  }
+  if (eventType !== undefined) {
+    return undefined;
+  }
+  if (contentType === "human") {
+    return "user";
+  }
+  if (contentType === "ai") {
+    return "assistant";
+  }
+  if (contentType === "tool") {
+    return "tool";
+  }
+  return undefined;
+}
+
+function _isHidden(
+  event: Record<string, unknown>,
+  content: Record<string, unknown>,
+  role: "user" | "assistant" | "tool"
+): boolean {
+  const caller = _asRecord(event.metadata)?.caller;
+  if (typeof caller === "string") {
+    if (caller.startsWith("middleware:")) {
+      return true;
+    }
+    if (role === "assistant" && caller.startsWith("subagent:")) {
+      return true;
+    }
+  }
+  const additional = _asRecord(content.additional_kwargs);
+  return content.name === "summary" || additional?.hide_from_ui === true;
+}
+
+function _normalizeToolCall(value: unknown): unknown {
+  const toolCall = _asRecord(value);
+  if (!toolCall || !("args" in toolCall) || "arguments" in toolCall) {
+    return value;
+  }
+  const { args, ...rest } = toolCall;
+  return { ...rest, arguments: args };
+}
+
+function _asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/packages/core/src/parsers/index.ts
+++ b/packages/core/src/parsers/index.ts
@@ -1,4 +1,5 @@
 export type { ThreadParseContext, ThreadParser } from "./thread-parser";
+export { DeerFlowJsonlThreadParser } from "./deerflow-jsonl-thread-parser";
 export { JsonThreadParser } from "./json-thread-parser";
 export { normalizeToThread } from "./normalize-thread";
 export {

--- a/packages/core/src/parsers/thread-parser-registry.ts
+++ b/packages/core/src/parsers/thread-parser-registry.ts
@@ -1,5 +1,6 @@
 import type { Thread } from "../types";
 
+import { DeerFlowJsonlThreadParser } from "./deerflow-jsonl-thread-parser";
 import { JsonThreadParser } from "./json-thread-parser";
 import type {
   ThreadParseContext,
@@ -84,7 +85,10 @@ export class ThreadParserRegistry {
  * A registry pre-registered with the built-in parsers.
  */
 export function createDefaultThreadParserRegistry(): ThreadParserRegistry {
-  return new ThreadParserRegistry([new JsonThreadParser()]);
+  return new ThreadParserRegistry([
+    new JsonThreadParser(),
+    new DeerFlowJsonlThreadParser(),
+  ]);
 }
 
 /** Lowercase and ensure a single leading dot, e.g. `"JSON"` → `".json"`. */


### PR DESCRIPTION
Adds import support for DeerFlow persisted run-event JSONL files. The importer keeps visible messages and skips malformed or internal rows.

Closes #99

Tests: `mise run test`, `mise run lint`, `mise run typecheck`, desktop build, and web build.