### PR TITLE
fix(ui): stabilize message list scrolling

### DIFF
--- a/packages/ui/src/components/thread-playground/message/message-list-view.tsx
+++ b/packages/ui/src/components/thread-playground/message/message-list-view.tsx
@@ -52,6 +52,7 @@ import {
 import { MessageListItem } from "./message-list-item";
 import { resolveMessageMove } from "./message-move";
 import { MessageNavigator } from "./message-navigator";
+import { followMessageViewportBottom } from "./message-scroll-stability";
 import { findCenteredVirtualItemIndex } from "./virtual-item-center";
 
 const MESSAGE_VIRTUALIZATION_THRESHOLD = 20;
@@ -300,12 +301,6 @@ export function MessageListView({
     },
     [messageIds, moveMessage]
   );
-  const scrollToBottom = useCallback(() => {
-    const viewport = getScrollElement();
-    if (viewport) {
-      viewport.scrollTop = viewport.scrollHeight;
-    }
-  }, [getScrollElement]);
   const scrollToMessageIndex = useCallback(
     (
       index: number,
@@ -401,10 +396,16 @@ export function MessageListView({
     };
   }, [displayRows.length, getScrollElement, shouldVirtualize]);
   useEffect(() => {
-    if (status === "running") {
-      scrollToBottom();
+    if (status !== "running") {
+      return;
     }
-  }, [status, scrollToBottom]);
+    const viewport = getScrollElement();
+    const content = contentRef.current;
+    if (!viewport || !content) {
+      return;
+    }
+    return followMessageViewportBottom(viewport, content);
+  }, [getScrollElement, status]);
   useEffect(() => {
     if (!autoFocusMessageId) {
       return;
@@ -455,8 +456,11 @@ export function MessageListView({
                 items={messageIds}
                 strategy={verticalListSortingStrategy}
               >
+                {/* TanStack writes the virtual height directly to the DOM, so
+                    these layouts must not reuse the same container node. */}
                 {shouldVirtualize ? (
                   <div
+                    key="virtualized"
                     ref={virtualizer.containerRef}
                     className="relative w-full"
                   >
@@ -482,7 +486,7 @@ export function MessageListView({
                     })}
                   </div>
                 ) : (
-                  <div className="w-full pt-3">
+                  <div key="standard" className="w-full pt-3">
                     {displayRows.map((row, index) => (
                       <MessageRow
                         key={row.message.id}

--- a/packages/ui/src/components/thread-playground/message/message-scroll-stability.ts
+++ b/packages/ui/src/components/thread-playground/message/message-scroll-stability.ts
@@ -1,4 +1,9 @@
 type FrameScheduler = (callback: FrameRequestCallback) => number;
+type FrameCanceler = (frameId: number) => void;
+
+type ResizeObserverFactory = (
+  callback: ResizeObserverCallback
+) => Pick<ResizeObserver, "disconnect" | "observe">;
 
 interface ScrollViewport {
   scrollTop: number;
@@ -15,6 +20,71 @@ interface ScrollStabilizationSession {
 
 const sessions = new WeakMap<HTMLElement, ScrollStabilizationSession>();
 const STABILIZATION_TIMEOUT_MS = 10_000;
+const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 48;
+
+/**
+ * Follow layout growth at the bottom of an active run without subscribing the
+ * full message list to every streaming update. Scrolling upward opts out until
+ * the viewport reaches the bottom again.
+ */
+export function followMessageViewportBottom(
+  viewport: HTMLElement,
+  content: HTMLElement,
+  options: {
+    cancelFrame?: FrameCanceler;
+    createResizeObserver?: ResizeObserverFactory;
+    scheduleFrame?: FrameScheduler;
+  } = {}
+) {
+  const scheduleFrame = options.scheduleFrame ?? requestAnimationFrame;
+  const cancelFrame = options.cancelFrame ?? cancelAnimationFrame;
+  let following = true;
+  let frameId: number | null = null;
+  let previousScrollTop = viewport.scrollTop;
+
+  const isNearBottom = () =>
+    viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop <=
+    AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+  const scrollToBottom = () => {
+    frameId = null;
+    if (!following) {
+      return;
+    }
+    viewport.scrollTop = viewport.scrollHeight;
+    previousScrollTop = viewport.scrollTop;
+  };
+  const scheduleScrollToBottom = () => {
+    if (following && frameId === null) {
+      frameId = scheduleFrame(scrollToBottom);
+    }
+  };
+  const handleScroll = () => {
+    const scrollTop = viewport.scrollTop;
+    if (isNearBottom()) {
+      following = true;
+    } else if (scrollTop < previousScrollTop - 1) {
+      following = false;
+    }
+    previousScrollTop = scrollTop;
+  };
+
+  const observer = (
+    options.createResizeObserver ??
+    ((callback: ResizeObserverCallback) => new ResizeObserver(callback))
+  )(scheduleScrollToBottom);
+  viewport.addEventListener("scroll", handleScroll, { passive: true });
+  observer.observe(content);
+  viewport.scrollTop = viewport.scrollHeight;
+  previousScrollTop = viewport.scrollTop;
+
+  return () => {
+    observer.disconnect();
+    viewport.removeEventListener("scroll", handleScroll);
+    if (frameId !== null) {
+      cancelFrame(frameId);
+    }
+  };
+}
 
 /**
  * Keep the message viewport at the same offset while React and the virtualizer

--- a/packages/ui/tests/components/thread-playground/message/message-scroll-stability.test.ts
+++ b/packages/ui/tests/components/thread-playground/message/message-scroll-stability.test.ts
@@ -1,6 +1,117 @@
 import { describe, expect, test } from "bun:test";
 
-import { preserveScrollOffsetAfterLayout } from "../../../../src/components/thread-playground/message/message-scroll-stability";
+import {
+  followMessageViewportBottom,
+  preserveScrollOffsetAfterLayout,
+} from "../../../../src/components/thread-playground/message/message-scroll-stability";
+
+class FakeViewport extends EventTarget {
+  clientHeight = 200;
+  scrollHeight = 1_000;
+  private _scrollTop = 0;
+
+  get scrollTop() {
+    return this._scrollTop;
+  }
+
+  set scrollTop(value: number) {
+    this._scrollTop = Math.max(
+      0,
+      Math.min(value, this.scrollHeight - this.clientHeight)
+    );
+  }
+}
+
+function _bottomFollowerHarness() {
+  const viewport = new FakeViewport();
+  const content = new EventTarget();
+  const frames: FrameRequestCallback[] = [];
+  const canceledFrames: number[] = [];
+  let disconnected = false;
+  let observed = false;
+  let resize: ResizeObserverCallback = () => undefined;
+  const cleanup = followMessageViewportBottom(
+    viewport as unknown as HTMLElement,
+    content as unknown as HTMLElement,
+    {
+      cancelFrame: (frameId) => canceledFrames.push(frameId),
+      createResizeObserver: (callback) => {
+        resize = callback;
+        return {
+          disconnect() {
+            disconnected = true;
+          },
+          observe() {
+            observed = true;
+          },
+        };
+      },
+      scheduleFrame: (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+    }
+  );
+  return {
+    canceledFrames,
+    cleanup,
+    frames,
+    resize,
+    viewport,
+    wasDisconnected: () => disconnected,
+    wasObserved: () => observed,
+  };
+}
+
+describe("followMessageViewportBottom", () => {
+  test("keeps following streaming content growth after the run starts", () => {
+    const { cleanup, frames, resize, viewport } = _bottomFollowerHarness();
+
+    expect(viewport.scrollTop).toBe(800);
+    viewport.scrollHeight = 1_200;
+    resize([], {} as ResizeObserver);
+    frames.shift()?.(0);
+
+    expect(viewport.scrollTop).toBe(1_000);
+    cleanup();
+  });
+
+  test("pauses on upward scrolling and resumes when the user returns", () => {
+    const { cleanup, frames, resize, viewport } = _bottomFollowerHarness();
+
+    viewport.scrollTop = 600;
+    viewport.dispatchEvent(new Event("scroll"));
+    viewport.scrollHeight = 1_200;
+    resize([], {} as ResizeObserver);
+    frames.shift()?.(0);
+    expect(viewport.scrollTop).toBe(600);
+
+    viewport.scrollTop = 1_000;
+    viewport.dispatchEvent(new Event("scroll"));
+    viewport.scrollHeight = 1_400;
+    resize([], {} as ResizeObserver);
+    frames.shift()?.(16);
+    expect(viewport.scrollTop).toBe(1_200);
+    cleanup();
+  });
+
+  test("cancels a pending follow-up when the run ends", () => {
+    const {
+      canceledFrames,
+      cleanup,
+      resize,
+      wasDisconnected,
+      wasObserved,
+    } = _bottomFollowerHarness();
+
+    expect(wasObserved()).toBe(true);
+    resize([], {} as ResizeObserver);
+    cleanup();
+
+    expect(canceledFrames).toEqual([1]);
+    expect(wasDisconnected()).toBe(true);
+  });
+});
 
 describe("preserveScrollOffsetAfterLayout", () => {
   test("restores the pre-update offset across two layout frames", () => {


### PR DESCRIPTION
## Summary

- remount the message container when switching out of virtualization so TanStack Virtual cannot leave stale inline height behind
- keep the message viewport pinned to the bottom as streaming content and tool results grow during automatic execution
- pause bottom-following when the user scrolls upward and resume after they return near the bottom
- add regression coverage for streaming growth, user override/resume, and cleanup

## Verification

- `bun test packages/ui/tests/components/thread-playground/message` (36 passing)
- `mise run check:changed`
- verified both regressions in the real Electrobun CEF renderer via CDP