### PR TITLE
fix(runtime): support Langfuse v3/v4 trace endpoints

### DIFF
--- a/packages/runtime/src/traces/langfuse-client.ts
+++ b/packages/runtime/src/traces/langfuse-client.ts
@@ -63,6 +63,42 @@ type LangfuseTraceFilter =
       value: string[];
     };
 
+type LangfuseObservationFilter =
+  | {
+      type: "string";
+      column:
+        | "traceId"
+        | "traceName"
+        | "userId"
+        | "sessionId"
+        | "traceVersion"
+        | "traceRelease";
+      operator: "=" | "contains";
+      value: string;
+    }
+  | {
+      type: "arrayOptions";
+      column: "tags";
+      operator: "all of";
+      value: string[];
+    }
+  | {
+      type: "stringOptions";
+      column: "environment";
+      operator: "any of";
+      value: string[];
+    };
+
+class LangfuseHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "LangfuseHttpError";
+    this.status = status;
+  }
+}
+
 const OBSERVATION_FIELDS =
   "core,basic,time,io,model,usage,trace_context,metrics";
 // Langfuse v2 observations return input/output as raw strings. The old
@@ -73,6 +109,7 @@ const DEFAULT_REMOTE_TRACE_LIMIT = 50;
 const MAX_REMOTE_TRACE_LIMIT = 100;
 const MAX_OBSERVATION_PAGES = 5;
 const OBSERVATION_PAGE_LIMIT = 1000;
+const LEGACY_OBSERVATION_PAGE_LIMIT = 100;
 const TRACE_SEARCH_QUERY_COLUMNS = [
   "id",
   "name",
@@ -136,19 +173,26 @@ export class LangfuseClient {
           value: query,
         }))
       : [null];
