### PR TITLE
feat(plugins): bundle a default cross-project Memory plugin

### DIFF
--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -16,6 +16,9 @@ async function _bootstrapDesktopApp(): Promise<void> {
   const { seedSkills } = await import("./skills/seed");
   seedSkills();
 
+  const { seedDefaultPlugins } = await import("./plugins/seed");
+  seedDefaultPlugins();
+
   const { startDesktopApp } = await import("./app");
   await startDesktopApp();
 }

--- a/apps/desktop/src/bun/plugins/memory-plugin-files.ts
+++ b/apps/desktop/src/bun/plugins/memory-plugin-files.ts
@@ -1,0 +1,369 @@
+/**
+ * Source files of the bundled default Memory plugin, inlined as strings so
+ * the app bundle is self-contained (no runtime read of the source tree) —
+ * the same approach as the bundled skills in `bun/skills/seed.ts`.
+ *
+ * `String.raw` keeps the tool sources byte-exact (they contain regexes and
+ * escape sequences); the tool code therefore avoids backticks and `${`
+ * interpolation and builds strings with plain concatenation.
+ */
+
+export const MEMORY_PLUGIN_ID = "@llm-space/memory";
+
+export interface MemoryPluginFile {
+  /** Path relative to the plugin root, using forward slashes. */
+  path: string;
+  content: string;
+}
+
+const PACKAGE_JSON = `{
+  "name": "${MEMORY_PLUGIN_ID}",
+  "version": "1.0.0",
+  "type": "module",
+  "displayName": "Memory",
+  "description": "Built-in cross-project memory. Gives the agent tools to save durable facts, preferences, and decisions, and to recall them in any project.",
+  "author": "LLM Space Contributors",
+  "license": "MIT",
+  "homepage": "https://github.com/deer-flow/llm-space",
+  "engines": {
+    "llm-space": ">=4.9.0"
+  }
+}
+`;
+
+// Shared by every tool: the memory store is one JSON-lines file under the
+// plugin data directory, which survives installs, updates, and reloads and
+// is shared by every workspace — that is what makes the memory cross-project.
+const STORE_HELPERS = String.raw`import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+interface MemoryRecord {
+  id: string;
+  content: string;
+  tags: string[];
+  origin: string | null;
+  createdAt: string;
+}
+
+const MAX_CONTENT_LENGTH = 8000;
+const MAX_TOTAL_MEMORIES = 1000;
+
+function dataFilePath(): string {
+  const home =
+    process.env.LLM_SPACE_HOME?.trim() || path.join(os.homedir(), ".llm-space");
+  return path.join(
+    home,
+    "data",
+    "plugins",
+    "@llm-space",
+    "memory",
+    "memories.jsonl"
+  );
+}
+
+function readRecords(): MemoryRecord[] {
+  const file = dataFilePath();
+  if (!fs.existsSync(file)) {
+    return [];
+  }
+  const text = fs.readFileSync(file, "utf8");
+  const records: MemoryRecord[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line) as MemoryRecord;
+      if (
+        parsed &&
+        typeof parsed.id === "string" &&
+        typeof parsed.content === "string"
+      ) {
+        records.push(parsed);
+      }
+    } catch {
+      // Skip malformed lines instead of failing the whole store.
+    }
+  }
+  return records;
+}
+
+function writeRecords(records: MemoryRecord[]): void {
+  const file = dataFilePath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const body = records.map((record) => JSON.stringify(record)).join("\n");
+  const temporary = file + ".tmp";
+  fs.writeFileSync(temporary, body ? body + "\n" : "", "utf8");
+  fs.renameSync(temporary, file);
+}
+`;
+
+const MEMORY_SAVE_TS = String.raw`import type {
+  JsonValue,
+  PluginToolContext,
+  PluginToolExtension,
+} from "@llm-space/core";
+${STORE_HELPERS}
+export default class MemorySaveTool implements PluginToolExtension {
+  name = "memory_save";
+  description =
+    "Persist a durable memory to long-term storage that is shared across all projects and sessions on this machine. Save user preferences, project conventions, decisions and their rationale, environment facts, and corrections. Write the content self-contained so a future session can understand it without extra context. Never save secrets such as API keys, tokens, or passwords.";
+  parameters = {
+    type: "object",
+    properties: {
+      content: {
+        type: "string",
+        description:
+          "The memory to save, as a self-contained sentence. One fact per memory.",
+      },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          'Optional short topic tags, for example ["preference", "testing"].',
+      },
+    },
+    required: ["content"],
+    additionalProperties: false,
+  };
+
+  execute(
+    context: PluginToolContext,
+    args: Record<string, unknown>
+  ): JsonValue {
+    void context;
+    const content = typeof args.content === "string" ? args.content.trim() : "";
+    if (!content) {
+      return { saved: false, error: "content must be a non-empty string." };
+    }
+    if (content.length > MAX_CONTENT_LENGTH) {
+      return {
+        saved: false,
+        error: "content exceeds " + MAX_CONTENT_LENGTH + " characters.",
+      };
+    }
+    const rawTags = Array.isArray(args.tags) ? args.tags : [];
+    const tags = rawTags
+      .filter((tag): tag is string => typeof tag === "string")
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+      .slice(0, 8);
+    const variables = context.variables as Record<string, unknown> | undefined;
+    const origin =
+      variables && typeof variables.current_working_directory === "string"
+        ? variables.current_working_directory
+        : null;
+    const records = readRecords();
+    const record: MemoryRecord = {
+      id:
+        "m_" +
+        Date.now().toString(36) +
+        "_" +
+        Math.random().toString(36).slice(2, 8),
+      content,
+      tags,
+      origin,
+      createdAt: new Date().toISOString(),
+    };
+    records.push(record);
+    while (records.length > MAX_TOTAL_MEMORIES) {
+      records.shift();
+    }
+    writeRecords(records);
+    return { saved: true, id: record.id };
+  }
+}
+`;
+
+const MEMORY_SEARCH_TS = String.raw`import type {
+  JsonValue,
+  PluginToolContext,
+  PluginToolExtension,
+} from "@llm-space/core";
+${STORE_HELPERS}
+function tokenize(query: string): string[] {
+  return query.toLowerCase().split(/[^a-z0-9\u4e00-\u9fff]+/);
+}
+
+function scoreRecord(record: MemoryRecord, terms: string[]): number {
+  let score = 0;
+  const content = record.content.toLowerCase();
+  const tags = record.tags.map((tag) => tag.toLowerCase());
+  for (const term of terms) {
+    if (!term) {
+      continue;
+    }
+    if (record.id === term) {
+      score += 10;
+    }
+    if (tags.some((tag) => tag === term)) {
+      score += 5;
+    }
+    if (tags.some((tag) => tag.includes(term))) {
+      score += 2;
+    }
+    if (content.includes(term)) {
+      score += 1;
+    }
+  }
+  return score;
+}
+
+export default class MemorySearchTool implements PluginToolExtension {
+  name = "memory_search";
+  description =
+    "Search persistent long-term memory that is shared across all projects and sessions on this machine. Returns the best-matching memories for a query, or the most recent memories when no query is given. Use it at the start of a task to recall relevant user preferences, project conventions, and past decisions.";
+  parameters = {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description:
+          "Keywords to look for, in any language. Omit to list the most recent memories.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of memories to return (1-50, default 5).",
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  };
+
+  execute(
+    context: PluginToolContext,
+    args: Record<string, unknown>
+  ): JsonValue {
+    void context;
+    const query = typeof args.query === "string" ? args.query.trim() : "";
+    const limit =
+      typeof args.limit === "number" && Number.isFinite(args.limit)
+        ? Math.min(Math.max(Math.floor(args.limit), 1), 50)
+        : 5;
+    const records = readRecords();
+    let matches = records;
+    if (query) {
+      const terms = tokenize(query);
+      matches = records
+        .map((record) => ({ record, score: scoreRecord(record, terms) }))
+        .filter((entry) => entry.score > 0)
+        .sort(
+          (a, b) =>
+            b.score - a.score ||
+            b.record.createdAt.localeCompare(a.record.createdAt)
+        )
+        .map((entry) => entry.record);
+    } else {
+      matches = [...records].reverse();
+    }
+    return {
+      query: query || null,
+      total: records.length,
+      returned: Math.min(matches.length, limit),
+      memories: matches.slice(0, limit),
+    };
+  }
+}
+`;
+
+const MEMORY_FORGET_TS = String.raw`import type {
+  JsonValue,
+  PluginToolContext,
+  PluginToolExtension,
+} from "@llm-space/core";
+${STORE_HELPERS}
+export default class MemoryForgetTool implements PluginToolExtension {
+  name = "memory_forget";
+  description =
+    "Delete one memory by id from the persistent long-term memory that is shared across all projects on this machine. Use it when the user points out that a saved memory is outdated or wrong, then save the corrected version with memory_save.";
+  parameters = {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description:
+          "The id of the memory to delete, as returned by memory_save or memory_search.",
+      },
+    },
+    required: ["id"],
+    additionalProperties: false,
+  };
+  strict = true;
+
+  execute(
+    context: PluginToolContext,
+    args: Record<string, unknown>
+  ): JsonValue {
+    void context;
+    const id = typeof args.id === "string" ? args.id.trim() : "";
+    if (!id) {
+      return { deleted: false, error: "id must be a non-empty string." };
+    }
+    const records = readRecords();
+    const next = records.filter((record) => record.id !== id);
+    if (next.length === records.length) {
+      return { deleted: false, error: "No memory found with id " + id + "." };
+    }
+    writeRecords(next);
+    return { deleted: true, id };
+  }
+}
+`;
+
+const MEMORY_SKILL_MD = String.raw`---
+name: memory
+description: Persistent memory shared across all projects on this machine. Use PROACTIVELY at the start of a task to search for relevant memories about the user, their preferences, project conventions, and past decisions, and save a new memory whenever the user states a durable preference, correction, convention, or decision. Trigger on phrases like "remember", "from now on", "as usual", "last time", or when continuing prior work.
+---
+
+# Memory
+
+You have persistent memory tools (memory_save, memory_search,
+memory_forget) backed by on-disk storage that is shared across **all
+projects and sessions** on this machine.
+
+## When to search (memory_search)
+
+- At the start of any non-trivial task, search for the project name, the
+  task topic, and related keywords.
+- When the user references past work: "last time", "as before",
+  "remember?", "as we agreed".
+- When a convention is unclear, prefer the choice recorded in memory over
+  guessing.
+
+## When to save (memory_save)
+
+Save durable facts:
+
+- User preferences: workflow, coding style, communication style, language.
+- Project conventions: commands, structure, naming, toolchain.
+- Decisions together with their rationale.
+- Environment specifics: paths, versions, quirks.
+- Corrections: when the user fixes you, save it so the mistake is not
+  repeated.
+
+Do NOT save secrets (API keys, tokens, passwords), ephemeral task
+details, anything already tracked in the repository or the thread, or
+other sensitive personal data.
+
+## How to write a memory
+
+- Self-contained: "Vincent uses bun, never npm, for this monorepo" must
+  make sense a year later with no other context.
+- One fact per memory, with short tags such as ["preference"],
+  ["project:llm-space"], ["convention"].
+
+## When to forget (memory_forget)
+
+When the user points out that a memory is outdated or wrong, delete it by
+id (find the id with memory_search) and save the corrected version.
+`;
+
+/** Every file of the bundled Memory plugin, ready to write to disk. */
+export const MEMORY_PLUGIN_FILES: readonly MemoryPluginFile[] = [
+  { path: "package.json", content: PACKAGE_JSON },
+  { path: "tools/memory-save.ts", content: MEMORY_SAVE_TS },
+  { path: "tools/memory-search.ts", content: MEMORY_SEARCH_TS },
+  { path: "tools/memory-forget.ts", content: MEMORY_FORGET_TS },
+  { path: "skills/memory/SKILL.md", content: MEMORY_SKILL_MD },
+];

