### PR TITLE
fix(runtime): cap bash/grep/glob tool output sizes

### DIFF
--- a/packages/runtime/src/tools/built-in/fs.ts
+++ b/packages/runtime/src/tools/built-in/fs.ts
@@ -578,7 +578,13 @@ export async function grep(
   }
   args.push("--regexp", pattern, "--", searchPath);
 
-  const { stdout, stderr, code } = await _run("rg", args);
+  const { stdout, stderr, code } = await _run(
+    "rg",
+    args,
+    undefined,
+    undefined,
+    SUBPROCESS_MAX_OUTPUT_BYTES
+  );
   if (code === 1) {
     return "No matches found.";
   }
@@ -620,6 +626,10 @@ export const globTool: BuiltinTool = {
   },
 };
 
+// The full path list is returned to the model and persisted with the thread,
+// so a broad pattern (e.g. `**/*` over a home directory) must be capped.
+const GLOB_MAX_RESULTS = 200;
+
 export async function glob(
   globPattern: string,
   targetDirectory: string | undefined,
@@ -642,10 +652,13 @@ export async function glob(
   if (matches.length === 0) {
     return "No files matched.";
   }
-  return matches
-    .sort((a, b) => b.mtimeMs - a.mtimeMs)
-    .map((match) => match.path)
-    .join("\n");
+  matches.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const shown = matches.slice(0, GLOB_MAX_RESULTS);
+  const lines = shown.map((match) => match.path).join("\n");
+  if (matches.length > GLOB_MAX_RESULTS) {
+    return `${lines}\n... [showing first ${GLOB_MAX_RESULTS} of ${matches.length} matches; narrow the pattern or target directory]`;
+  }
+  return lines;
 }
 
 // -- bash ---------------------------------------------------------------------
@@ -683,6 +696,10 @@ export const bashTool: BuiltinTool = {
 
 const BASH_DEFAULT_TIMEOUT_MS = 120_000;
 const BASH_MAX_TIMEOUT_MS = 600_000;
+// Matches READ_MAX_SIZE_BYTES: subprocess output is returned to the model and
+// persisted into the thread, so an unbounded stream (e.g. `cat huge.log`)
+// must not flow through untouched.
+const SUBPROCESS_MAX_OUTPUT_BYTES = 256 * 1024;
 
 export async function bash(
   command: string,
@@ -701,7 +718,8 @@ export async function bash(
     "bash",
     ["-c", command],
     timeoutMs,
-    workspaceRoot
+    workspaceRoot,
+    SUBPROCESS_MAX_OUTPUT_BYTES
   );
   return { stdout, stderr, exitCode: code };
 }
@@ -913,15 +931,14 @@ function _run(
   command: string,
   args: string[],
   timeoutMs?: number,
-  cwd?: string
+  cwd?: string,
+  maxOutputBytes?: number
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    let stdout = "";
-    let stderr = "";
     let timedOut = false;
     const timer =
       timeoutMs === undefined
@@ -930,12 +947,40 @@ function _run(
             timedOut = true;
             child.kill("SIGKILL");
           }, timeoutMs);
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk;
-    });
+    // Collect into Buffers so the cap is enforced on bytes, not UTF-16 code
+    // units; once a stream crosses it, detach the listener and resume() so the
+    // child never blocks on a full pipe while we discard the rest.
+    const collect = (stream: NodeJS.ReadableStream) => {
+      let chunks = Buffer.alloc(0);
+      let truncated = false;
+      stream.on("data", (chunk: Buffer) => {
+        if (truncated) {
+          return;
+        }
+        chunks = Buffer.concat([chunks, chunk]);
+        if (
+          maxOutputBytes !== undefined &&
+          chunks.length >= maxOutputBytes
+        ) {
+          truncated = true;
+          stream.removeAllListeners("data");
+          stream.resume();
+        }
+      });
+      return () => ({ chunks, truncated });
+    };
+    const stdoutChunks = collect(child.stdout);
+    const stderrChunks = collect(child.stderr);
+    const suffix =
+      maxOutputBytes === undefined
+        ? ""
+        : `\n... [truncated at ${maxOutputBytes} bytes; redirect output to a file and read ranges with the read tool]`;
+    const capped = (collected: () => { chunks: Buffer; truncated: boolean }) => {
+      const { chunks, truncated } = collected();
+      // Slice on a UTF-8 code-point boundary so the marker can't split one.
+      const text = chunks.subarray(0, maxOutputBytes).toString("utf8");
+      return truncated ? text + suffix : text;
+    };
     child.on("error", (error) => {
       if (timer) clearTimeout(timer);
       reject(error);
@@ -946,7 +991,11 @@ function _run(
         reject(new Error(`Command timed out after ${timeoutMs}ms`));
         return;
       }
-      resolve({ stdout, stderr, code: code ?? 0 });
+      resolve({
+        stdout: capped(stdoutChunks),
+        stderr: capped(stderrChunks),
+        code: code ?? 0,
+      });
     });
   });
 }

