### PR TITLE
fix: allow scripts in HTML preview

### DIFF
--- a/packages/ui/src/components/preview-dialog.tsx
+++ b/packages/ui/src/components/preview-dialog.tsx
@@ -84,7 +84,7 @@ function _PreviewDialog({
               <iframe
                 className="size-full rounded-lg border bg-white"
                 referrerPolicy="no-referrer"
-                sandbox=""
+                sandbox="allow-scripts"
                 srcDoc={value}
                 title={`${title} HTML preview`}
               />


### PR DESCRIPTION
## Summary

- allow JavaScript to run in the HTML preview iframe
- retain sandbox origin isolation by enabling only `allow-scripts`

## Validation

- targeted ESLint passed
- UI and full repository typechecks passed
- verified in the Electrobun CEF renderer that `const` executes inside the preview while the iframe origin remains opaque
- full Bun suite: 667 passed; 1 unrelated generated-Python test failed because the local Python 3.9 runtime does not support `int | None` syntax