### PR TITLE
fix(core): confine LocalFileSystem paths

### DIFF
--- a/packages/core/src/server/storage/local/file-system.ts
+++ b/packages/core/src/server/storage/local/file-system.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { lstatSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -247,9 +248,26 @@ export class LocalFileSystem implements FileSystem, ThreadStorage {
    * that would escape it.
    */
   private _resolve(p: string): string {
-    const real = path.resolve(this.root, this._relative(p));
+    if (path.posix.isAbsolute(p) || path.win32.isAbsolute(p)) {
+      throw new Error(`Path must be relative to the storage root: ${p}`);
+    }
+    const relative = this._relative(p);
+    const real = path.resolve(this.root, relative);
     if (real !== this.root && !real.startsWith(this.root + path.sep)) {
       throw new Error(`Path escapes the storage root: ${p}`);
+    }
+    let current = this.root;
+    for (const part of relative.split(path.sep)) {
+      if (!part) continue;
+      current = path.join(current, part);
+      try {
+        if (lstatSync(current).isSymbolicLink()) {
+          throw new Error(`Symbolic links are not allowed in storage paths: ${p}`);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") break;
+        throw error;
+      }
     }
     return real;
   }

--- a/packages/core/tests/server/storage/local/file-system.test.ts
+++ b/packages/core/tests/server/storage/local/file-system.test.ts
@@ -116,6 +116,28 @@ describe("LocalFileSystem.mv", () => {
   });
 });
 
+describe("LocalFileSystem path confinement", () => {
+  test("rejects absolute paths", async () => {
+    const fileSystem = await _createFileSystem();
+
+    expect(fileSystem.ls("/outside")).rejects.toThrow(
+      "Path must be relative to the storage root"
+    );
+  });
+
+  test("rejects symlinks that point outside the workspace", async () => {
+    const workspace = await _createWorkspace();
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "llm-space-outside-"));
+    TEMP_DIRS.push(outside);
+    await fs.writeFile(path.join(outside, "secret.json"), '{"title":"outside"}');
+    await fs.symlink(outside, workspace.fileSystem.realpath("link"));
+
+    expect(workspace.fileSystem.read("link/secret.json")).rejects.toThrow(
+      "Symbolic links are not allowed in storage paths"
+    );
+  });
+});
+
 describe("LocalFileSystem.write", () => {
   test("writes a new formatted thread file", async () => {
     const fileSystem = await _createFileSystem();


### PR DESCRIPTION
## Summary

- reject absolute paths passed to workspace-scoped LocalFileSystem APIs
- reject symlink components so workspace operations cannot escape the storage root
- add regression tests for both cases

## Validation

- `bun test packages/core/tests/server/storage/local/file-system.test.ts`
- `bun x tsc --noEmit -p packages/core/tsconfig.json`
- targeted ESLint

This PR is intentionally based on `main` and does not include the separate Langfuse changes.