--- a/packages/runtime/tests/tools/built-in/fs.test.ts
+++ b/packages/runtime/tests/tools/built-in/fs.test.ts
@@ -3,7 +3,17 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { edit, glob, grep, ls, present_files, read, tree, write } from "../../../src/tools/built-in/fs";
+import {
+  bash,
+  edit,
+  glob,
+  grep,
+  ls,
+  present_files,
+  read,
+  tree,
+  write,
+} from "../../../src/tools/built-in/fs";
 
 const testDirectories: string[] = [];
 
@@ -84,5 +94,54 @@ describe("filesystem built-in paths", () => {
     expect(await tree(homeDirectory)).toContain("└── example.txt");
     expect(await grep("target", homeDirectory)).toContain(absolutePath);
     expect(await glob("*.txt", homeDirectory, "/unused")).toBe(absolutePath);
+  });
+});
+
+describe("subprocess and glob output caps", () => {
+  test("bash truncates stdout past the cap with a marker", async () => {
+    const { stdout, exitCode } = await bash("seq 1 60000", os.tmpdir());
+
+    expect(exitCode).toBe(0);
+    expect(stdout.length).toBeLessThan(280_000);
+    expect(stdout).toContain(
+      "[truncated at 262144 bytes; redirect output to a file and read ranges with the read tool]"
+    );
+  });
+
+  test("bash truncates stderr past the cap with a marker", async () => {
+    const { stderr, exitCode } = await bash("seq 1 60000 >&2", os.tmpdir());
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[truncated at 262144 bytes");
+    expect(stderr.length).toBeLessThan(280_000);
+  });
+
+  test("bash keeps short output byte-identical", async () => {
+    const { stdout, stderr, exitCode } = await bash(
+      "printf out; printf err >&2; exit 3",
+      os.tmpdir()
+    );
+
+    expect(stdout).toBe("out");
+    expect(stderr).toBe("err");
+    expect(exitCode).toBe(3);
+  });
+
+  test("glob caps results and reports the total", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "llm-space-glob-cap-")
+    );
+    testDirectories.push(directory);
+    for (let i = 0; i < 205; i++) {
+      await fs.writeFile(path.join(directory, `file-${i}.txt`), "x", "utf8");
+    }
+
+    const result = await glob("*.txt", directory, "/unused");
+    const lines = result.split("\n");
+
+    expect(lines).toHaveLength(201);
+    expect(lines[200]).toBe(
+      "... [showing first 200 of 205 matches; narrow the pattern or target directory]"
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `bash` and `grep` collected subprocess output with no bound: one immoderate command (`cat` on a huge log, `yes`, a broad `rg` pattern) streamed unbounded bytes into the model-facing tool result and the persisted thread JSON, while the sibling `read` tool already caps at `READ_MAX_SIZE_BYTES = 256KB`. `_run` now enforces the same 256KB cap per stream, keeps draining past the cap so the child never blocks on a full pipe, and appends a truncation marker pointing at the `read` tool for ranged access.
- `glob` returned every match (full absolute paths, one `stat` per entry). A broad pattern such as `**/*` over a home directory produced hundreds of thousands of persisted lines. Results are now capped at 200 (newest-first, as before) with a `showing first N of M matches` marker.

## Validation

- `bun test packages/runtime/tests/tools/built-in/fs.test.ts` — 8 pass (4 new: stdout cap, stderr cap, short-output byte-identity, glob cap)
- `bun run check:changed` — lint + typecheck clean