--- a/apps/desktop/src/bun/plugins/seed.test.ts
+++ b/apps/desktop/src/bun/plugins/seed.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { PluginToolExtension } from "@llm-space/core";
+
+import {
+  MEMORY_PLUGIN_FILES,
+  MEMORY_PLUGIN_ID,
+} from "./memory-plugin-files";
+import { seedDefaultPlugins } from "./seed";
+
+type PluginToolContextLike = Parameters<PluginToolExtension["execute"]>[0];
+
+/** The runner-facing surface of a seeded plugin tool module. */
+interface PluginToolLike {
+  name: string;
+  execute(context: PluginToolContextLike, args: Record<string, unknown>): unknown;
+}
+
+function _makeTempDir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "llm-space-memory-seed-"));
+}
+
+describe("seedDefaultPlugins", () => {
+  test("writes every memory plugin file under the scoped plugin id", () => {
+    const pluginsDir = _makeTempDir();
+    try {
+      seedDefaultPlugins(pluginsDir);
+      const pluginRoot = path.join(pluginsDir, ...MEMORY_PLUGIN_ID.split("/"));
+      for (const file of MEMORY_PLUGIN_FILES) {
+        expect(existsSync(path.join(pluginRoot, ...file.path.split("/")))).toBe(
+          true
+        );
+      }
+      const manifest = JSON.parse(
+        readFileSync(path.join(pluginRoot, "package.json"), "utf8")
+      ) as { name?: string };
+      expect(manifest.name).toBe(MEMORY_PLUGIN_ID);
+      expect(existsSync(path.join(pluginRoot, "skills/memory/SKILL.md"))).toBe(
+        true
+      );
+    } finally {
+      rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
+
+  test("never overwrites an existing installation", () => {
+    const pluginsDir = _makeTempDir();
+    try {
+      seedDefaultPlugins(pluginsDir);
+      const pluginRoot = path.join(pluginsDir, ...MEMORY_PLUGIN_ID.split("/"));
+      const manifestPath = path.join(pluginRoot, "package.json");
+      writeFileSync(manifestPath, "{}", "utf8");
+      seedDefaultPlugins(pluginsDir);
+      expect(readFileSync(manifestPath, "utf8")).toBe("{}");
+    } finally {
+      rmSync(pluginsDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("memory plugin tools", () => {
+  test("save, search, and forget round-trip against a temporary store", async () => {
+    const pluginsDir = _makeTempDir();
+    const homeDir = _makeTempDir();
+    const previousHome = process.env.LLM_SPACE_HOME;
+    process.env.LLM_SPACE_HOME = homeDir;
+    try {
+      seedDefaultPlugins(pluginsDir);
+      const toolsDir = path.join(
+        pluginsDir,
+        ...MEMORY_PLUGIN_ID.split("/"),
+        "tools"
+      );
+      // Import the seeded source files exactly like the plugin runner does:
+      // Bun compiles TypeScript at import time.
+      const stamp = Date.now();
+      const loadTool = async (
+        fileName: string
+      ): Promise<PluginToolLike> => {
+        const module = (await import(
+          pathToFileURL(path.join(toolsDir, fileName)).href + "?t=" + stamp
+        )) as unknown as { default: new () => PluginToolLike };
+        return new module.default();
+      };
+      const save = await loadTool("memory-save.ts");
+      const search = await loadTool("memory-search.ts");
+      const forget = await loadTool("memory-forget.ts");
+
+      expect(save.name).toBe("memory_save");
+      expect(search.name).toBe("memory_search");
+      expect(forget.name).toBe("memory_forget");
+
+      const context = {
+        variables: { current_working_directory: "/tmp/project-a" },
+      } as unknown as PluginToolContextLike;
+
+      const saved = save.execute(context, {
+        content: "Vincent uses bun, never npm, for this monorepo.",
+        tags: ["preference", "toolchain"],
+      }) as { saved: boolean; id: string };
+      expect(saved.saved).toBe(true);
+
+      save.execute(context, {
+        content: "项目使用 Vitest 风格的测试，通过 mise 运行任务。",
+        tags: ["convention"],
+      });
+
+      // Cross-project: a different working directory finds the same memory.
+      const otherProject = {
+        variables: { current_working_directory: "/tmp/project-b" },
+      } as unknown as PluginToolContextLike;
+      const found = search.execute(otherProject, {
+        query: "bun toolchain preference",
+      }) as {
+        returned: number;
+        memories: { id: string; content: string; origin: string | null }[];
+      };
+      expect(found.returned).toBeGreaterThan(0);
+      expect(found.memories[0].content).toContain("bun");
+      expect(found.memories[0].origin).toBe("/tmp/project-a");
+
+      const removed = forget.execute(otherProject, {
+        id: saved.id,
+      }) as { deleted: boolean };
+      expect(removed.deleted).toBe(true);
+
+      const empty = search.execute(otherProject, {
+        query: "bun toolchain preference",
+      }) as { returned: number };
+      expect(empty.returned).toBe(0);
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.LLM_SPACE_HOME;
+      } else {
+        process.env.LLM_SPACE_HOME = previousHome;
+      }
+      rmSync(pluginsDir, { recursive: true, force: true });
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/bun/plugins/seed.ts
+++ b/apps/desktop/src/bun/plugins/seed.ts
@@ -1,0 +1,30 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { getLlmSpaceHomePath } from "@llm-space/core/server";
+
+import { MEMORY_PLUGIN_FILES, MEMORY_PLUGIN_ID } from "./memory-plugin-files";
+
+/** The llm-space-managed plugins discovery root (`<home>/plugins`). */
+export function getManagedPluginsDir(): string {
+  return path.join(getLlmSpaceHomePath(), "plugins");
+}
+
+/**
+ * Seed the bundled default Memory plugin into the plugins discovery root so
+ * every install has cross-project memory out of the box. No-op when the
+ * plugin directory already exists — a user who removed, replaced, or edited
+ * the plugin is never overwritten (mirroring `seedSkills`).
+ */
+export function seedDefaultPlugins(pluginsDir?: string): void {
+  const root = pluginsDir ?? getManagedPluginsDir();
+  const pluginRoot = path.join(root, ...MEMORY_PLUGIN_ID.split("/"));
+  if (existsSync(pluginRoot)) {
+    return;
+  }
+  for (const file of MEMORY_PLUGIN_FILES) {
+    const target = path.join(pluginRoot, ...file.path.split("/"));
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, file.content, "utf8");
+  }
+}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -160,6 +160,21 @@ Plugin before enabling or running it:
 Descriptions are UI copy, not identifiers. Stable IDs still come from the
 Plugin package name and the declaring file or object ID.
 
+### 2.4 Bundled default plugin
+
+LLM Space ships one default Plugin, the Memory plugin
+(`@llm-space/memory`), which gives the agent cross-project persistent
+memory through the `memory_save`, `memory_search`, and `memory_forget`
+Plugin Tools plus a `memory` Skill that tells the agent when to use them.
+
+On startup, before plugins are discovered, the desktop app writes the
+plugin into `<home>/plugins/@llm-space/memory/` if that directory does
+not exist yet. Seeding is once-only and never overwrites: if you delete,
+replace, or edit the plugin, your version is kept. The agent's memories
+live in `LLM_SPACE_HOME/data/plugins/@llm-space/memory/memories.jsonl`,
+which survives plugin updates and is shared by every workspace, making
+the memory cross-project by design.
+
 ## 3. Metadata in `package.json`
 
 Minimal metadata:

--- a/docs/plugins.zh-CN.md
+++ b/docs/plugins.zh-CN.md
@@ -158,6 +158,19 @@ Settings → Plugins 会按类型分组展示已发现的 Extensions，并显示
 描述只是界面文案，不是标识符。稳定 ID 仍由 Plugin 包名及声明扩展的文件名或对象
 ID 决定。
 
+### 2.4 内置默认 Plugin
+
+LLM Space 自带一个默认 Plugin——Memory 插件（`@llm-space/memory`），通过
+`memory_save`、`memory_search`、`memory_forget` 三个 Plugin Tools 和一个
+`memory` Skill，让 Agent 拥有跨项目的持久记忆。
+
+桌面应用启动时会在发现插件之前，把该插件写入
+`<home>/plugins/@llm-space/memory/`（仅当该目录不存在时）。种子写入只发生
+一次，且永远不会覆盖：如果你删除、替换或修改了这个插件，将保留你的版本。
+Agent 的记忆保存在
+`LLM_SPACE_HOME/data/plugins/@llm-space/memory/memories.jsonl`，该文件在
+插件更新后依然保留，并被所有工作区共享，因此记忆天然是跨项目的。
+
 ## 3. `package.json`
 
 最小可用 metadata：


### PR DESCRIPTION
## Summary

Ships a built-in default plugin, **`@llm-space/memory`**, that gives the agent persistent memory **shared across all projects** on the machine.

- Tools: `memory_save`, `memory_search` (keyword-scored, CJK-aware; lists recent memories without a query), and `memory_forget` — plus a proactive `memory` Skill that tells the agent when to recall (task start, "last time…") and what is worth saving (and what must never be saved: secrets).
- Cross-project by design: memories live in the plugin **data** directory (`LLM_SPACE_HOME/data/plugins/@llm-space/memory/memories.jsonl`), which is shared by every workspace and survives plugin updates/reloads. Each record is tagged with the originating working directory.
- Bundled like the built-in skills: the plugin sources are inlined (`bun/plugins/memory-plugin-files.ts`, same `String.raw`/text-embedding approach as `seed-skills`) and written to `<home>/plugins/@llm-space/memory/` on first launch. Seeding is **once-only and never overwrites** — a user who deletes or edits the plugin keeps their version.
- Zero dependencies: tools use only `@llm-space/core` types and node builtins, so no package-manager step is needed (plugins don't run installs).

## Test plan

- [x] Seed tests: file layout under the scoped plugin id, no-overwrite semantics, manifest validity
- [x] Round-trip test that imports the seeded tool sources exactly like the plugin runner does (Bun TS import) and exercises save → cross-project search → forget against a temporary `LLM_SPACE_HOME`
- [x] Full `bun run typecheck` and ESLint clean; docs updated (en + zh-CN)