### PR TITLE
feat(models): route DeepSeek V4 Pro through Responses

### DIFF
--- a/packages/runtime/src/models/providers/deepseek.ts
+++ b/packages/runtime/src/models/providers/deepseek.ts
@@ -12,7 +12,10 @@ type DeepSeekApi = "openai-completions" | "openai-responses";
 
 export function deepseekProvider(): Provider<DeepSeekApi> {
   const models = Object.values(DEEPSEEK_MODELS).map((model) => {
-    if (model.id !== "deepseek-v4-flash") {
+    if (
+      model.id !== "deepseek-v4-flash" &&
+      model.id !== "deepseek-v4-pro"
+    ) {
       return model;
     }
     return {

--- a/packages/runtime/tests/models/providers/deepseek.test.ts
+++ b/packages/runtime/tests/models/providers/deepseek.test.ts
@@ -3,15 +3,18 @@ import { describe, expect, test } from "bun:test";
 import { deepseekProvider } from "../../../src/models/providers/deepseek";
 
 describe("DeepSeek mixed API provider", () => {
-  test("routes V4 Flash through Responses and keeps V4 Pro on Completions", () => {
+  test("routes V4 Flash and V4 Pro through Responses", () => {
     const models = deepseekProvider().getModels();
     const flash = models.find((model) => model.id === "deepseek-v4-flash");
     const pro = models.find((model) => model.id === "deepseek-v4-pro");
 
     expect(flash?.api).toBe("openai-responses");
-    expect(pro?.api).toBe("openai-completions");
+    expect(pro?.api).toBe("openai-responses");
     expect(
       models.filter((model) => model.id === "deepseek-v4-flash")
+    ).toHaveLength(1);
+    expect(
+      models.filter((model) => model.id === "deepseek-v4-pro")
     ).toHaveLength(1);
     expect(flash).toMatchObject({
       input: ["text"],
@@ -21,6 +24,22 @@ describe("DeepSeek mixed API provider", () => {
         input: 0.14,
         output: 0.28,
         cacheRead: 0.0028,
+        cacheWrite: 0,
+      },
+      compat: {
+        supportsDeveloperRole: false,
+        supportsLongCacheRetention: false,
+        sessionAffinityFormat: "openai-nosession",
+      },
+    });
+    expect(pro).toMatchObject({
+      input: ["text"],
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      cost: {
+        input: 0.435,
+        output: 0.87,
+        cacheRead: 0.003625,
         cacheWrite: 0,
       },
       compat: {


### PR DESCRIPTION
## Summary

- Route `deepseek-v4-pro` through the `openai-responses` adapter, matching the existing V4 Flash behavior.
- Preserve the upstream model catalog metadata while applying the existing stateless DeepSeek Responses compatibility settings.
- Extend the focused provider regression test to cover both DeepSeek V4 models.

## Why

DeepSeek now documents Responses API support for both `deepseek-v4-flash` and `deepseek-v4-pro`. LLM Space already overrides Flash because the current `pi-ai` catalog still marks both models as `openai-completions`; this change brings Pro onto the same Responses path so it can use Responses-format output and provider-hosted tools.

DeepSeek documentation: https://api-docs.deepseek.com/guides/responses_api/

## Validation

- `bun test packages/runtime/tests/models/providers/deepseek.test.ts`
- `mise run test`
- `mise run check:changed`