-    const results = await Promise.all(
-      queryFilters.map((queryFilter) =>
-        this._listTraces({
-          filters: queryFilter ? [...baseFilters, queryFilter] : baseFilters,
-          limit: filters.limit ?? DEFAULT_REMOTE_TRACE_LIMIT,
-          orderBy: filters.orderBy,
-        })
-      )
-    );
-    return _sortTraceSummaries(
-      _dedupeTraceSummaries(results.flat()),
-      filters.orderBy
-    ).slice(0, filters.limit ?? DEFAULT_REMOTE_TRACE_LIMIT);
+    try {
+      const results = await Promise.all(
+        queryFilters.map((queryFilter) =>
+          this._listTraces({
+            filters: queryFilter ? [...baseFilters, queryFilter] : baseFilters,
+            limit: filters.limit ?? DEFAULT_REMOTE_TRACE_LIMIT,
+            orderBy: filters.orderBy,
+          })
+        )
+      );
+      return _sortTraceSummaries(
+        _dedupeTraceSummaries(results.flat()),
+        filters.orderBy
+      ).slice(0, filters.limit ?? DEFAULT_REMOTE_TRACE_LIMIT);
+    } catch (error) {
+      if (!_isLangfuseNotFound(error)) {
+        throw error;
+      }
+      return this._searchTracesFromObservations(filters);
+    }
   }
 
   private async _listTraces({
@@ -176,43 +220,141 @@ export class LangfuseClient {
       .filter((row): row is TraceRemoteTraceSummary => row !== null);
   }
 
-  /** Fetch all observations for a remote trace id, bounded for V1 safety. */
+  private async _searchTracesFromObservations(
+    filters: ReturnType<typeof _normalizeTraceSearchInput>
+  ): Promise<TraceRemoteTraceSummary[]> {
+    const baseFilters = _observationFiltersFromSearchInput(filters);
+    const queryFilters = filters.query
+      ? (["traceId", "traceName", "userId", "sessionId"] as const).map(
+          (column): LangfuseObservationFilter => ({
+            type: "string",
+            column,
+            operator: "contains",
+            value: filters.query!,
+          })
+        )
+      : [null];
+    const results = await Promise.all(
+      queryFilters.map((queryFilter) =>
+        this._listObservationPages({
+          filters: queryFilter ? [...baseFilters, queryFilter] : baseFilters,
+          fromTimestamp: filters.fromTimestamp,
+          toTimestamp: filters.toTimestamp,
+        })
+      )
+    );
+    return _sortTraceSummaries(
+      _dedupeTraceSummaries(
+        results.flatMap(({ rows }) => _traceSummariesFromObservations(rows))
+      ),
+      filters.orderBy
+    ).slice(0, filters.limit ?? DEFAULT_REMOTE_TRACE_LIMIT);
+  }
+
+  /** Fetch all observations for a remote trace id, bounded for compatibility. */
   async getObservationsForTrace(
     traceId: string
   ): Promise<LangfuseObservationFetchResult> {
+    try {
+      return await this._listObservationPages({ traceId });
+    } catch (error) {
+      if (!_isLangfuseNotFound(error)) {
+        throw error;
+      }
+      return this._listObservationPages({
+        traceId,
+        legacy: true,
+      });
+    }
+  }
+
+  private async _listObservationPages({
+    filters = [],
+    traceId,
+    fromTimestamp,
+    toTimestamp,
+    legacy = false,
+  }: {
+    filters?: LangfuseObservationFilter[];
+    traceId?: string;
+    fromTimestamp?: string;
+    toTimestamp?: string;
+    legacy?: boolean;
+  }): Promise<
+    LangfuseObservationFetchResult & { rows: LangfuseObservation[] }
+  > {
     const rows: LangfuseObservation[] = [];
     let cursor: string | undefined;
     let pageCount = 0;
+    let legacyPage = 1;
     for (let page = 0; page < MAX_OBSERVATION_PAGES; page += 1) {
       pageCount = page + 1;
-      const url = new URL(`${this._baseUrl}/api/public/v2/observations`);
-      url.searchParams.set("fields", OBSERVATION_FIELDS);
-      url.searchParams.set("limit", String(OBSERVATION_PAGE_LIMIT));
-      url.searchParams.set("traceId", traceId);
-      if (cursor) {
+      const path = legacy
+        ? "/api/public/observations"
+        : "/api/public/v2/observations";
+      const url = new URL(`${this._baseUrl}${path}`);
+      if (!legacy) {
+        url.searchParams.set("fields", OBSERVATION_FIELDS);
+        url.searchParams.set("limit", String(OBSERVATION_PAGE_LIMIT));
+      } else {
+        url.searchParams.set("limit", String(LEGACY_OBSERVATION_PAGE_LIMIT));
+        url.searchParams.set("page", String(legacyPage));
+      }
+      if (traceId) {
+        url.searchParams.set("traceId", traceId);
+      }
+      if (fromTimestamp) {
+        url.searchParams.set(
+          legacy ? "fromTimestamp" : "fromStartTime",
+          fromTimestamp
+        );
+      }
+      if (toTimestamp) {
+        url.searchParams.set(
+          legacy ? "toTimestamp" : "toStartTime",
+          toTimestamp
+        );
+      }
+      if (filters.length > 0) {
+        url.searchParams.set("filter", JSON.stringify(filters));
+      }
+      if (!legacy && cursor) {
         url.searchParams.set("cursor", cursor);
       }
       const body = await this._getJson(url);
       const data = _asRecord(body)?.data;
-      if (Array.isArray(data)) {
-        rows.push(
-          ...data
-            .map(_asRecord)
-            .filter((row): row is LangfuseObservation => Boolean(row))
-        );
-      }
-      cursor = _firstString(
-        _asRecord(_asRecord(body)?.meta)?.nextCursor,
-        _asRecord(_asRecord(body)?.meta)?.cursor,
-        _asRecord(body)?.nextCursor
+      const dataRows = Array.isArray(data) ? data : [];
+      rows.push(
+        ...dataRows
+          .map(_asRecord)
+          .filter((row): row is LangfuseObservation => Boolean(row))
       );
-      if (!cursor) {
-        break;
+      const meta = _asRecord(_asRecord(body)?.meta);
+      if (legacy) {
+        const totalPages = _finiteNumber(meta?.totalPages);
+        const currentPage = _finiteNumber(meta?.page) || legacyPage;
+        if (
+          (totalPages > 0 && currentPage >= totalPages) ||
+          (totalPages === 0 && dataRows.length < LEGACY_OBSERVATION_PAGE_LIMIT)
+        ) {
+          cursor = undefined;
+          break;
+        }
+        legacyPage += 1;
+      } else {
+        cursor = _firstString(
+          meta?.nextCursor,
+          meta?.cursor,
+          _asRecord(body)?.nextCursor
+        );
+        if (!cursor) {
+          break;
+        }
       }
     }
     return {
       rows,
-      truncated: Boolean(cursor),
+      truncated: legacy ? legacyPage > MAX_OBSERVATION_PAGES : Boolean(cursor),
       pageCount,
       maxPages: MAX_OBSERVATION_PAGES,
     };
@@ -232,7 +374,10 @@ export class LangfuseClient {
       throw new Error(_redactedFetchError(error), { cause: error });
     }
     if (!response.ok) {
-      throw new Error(await _redactedHttpError(response));
+      throw new LangfuseHttpError(
+        response.status,
+        await _redactedHttpError(response)
+      );
     }
     try {
       return await response.json();
@@ -267,6 +412,121 @@ export function previewSecret(value: string): string {
     return trimmed ? `${trimmed.slice(0, 2)}...` : "";
   }
   return `${trimmed.slice(0, 5)}...${trimmed.slice(-4)}`;
+}
+
+function _observationFiltersFromSearchInput(
+  input: ReturnType<typeof _normalizeTraceSearchInput>
+): LangfuseObservationFilter[] {
+  const filters: LangfuseObservationFilter[] = [];
+  const stringFilters = [
+    ["traceId", input.id],
+    ["traceName", input.name],
+    ["userId", input.userId],
+    ["sessionId", input.sessionId],
+    ["traceVersion", input.version],
+    ["traceRelease", input.release],
+  ] as const;
+  for (const [column, value] of stringFilters) {
+    if (value) {
+      filters.push({ type: "string", column, operator: "=", value });
+    }
+  }
+  if (input.tags && input.tags.length > 0) {
+    filters.push({
+      type: "arrayOptions",
+      column: "tags",
+      operator: "all of",
+      value: input.tags,
+    });
+  }
+  if (input.environment && input.environment.length > 0) {
+    filters.push({
+      type: "stringOptions",
+      column: "environment",
+      operator: "any of",
+      value: input.environment,
+    });
+  }
+  return filters;
+}
+
+function _traceSummariesFromObservations(
+  rows: LangfuseObservation[]
+): TraceRemoteTraceSummary[] {
+  const byId = new Map<string, TraceRemoteTraceSummary>();
+  for (const row of rows) {
+    const id = _firstString(row.traceId);
+    if (!id) {
+      continue;
+    }
+    const timestamp = _firstString(row.startTime, row.timestamp, row.createdAt);
+    const existing = byId.get(id);
+    if (!existing) {
+      byId.set(id, {
+        id,
+        ...(_firstString(row.traceName, row.name)
+          ? { name: _firstString(row.traceName, row.name) }
+          : {}),
+        ...(timestamp ? { timestamp } : {}),
+        ...(_firstString(row.userId)
+          ? { userId: _firstString(row.userId) }
+          : {}),
+        ...(_firstString(row.sessionId)
+          ? { sessionId: _firstString(row.sessionId) }
+          : {}),
+        ...(_firstString(row.traceVersion, row.version)
+          ? { version: _firstString(row.traceVersion, row.version) }
+          : {}),
+        ...(_firstString(row.traceRelease, row.release)
+          ? { release: _firstString(row.traceRelease, row.release) }
+          : {}),
+        ...(_firstString(row.environment)
+          ? { environment: _firstString(row.environment) }
+          : {}),
+        ...(_stringArray(row.tags).length > 0
+          ? { tags: _stringArray(row.tags) }
+          : {}),
+        observationCount: 1,
+        ...(_finiteNumber(row.totalCost) > 0
+          ? { totalCost: _finiteNumber(row.totalCost) }
+          : {}),
+      });
+      continue;
+    }
+    existing.observationCount = (existing.observationCount ?? 0) + 1;
+    if (timestamp && (!existing.timestamp || timestamp < existing.timestamp)) {
+      existing.timestamp = timestamp;
+    }
+    if (!existing.name) {
+      existing.name = _firstString(row.traceName, row.name);
+    }
+    if (!existing.userId) {
+      existing.userId = _firstString(row.userId);
+    }
+    if (!existing.sessionId) {
+      existing.sessionId = _firstString(row.sessionId);
+    }
+    if (!existing.version) {
+      existing.version = _firstString(row.traceVersion, row.version);
+    }
+    if (!existing.release) {
+      existing.release = _firstString(row.traceRelease, row.release);
+    }
+    if (!existing.environment) {
+      existing.environment = _firstString(row.environment);
+    }
+    if ((existing.tags?.length ?? 0) === 0) {
+      const tags = _stringArray(row.tags);
+      if (tags.length > 0) {
+        existing.tags = tags;
+      }
+    }
+    const cost = _finiteNumber(row.totalCost);
+    if (cost > 0) {
+      existing.totalCost = (existing.totalCost ?? 0) + cost;
+    }
+  }
+  return [...byId.values()];
 }
 
 function _normalizeTraceSearchInput(
@@ -535,15 +795,6 @@ function _traceSummaryFromRow(
 
 async function _redactedHttpError(response: Response): Promise<string> {
   const status = response.status;
-  if (status === 401) {
-    return "Langfuse rejected the API keys (401 Unauthorized).";
-  }
-  if (status === 403) {
-    return "Langfuse API keys do not have access to this project (403 Forbidden).";
-  }
-  if (status === 404) {
-    return "Langfuse endpoint was not found. Check the base URL.";
-  }
   let message = "";
   try {
     const body = (await response.json()) as unknown;
@@ -552,7 +803,22 @@ async function _redactedHttpError(response: Response): Promise<string> {
   } catch {
     // Ignore non-JSON error bodies; status text is enough.
   }
+  if (status === 401) {
+    return "Langfuse rejected the API keys (401 Unauthorized).";
+  }
+  if (status === 403) {
+    return "Langfuse API keys do not have access to this project (403 Forbidden).";
+  }
+  if (status === 404) {
+    return `Langfuse endpoint was not found (404)${
+      message ? `: ${message}` : "."
+    }`;
+  }
   return `Langfuse request failed (${status})${message ? `: ${message}` : "."}`;
+}
+
+function _isLangfuseNotFound(error: unknown): boolean {
+  return error instanceof LangfuseHttpError && error.status === 404;
 }
 
 function _redactedFetchError(error: unknown): string {

--- a/packages/runtime/tests/traces/langfuse-client.test.ts
+++ b/packages/runtime/tests/traces/langfuse-client.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { LangfuseClient } from "../../src/traces/langfuse-client";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof URL ? input.toString() : input.url;
+}
+
+function installFetch(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+): void {
+  globalThis.fetch = handler as typeof fetch;
+}
+
+function client(): LangfuseClient {
+  return new LangfuseClient({
+    baseUrl: "https://langfuse.example.test",
+    publicKey: "pk-test",
+    secretKey: "sk-test",
+  });
+}
+
+describe("Langfuse endpoint compatibility", () => {
+  test("falls back to v2 observations when trace search is unavailable", async () => {
+    const requests: string[] = [];
+    installFetch(async (input) => {
+      const url = requestUrl(input);
+      requests.push(url);
+      if (url.includes("/api/public/traces")) {
+        return jsonResponse(
+          {
+            message:
+              "This endpoint is not available on events_only deployments.",
+          },
+          404
+        );
+      }
+      return jsonResponse({
+        data: [
+          {
+            traceId: "trace-1",
+            traceName: "agent-run",
+            startTime: "2026-08-20T10:00:00.000Z",
+            userId: "user-1",
+            sessionId: "session-1",
+            traceVersion: "v1",
+            traceRelease: "release-1",
+            environment: "production",
+            tags: ["important"],
+            totalCost: 1.25,
+          },
+          {
+            traceId: "trace-1",
+            traceName: "agent-run",
+            startTime: "2026-08-20T10:00:01.000Z",
+            totalCost: 0.75,
+          },
+        ],
+      });
+    });
+
+    expect(client().searchTraces({ limit: 10 })).resolves.toEqual([
+      {
+        id: "trace-1",
+        name: "agent-run",
+        timestamp: "2026-08-20T10:00:00.000Z",
+        userId: "user-1",
+        sessionId: "session-1",
+        version: "v1",
+        release: "release-1",
+        environment: "production",
+        tags: ["important"],
+        observationCount: 2,
+        totalCost: 2,
+      },
+    ]);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toContain("/api/public/traces");
+    expect(requests[1]).toContain("/api/public/v2/observations");
+  });
+
+  test("falls back to legacy observations when v2 observations are unavailable", async () => {
+    const requests: string[] = [];
+    installFetch(async (input) => {
+      const url = requestUrl(input);
+      requests.push(url);
+      if (url.includes("/api/public/v2/observations")) {
+        return jsonResponse({ message: "v2 is unavailable" }, 404);
+      }
+      return jsonResponse({
+        data: [{ id: "observation-1", traceId: "trace-1", name: "root" }],
+        meta: { page: 1, totalPages: 1 },
+      });
+    });
+
+    expect(client().getObservationsForTrace("trace-1")).resolves.toEqual({
+      rows: [{ id: "observation-1", traceId: "trace-1", name: "root" }],
+      truncated: false,
+      pageCount: 1,
+      maxPages: 5,
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toContain("/api/public/observations");
+    expect(requests[1]).toContain("page=1");
+  });
+
+  test("does not fall back for authentication failures", async () => {
+    let requestCount = 0;
+    installFetch(async () => {
+      requestCount += 1;
+      return jsonResponse({ message: "invalid credentials" }, 401);
+    });
+
+    expect(client().getObservationsForTrace("trace-1")).rejects.toThrow(
+      "401 Unauthorized"
+    );
+    expect(requestCount).toBe(1);
+  });
+
+  test("preserves unsupported-deployment details when both search APIs fail", async () => {
+    installFetch(async () =>
+      jsonResponse(
+        {
+          message:
+            "This endpoint is not available on deployments running in events_only mode.",
+        },
+        404
+      )
+    );
+
+    expect(client().searchTraces()).rejects.toThrow("events_only mode");
+  });
+});


### PR DESCRIPTION
## Summary

- Fall back from `GET /api/public/traces` to v2 observations for Langfuse v4 `events_only` deployments.
- Fall back from v2 observations to legacy `GET /api/public/observations` for Langfuse v3 self-hosted deployments.
- Aggregate observation rows into trace summaries and preserve deployment-specific 404 details.
- Add regression tests covering both fallbacks and authentication failures.

Closes #146

## Validation

- `bun test packages/runtime/tests` — 106 passed
- `bun run lint` — passed
- `bun run typecheck` — passed
- `bun test` — 773 passed, 1 unrelated failure because the local Python environment lacks `jinja2` (`templates.test.ts`)
