### PR TITLE
fix(runtime): run bash from workspace root

### DIFF
--- a/packages/runtime/src/tools/built-in/built-in-tools-module.test.ts
+++ b/packages/runtime/src/tools/built-in/built-in-tools-module.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -18,6 +18,42 @@ afterEach(async () => {
 });
 
 describe("built-in tools module", () => {
+  test("runs bash commands from the workspace root", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bash-tool-"));
+    TEMP_DIRS.push(directory);
+    const expectedDirectory = await realpath(directory);
+    const tools = new ToolRegistry();
+    createBuiltInToolsModule({
+      env: {},
+      findSkill: () => null,
+      generateImage: () => Promise.reject(new Error("unused")),
+      getSearchSettings: () => ({
+        provider: "firecrawl",
+        braveApiKey: "",
+        firecrawlApiKey: "",
+        tavilyApiKey: "",
+      }),
+      workspaceRoot: directory,
+    }).register(tools);
+    tools.freeze();
+
+    const result = await tools.call({
+      name: "bash",
+      arguments: { description: "Print working directory", command: "pwd" },
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify(
+          { stdout: `${expectedDirectory}\n`, stderr: "", exitCode: 0 },
+          null,
+          2
+        ),
+      },
+    ]);
+  });
+
   test("contributes the existing tools in their RPC list order", async () => {
     const tools = new ToolRegistry();
     let generatedInput: unknown;

--- a/packages/runtime/src/tools/built-in/fs.ts
+++ b/packages/runtime/src/tools/built-in/fs.ts
@@ -653,6 +653,7 @@ const BASH_MAX_TIMEOUT_MS = 600_000;
 
 export async function bash(
   command: string,
+  workspaceRoot: string,
   timeout?: number
 ): Promise<{
   stdout: string;
@@ -666,7 +667,8 @@ export async function bash(
   const { stdout, stderr, code } = await _run(
     "bash",
     ["-c", command],
-    timeoutMs
+    timeoutMs,
+    workspaceRoot
   );
   return { stdout, stderr, exitCode: code };
 }
@@ -852,6 +854,7 @@ export function createFsBuiltInTools(
       async execute(args: Record<string, unknown>) {
         return bash(
           _requireString(args, "command"),
+          workspaceRoot,
           _optionalNumber(args, "timeout")
         );
       },
@@ -870,10 +873,14 @@ export function createFsBuiltInTools(
 function _run(
   command: string,
   args: string[],
-  timeoutMs?: number
+  timeoutMs?: number,
+  cwd?: string
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     let stdout = "";
     let stderr = "";
     let timedOut = false;


### PR DESCRIPTION
## Summary

- pass the built-in tools workspace root into bash execution
- launch bash with the workspace root as its working directory
- add a regression test that verifies `pwd` resolves to the workspace root

## Verification

- `bun test packages/runtime/src/tools/built-in/built-in-tools-module.test.ts`
- `bun run typecheck`
- `bun run lint`
- full suite: 667 passed; 1 unrelated LangGraph generated-filesystem test requires Python 3.10+ while the local system Python is 3.9.6