### PR TITLE
fix(ui): lower message navigator stacking

### DIFF
--- a/packages/ui/src/components/thread-playground/message/message-navigator.tsx
+++ b/packages/ui/src/components/thread-playground/message/message-navigator.tsx
@@ -174,7 +174,7 @@ function _MessageNavigator({
   return (
     <nav
       aria-label="Message navigation"
-      className="pointer-events-none absolute top-1/2 -left-2 z-100 -translate-y-1/2"
+      className="pointer-events-none absolute top-1/2 -left-2 z-50 -translate-y-1/2"
     >
       <div className="hover:bg-background/70 focus-within:bg-background/70 pointer-events-auto flex max-h-[45vh] w-7 flex-col items-start gap-px overflow-hidden hover:overflow-y-auto rounded-full py-1 pl-1.5 opacity-65 transition-[background-color,opacity] focus-within:opacity-100 hover:opacity-100">
         {messages.map((message, index) => {


### PR DESCRIPTION
## Summary

- lower the message navigator z-index from 100 to 50
- keep the navigator below higher-priority overlays while preserving its placement above regular content

## Testing

- `bun run lint` ✅
- `bun run typecheck` ⚠️ fails on existing `signal` property type errors in `packages/runtime/src/models/model-manager.ts` and `packages/runtime/src/models/providers/openai-codex.test.ts`; this PR does not modify either file